### PR TITLE
Fix i18n tests

### DIFF
--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -25,6 +25,7 @@
 import builtins
 import gettext
 import locale
+import os
 
 from PyQt5.QtCore import QLocale
 
@@ -113,11 +114,20 @@ def _try_locales(language):
 
 def _load_translation(domain, localedir, language):
     try:
-        _logger("Loading gettext translation for %s, localedir=%r, langage=%r", domain, localedir, language)
+        _logger("Loading gettext translation for %s, localedir=%r, language=%r", domain, localedir, language)
         return gettext.translation(domain, localedir, languages=[language])
     except OSError as e:
         _logger(e)
         return gettext.NullTranslations()
+
+
+def _log_lang_env_vars():
+    env_vars = []
+    lc_keys = sorted(k for k in os.environ.keys() if k.startswith('LC_'))
+    for k in ('LANG', 'LANGUAGE') + tuple(lc_keys):
+        if k in os.environ:
+            env_vars.append(k + '=' + os.environ[k])
+    _logger("Env vars: %s", ' '.join(env_vars))
 
 
 def setup_gettext(localedir, ui_language=None, logger=None):
@@ -133,6 +143,7 @@ def setup_gettext(localedir, ui_language=None, logger=None):
         try_locales = list(_try_locales(ui_language))
     else:
         _logger("UI language: system")
+        _log_lang_env_vars()
         try_locales = []
 
     default_locale = _get_default_locale()

--- a/picard/i18n.py
+++ b/picard/i18n.py
@@ -93,11 +93,10 @@ elif IS_MACOS:
         current_locale = defaults.objectForKey_('AppleLanguages')[0]
         current_locale = current_locale.replace('-', '_')
         try:
-            locale.setlocale(locale.LC_ALL, current_locale)
-            return current_locale
+            return locale.setlocale(locale.LC_ALL, current_locale)
         except locale.Error:
-            _logger("Defaulting to C locale")
-            return locale.setlocale(locale.LC_ALL, 'C')
+            _logger("Failed to set locale: %r", current_locale)
+            return set_locale_from_env()
 
 else:
     def _init_default_locale():

--- a/test/picardtestcase.py
+++ b/test/picardtestcase.py
@@ -40,6 +40,7 @@ from picard import (
     config,
     log,
 )
+from picard.i18n import setup_gettext
 from picard.releasegroup import ReleaseGroup
 
 
@@ -81,6 +82,7 @@ class FakeTagger(QtCore.QObject):
 class PicardTestCase(unittest.TestCase):
     def setUp(self):
         log.set_level(logging.DEBUG)
+        setup_gettext(None, 'C')
         self.tagger = FakeTagger()
         QtCore.QObject.tagger = self.tagger
         QtCore.QCoreApplication.instance = lambda: self.tagger

--- a/test/test_bytes2human.py
+++ b/test/test_bytes2human.py
@@ -27,22 +27,12 @@ import os.path
 
 from test.picardtestcase import PicardTestCase
 
-from picard.i18n import setup_gettext
 from picard.util import bytes2human
 
 
 class Testbytes2human(PicardTestCase):
-    def setUp(self):
-        super().setUp()
-        # we are using temporary locales for tests
-        self.tmp_path = self.mktmpdir()
-        self.localedir = os.path.join(self.tmp_path, 'locale')
-
     def test_00(self):
-        # testing with default C locale, english
-        lang = 'C'
-        setup_gettext(self.localedir, lang)
-        self.run_test(lang)
+        self.run_test()
 
         self.assertEqual(bytes2human.binary(45682), '44.6 KiB')
         self.assertEqual(bytes2human.binary(-45682), '-44.6 KiB')

--- a/test/test_coverart_utils.py
+++ b/test/test_coverart_utils.py
@@ -21,8 +21,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-import os.path
-
 from test.picardtestcase import PicardTestCase
 
 from picard.coverart.utils import (
@@ -31,17 +29,9 @@ from picard.coverart.utils import (
     translate_caa_type,
     types_from_id3,
 )
-from picard.i18n import setup_gettext
 
 
 class CaaTypeTranslationTest(PicardTestCase):
-    def setUp(self):
-        super().setUp()
-        # we are using temporary locales for tests
-        self.tmp_path = self.mktmpdir()
-        self.localedir = os.path.join(self.tmp_path, 'locale')
-        setup_gettext(self.localedir, "C")
-
     def test_translating_unknown_types_returns_input(self):
         testtype = "ThisIsAMadeUpCoverArtTypeName"
         self.assertEqual(translate_caa_type(testtype), testtype)

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -57,7 +57,13 @@ class TestI18n(PicardTestCase):
     def test_existing_locales(self):
         locale_de = os.path.join(localedir, 'de', 'LC_MESSAGES', 'picard.mo')
         self.assertTrue(os.path.exists(locale_de), 'expected file %s' % locale_de)
+
+        gettext_before_setup = _
         i18n.setup_gettext(localedir, 'de')
+        gettext_after_setup = _
+
+        self.assertNotEqual(gettext_before_setup, gettext_after_setup)
+
         self.assertEqual('foo', _('foo'))
         self.assertEqual('Land', _('Country'))
         self.assertEqual('Country', N_('Country'))

--- a/test/test_releaseversions.py
+++ b/test/test_releaseversions.py
@@ -24,14 +24,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
 
-import os.path
-
 from test.picardtestcase import (
     PicardTestCase,
     load_test_json,
 )
 
-from picard.i18n import setup_gettext
 from picard.releasegroup import ReleaseGroup
 
 
@@ -44,13 +41,6 @@ settings = {
 
 
 class ReleaseTest(PicardTestCase):
-
-    def setUp(self):
-        super().setUp()
-        # we are using temporary locales for tests
-        self.tmp_path = self.mktmpdir()
-        self.localedir = os.path.join(self.tmp_path, 'locale')
-        setup_gettext(self.localedir, 'C')
 
     def test_1(self):
         self.set_config_values(settings)


### PR DESCRIPTION
- `locale.setlocale(locale.LC_ALL, '')` isn't guaranteed to work, so handle this case better.
- Complete tests by checking log output for expected messages ('de').
- Ensure we reset the env to default 'C' language as it is the expected language for most tests.
