### PR TITLE
Get rid of webbrowser.goto()

### DIFF
--- a/picard/coverart/providers/caa.py
+++ b/picard/coverart/providers/caa.py
@@ -7,7 +7,7 @@
 # Copyright (C) 2007-2011, 2015, 2018-2019 Philipp Wolfer
 # Copyright (C) 2011 Michael Wiencek
 # Copyright (C) 2011-2012 Wieland Hoffmann
-# Copyright (C) 2013-2015, 2018-2019 Laurent Monin
+# Copyright (C) 2013-2015, 2018-2021 Laurent Monin
 # Copyright (C) 2015-2016 Rahul Raturi
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Frederik “Freso” S. Olesen
@@ -379,7 +379,7 @@ class CAATypesSelectorDialog(PicardDialog):
                 self.list_ignore.addItem(item)
 
     def help(self):
-        webbrowser2.goto('doc_cover_art_types')
+        webbrowser2.open('doc_cover_art_types')
 
     def get_selected_types_include(self):
         return list(self.list_include.all_items_data()) or ['front']

--- a/picard/ui/__init__.py
+++ b/picard/ui/__init__.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2008 Lukáš Lalinský
 # Copyright (C) 2014 Sophist-UK
-# Copyright (C) 2014, 2018 Laurent Monin
+# Copyright (C) 2014, 2018, 2020-2021 Laurent Monin
 # Copyright (C) 2016-2018 Sambhav Kothari
 # Copyright (C) 2018 Vishal Choudhary
 # Copyright (C) 2019-2021 Philipp Wolfer
@@ -128,10 +128,7 @@ class PicardDialog(QtWidgets.QDialog, PreserveGeometry):
             url = self.help_url
             if url.startswith('/'):
                 url = DOCS_BASE_URL + url
-            if url.startswith('goto://'):
-                webbrowser2.goto(url[7:])
-            else:
-                webbrowser2.open(url)
+            webbrowser2.open(url)
 
 
 # With py3, QObjects are no longer hashable unless they have

--- a/picard/ui/mainwindow.py
+++ b/picard/ui/mainwindow.py
@@ -14,7 +14,7 @@
 # Copyright (C) 2011-2013, 2015-2017 Wieland Hoffmann
 # Copyright (C) 2011-2014 Michael Wiencek
 # Copyright (C) 2013-2014, 2017 Sophist-UK
-# Copyright (C) 2013-2020 Laurent Monin
+# Copyright (C) 2013-2021 Laurent Monin
 # Copyright (C) 2015 Ohm Patel
 # Copyright (C) 2015 samithaj
 # Copyright (C) 2016 Rahul Raturi
@@ -1054,7 +1054,7 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         return OptionsDialog.show_instance(page, self)
 
     def show_help(self):
-        webbrowser2.goto('documentation')
+        webbrowser2.open('documentation')
 
     def show_log(self):
         self.log_dialog.show()
@@ -1067,13 +1067,13 @@ class MainWindow(QtWidgets.QMainWindow, PreserveGeometry):
         self.history_dialog.activateWindow()
 
     def open_bug_report(self):
-        webbrowser2.goto('troubleshooting')
+        webbrowser2.open('troubleshooting')
 
     def open_support_forum(self):
-        webbrowser2.goto('forum')
+        webbrowser2.open('forum')
 
     def open_donation_page(self):
-        webbrowser2.goto('donate')
+        webbrowser2.open('donate')
 
     def save(self):
         """Tell the tagger to save the selected objects."""

--- a/picard/ui/options/dialog.py
+++ b/picard/ui/options/dialog.py
@@ -8,7 +8,7 @@
 # Copyright (C) 2011 Pavan Chander
 # Copyright (C) 2011-2012, 2019 Wieland Hoffmann
 # Copyright (C) 2011-2013 Michael Wiencek
-# Copyright (C) 2013, 2017-2019 Laurent Monin
+# Copyright (C) 2013, 2017-2020 Laurent Monin
 # Copyright (C) 2014 Sophist-UK
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Suhas
@@ -191,7 +191,7 @@ class OptionsDialog(PicardDialog, SingletonDialog):
             current_page = self.item_to_page[self.page_to_item[current_page.PARENT]]
             url = current_page.HELP_URL
         if not url:
-            url = '/config/configuration.html'
+            url = 'doc_options'  # key in PICARD_URLS
         return url
 
     def accept(self):

--- a/picard/ui/options/fingerprinting.py
+++ b/picard/ui/options/fingerprinting.py
@@ -4,8 +4,8 @@
 #
 # Copyright (C) 2011-2012 Lukáš Lalinský
 # Copyright (C) 2011-2013 Michael Wiencek
-# Copyright (C) 2013, 2018 Laurent Monin
 # Copyright (C) 2015, 2020 Philipp Wolfer
+# Copyright (C) 2013, 2018, 2020-2021 Laurent Monin
 # Copyright (C) 2016-2017 Sambhav Kothari
 #
 # This program is free software; you can redistribute it and/or
@@ -119,10 +119,10 @@ class FingerprintingOptionsPage(OptionsPage):
             self.ui.acoustid_fpcalc.setText(path)
 
     def acoustid_fpcalc_download(self):
-        webbrowser2.goto('chromaprint')
+        webbrowser2.open('chromaprint')
 
     def acoustid_apikey_get(self):
-        webbrowser2.goto('acoustid_apikey')
+        webbrowser2.open('acoustid_apikey')
 
     def _acoustid_fpcalc_check(self):
         if not self.ui.use_acoustid.isChecked():

--- a/picard/ui/tagsfromfilenames.py
+++ b/picard/ui/tagsfromfilenames.py
@@ -8,8 +8,8 @@
 # Copyright (C) 2014, 2017 Sophist-UK
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2017 Ville Skyttä
-# Copyright (C) 2018 Laurent Monin
 # Copyright (C) 2018 Vishal Choudhary
+# Copyright (C) 2018, 2020-2021 Laurent Monin
 #
 # This program is free software; you can redistribute it and/or
 # modify it under the terms of the GNU General Public License
@@ -99,7 +99,7 @@ class TagMatchExpression:
 class TagsFromFileNamesDialog(PicardDialog):
 
     autorestore = False
-    help_url = 'goto://doc_tags_from_filenames'
+    help_url = 'doc_tags_from_filenames'
 
     options = [
         TextOption("persist", "tags_from_filenames_format", ""),

--- a/picard/util/webbrowser2.py
+++ b/picard/util/webbrowser2.py
@@ -4,7 +4,7 @@
 #
 # Copyright (C) 2006-2007 Lukáš Lalinský
 # Copyright (C) 2011 Calvin Walton
-# Copyright (C) 2013, 2018-2019 Laurent Monin
+# Copyright (C) 2013, 2018-2021 Laurent Monin
 # Copyright (C) 2016-2017 Sambhav Kothari
 # Copyright (C) 2018 Wieland Hoffmann
 # Copyright (C) 2019 Philipp Wolfer
@@ -39,6 +39,8 @@ from picard.const import PICARD_URLS
 
 
 def open(url):
+    if url in PICARD_URLS:
+        url = PICARD_URLS[url]
     try:
         webbrowser.open(url)
     except webbrowser.Error as e:
@@ -52,7 +54,3 @@ def open(url):
             # preferred browser.
             log.info("Working around https://bugs.python.org/issue31014 - URLs might not be opened in the correct browser")
             webbrowser.open(url)
-
-
-def goto(url_id):
-    open(PICARD_URLS[url_id])


### PR DESCRIPTION
Check if `url` passed is a key from `PICARD_URLS`, and uses the value if it is.

