### PR TITLE
get_submission_host() -> get_submission_server(), return named tuple

### DIFF
--- a/picard/util/mbserver.py
+++ b/picard/util/mbserver.py
@@ -18,9 +18,14 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
+from collections import namedtuple
+
 from picard.config import get_config
 from picard.const import MUSICBRAINZ_SERVERS
 from picard.util import build_qurl
+
+
+ServerTuple = namedtuple('ServerTuple', ('host', 'port'))
 
 
 def is_official_server(host):
@@ -46,12 +51,12 @@ def get_submission_server():
     config = get_config()
     host = config.setting['server_host']
     if is_official_server(host):
-        return (host, 443)
+        return ServerTuple(host, 443)
     elif host and config.setting['use_server_for_submission']:
         port = config.setting['server_port']
-        return (host, port)
+        return ServerTuple(host, port)
     else:
-        return (MUSICBRAINZ_SERVERS[0], 443)
+        return ServerTuple(MUSICBRAINZ_SERVERS[0], 443)
 
 
 def build_submission_url(path=None, query_args=None):
@@ -63,6 +68,6 @@ def build_submission_url(path=None, query_args=None):
 
     Returns: The submission URL as a string
     """
-    host, port = get_submission_server()
-    url = build_qurl(host, port, path, query_args)
+    server = get_submission_server()
+    url = build_qurl(server.host, server.port, path, query_args)
     return url.toString()

--- a/picard/util/mbserver.py
+++ b/picard/util/mbserver.py
@@ -34,7 +34,7 @@ def is_official_server(host):
     return host in MUSICBRAINZ_SERVERS
 
 
-def get_submission_host():
+def get_submission_server():
     """Returns the host and port used for data submission.
 
     Data submission usually should be done against the primary database. This function
@@ -63,6 +63,6 @@ def build_submission_url(path=None, query_args=None):
 
     Returns: The submission URL as a string
     """
-    host, port = get_submission_host()
+    host, port = get_submission_server()
     url = build_qurl(host, port, path, query_args)
     return url.toString()

--- a/test/test_util_mbserver.py
+++ b/test/test_util_mbserver.py
@@ -69,6 +69,16 @@ class GetSubmissionServerTest(PicardTestCase):
         })
         self.assertEqual((MUSICBRAINZ_SERVERS[0], 443), get_submission_server())
 
+    def test_named_tuple(self):
+        self.set_config_values(setting={
+            'server_host': 'example.com',
+            'server_port': 8042,
+            'use_server_for_submission': True,
+        })
+        server = get_submission_server()
+        self.assertEqual('example.com', server.host)
+        self.assertEqual(8042, server.port)
+
 
 class BuildSubmissionUrlTest(PicardTestCase):
 

--- a/test/test_util_mbserver.py
+++ b/test/test_util_mbserver.py
@@ -24,7 +24,7 @@ from test.picardtestcase import PicardTestCase
 from picard.const import MUSICBRAINZ_SERVERS
 from picard.util.mbserver import (
     build_submission_url,
-    get_submission_host,
+    get_submission_server,
     is_official_server,
 )
 
@@ -42,7 +42,7 @@ class IsOfficialServerTest(PicardTestCase):
         self.assertFalse(is_official_server('localhost'))
 
 
-class GetSubmissionHostTest(PicardTestCase):
+class GetSubmissionServerTest(PicardTestCase):
 
     def test_official(self):
         for host in MUSICBRAINZ_SERVERS:
@@ -51,7 +51,7 @@ class GetSubmissionHostTest(PicardTestCase):
                 'server_port': 80,
                 'use_server_for_submission': False,
             })
-            self.assertEqual((host, 443), get_submission_host())
+            self.assertEqual((host, 443), get_submission_server())
 
     def test_use_unofficial(self):
         self.set_config_values(setting={
@@ -59,7 +59,7 @@ class GetSubmissionHostTest(PicardTestCase):
             'server_port': 8042,
             'use_server_for_submission': True,
         })
-        self.assertEqual(('example.com', 8042), get_submission_host())
+        self.assertEqual(('example.com', 8042), get_submission_server())
 
     def test_unofficial_fallback(self):
         self.set_config_values(setting={
@@ -67,7 +67,7 @@ class GetSubmissionHostTest(PicardTestCase):
             'server_port': 80,
             'use_server_for_submission': False,
         })
-        self.assertEqual((MUSICBRAINZ_SERVERS[0], 443), get_submission_host())
+        self.assertEqual((MUSICBRAINZ_SERVERS[0], 443), get_submission_server())
 
 
 class BuildSubmissionUrlTest(PicardTestCase):


### PR DESCRIPTION
Implementation of the change suggested in https://github.com/metabrainz/picard/pull/1843#discussion_r651496353