### PR TITLE
Improvements for PICARD-2197 alias sort name lookup

### DIFF
--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -611,6 +611,12 @@ def _translate_artist_node(node: Node, config: Config | None = None) -> Alias:
 
 
 def _select_sort_name_from_aliases(node: Node, name: str, config: Config | None = None) -> str:
+    """Find a sort name matching the given credited name in the artist's aliases.
+
+    If translation is enabled, prefers an alias whose locale matches the
+    configured translation locales.  Falls back to the artist's default
+    sort-name, or the credited name itself if sort-name is empty.
+    """
     if 'aliases' in node:
         config = config or get_config()
         candidates = [alias for alias in node['aliases'] if alias['name'] == name and alias['sort-name']]
@@ -624,6 +630,7 @@ def _select_sort_name_from_aliases(node: Node, name: str, config: Config | None 
         if candidates:
             return candidates[0]['sort-name']
 
+    # Fallback: use the artist's own sort-name, or the credited name if empty
     return node['sort-name'] or name
 
 

--- a/picard/mbjson.py
+++ b/picard/mbjson.py
@@ -227,7 +227,7 @@ def _relations_to_metadata_target_type_artist(relation: Node, m: 'Metadata', con
     artist_sort_name = translated_alias.sort_name
     if not has_translation and context.use_credited_as and 'target-credit' in relation:
         credited_as = relation['target-credit']
-        if credited_as:
+        if credited_as and credited_as != artist['name']:
             artist_name = credited_as
             artist_sort_name = _select_sort_name_from_aliases(artist, credited_as, config=context.config)
     reltype = relation['type']
@@ -651,7 +651,10 @@ def artist_credit_from_node(node: list[Node]) -> ArtistCreditInfo:
         has_translation = translated_alias.name != artist['name']
         if not has_translation and use_credited_as and 'name' in artist_info:
             name = artist_info['name']
-            sort_name = _select_sort_name_from_aliases(artist, name, config=config)
+            if name != artist['name']:
+                sort_name = _select_sort_name_from_aliases(artist, name, config=config)
+            else:
+                sort_name = translated_alias.sort_name
         else:
             name = translated_alias.name
             sort_name = translated_alias.sort_name

--- a/test/data/ws_data/recording_artist_aliases_locales.json
+++ b/test/data/ws_data/recording_artist_aliases_locales.json
@@ -1,0 +1,48 @@
+{
+  "first-release-date": "2013-02-20",
+  "aliases": [],
+  "title": "そして伝説のように × my burning desire",
+  "length": 289840,
+  "id": "3cf17055-68db-477a-a9b6-a3271f188f27",
+  "video": false,
+  "disambiguation": "",
+  "artist-credit": [
+    {
+      "joinphrase": "",
+      "artist": {
+        "type": "Character",
+        "type-id": "5c1375b0-f18d-3db7-a164-a49d7a63773f",
+        "id": "9d844524-86b7-4424-98d4-4fae85c7eeb8",
+        "sort-name": "Kūko",
+        "disambiguation": "這いよれ！ニャル子さん",
+        "country": "JP",
+        "name": "クー子",
+        "aliases": [
+          {
+            "ended": false,
+            "locale": "ja",
+            "name": "後ろから這いより隊C",
+            "primary": true,
+            "begin": null,
+            "type": "Artist name",
+            "type-id": "894afba6-2816-3c24-8072-eadb66bd04bc",
+            "end": null,
+            "sort-name": "ウシロカラハイヨリタイC"
+          },
+          {
+            "ended": false,
+            "locale": "en",
+            "name": "後ろから這いより隊C",
+            "primary": true,
+            "begin": null,
+            "type": "Artist name",
+            "type-id": "894afba6-2816-3c24-8072-eadb66bd04bc",
+            "end": null,
+            "sort-name": "Ushirokara Haiyoritai C"
+          }
+        ]
+      },
+      "name": "後ろから這いより隊C"
+    }
+  ]
+}

--- a/test/test_mbjson.py
+++ b/test/test_mbjson.py
@@ -545,6 +545,20 @@ class RecordingArtistAliasesTest(MBJSONTest):
         self.assertEqual(m['artistsort'], 'Ushirokara Haiyoritai C')
 
 
+class RecordingArtistAliasesLocalesTest(MBJSONTest):
+    filename = 'recording_artist_aliases_locales.json'
+
+    def test_use_credited_as_with_translation_prefers_locale(self):
+        m = Metadata()
+        t = Track('1')
+        config.setting['translate_artist_names'] = True
+        config.setting['standardize_artists'] = False
+        config.setting['translation_locales'] = ['ja']
+        recording_to_metadata(self.json_doc, m, t)
+        self.assertEqual(m['artist'], '後ろから這いより隊C')
+        self.assertEqual(m['artistsort'], 'ウシロカラハイヨリタイC')
+
+
 class RecordingInstrumentalTest(MBJSONTest):
     filename = 'recording_instrumental.json'
 


### PR DESCRIPTION
Suggested improvements for #3157:

1. **Add test for locale-preferred sort name selection** — exercises the `translate_artist_names=True` path in `_select_sort_name_from_aliases` with multiple locale aliases.

2. **Add docstring and edge case comment** — documents the function's purpose, fallback behavior, and the empty sort-name edge case.

3. **Skip alias lookup when credited name equals canonical name** — avoids unnecessary work in both `artist_credit_from_node` and `_relations_to_metadata_target_type_artist` when the credit is the same as the artist's canonical name.