### PR TITLE
PICARD-3277: Add CoverArtImage.clone() method

### DIFF
--- a/picard/coverart/image.py
+++ b/picard/coverart/image.py
@@ -396,9 +396,10 @@ class CoverArtImage:
         except OSError as e:
             raise CoverArtImageIOError(e) from e
 
-    def set_external_file_data(self, data: bytes):
-        self.external_file_coverart = CoverArtImage(
-            data=data,
+    def clone(self, data: bytes | None = None) -> 'CoverArtImage':
+        """Create a copy of this image, optionally with different image data."""
+        return __class__(
+            data=data if data is not None else self.data,
             url=self.url,
             comment=self.comment,
             types=self.types,
@@ -406,6 +407,9 @@ class CoverArtImage:
             support_multi_types=self.support_multi_types,
             id3_type=self.id3_type,
         )
+
+    def set_external_file_data(self, data: bytes):
+        self.external_file_coverart = self.clone(data)
 
     @property
     def maintype(self):

--- a/test/test_coverart_image.py
+++ b/test/test_coverart_image.py
@@ -336,6 +336,23 @@ class CoverArtImageTest(PicardTestCase):
             self.assertEqual(len(image2.data), os.path.getsize(expected_filename_2))
             self.assertEqual(2, counters[counter_filename])
 
+    def test_clone_with_data(self):
+        data = create_fake_png(b'\x01')
+        image = CoverArtImage(data=data, comment='Foo', types=['back'], support_types=True)
+        new_data = create_fake_png(b'\x02')
+        clone = image.clone(new_data)
+        self.assertEqual(clone.data, new_data)
+        self.assertEqual(clone.comment, image.comment)
+        self.assertEqual(clone.types, image.types)
+
+    def test_clone_without_data(self):
+        data = create_fake_png(b'\x01')
+        image = CoverArtImage(data=data, comment='Bar', types=['front'], support_types=True)
+        clone = image.clone()
+        self.assertEqual(clone.data, image.data)
+        self.assertEqual(clone.comment, image.comment)
+        self.assertEqual(clone.types, image.types)
+
     def test_set_external_file_data(self):
         image = CoverArtImage(comment='Foo', types=['back', 'spine'], support_types=True, support_multi_types=True)
         self.assertIsNone(image.external_file_coverart)


### PR DESCRIPTION
Extract image cloning logic into a reusable clone() method that creates a copy with the same metadata, optionally with different image data. Refactor set_external_file_data() to use it.

Uses __class__ instead of the class name directly for rename safety.
