### PR TITLE
Address review suggestions from PR #3211

### DIFF
--- a/picard/matching.py
+++ b/picard/matching.py
@@ -470,10 +470,8 @@ def _compare_tracknumber(recording_id: str, metadata: 'Metadata', releases: list
                 # The track has no position field, so we use the track-offset to compare.
                 if track_offset is not None and 'track' in medium:
                     if medium['track'] and tracknumber == track_offset + 1:
-                        sim = 1.0
-                    else:
-                        sim = 0.0
-                    return sim
+                        return 1.0
+                    continue
                 # Else if the data contains a "tracks" field with full track listing
                 # search for the track with matching recording and compare its position.
                 else:
@@ -485,9 +483,10 @@ def _compare_tracknumber(recording_id: str, metadata: 'Metadata', releases: list
                     for matching_track in matching_tracks:
                         if matching_track.get('position') == tracknumber:
                             return 1.0
-                    return 0.0
+        # Track number did not match on any medium across all releases
+        return 0.0
 
-    # Track number not found in any medium — neutral (neither confirms nor denies)
+    # No valid track number in metadata — neutral (neither confirms nor denies)
     return 0.5
 
 

--- a/picard/matching.py
+++ b/picard/matching.py
@@ -469,7 +469,7 @@ def _compare_tracknumber(recording_id: str, metadata: 'Metadata', releases: list
                 # the track-offset to indicate the number of skipped tracks before it.
                 # The track has no position field, so we use the track-offset to compare.
                 if track_offset is not None and 'track' in medium:
-                    if medium.get('track', None) and tracknumber == track_offset + 1:
+                    if medium['track'] and tracknumber == track_offset + 1:
                         sim = 1.0
                     else:
                         sim = 0.0

--- a/scripts/eval_matching/corpus/eval_release_1a8c4ac3.json
+++ b/scripts/eval_matching/corpus/eval_release_1a8c4ac3.json
@@ -1,108 +1,171 @@
 {
-  "date": "1984-04-24",
-  "barcode": "075990301024",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "quality": "normal",
   "artist-credit": [
     {
-      "name": "Fleetwood Mac",
-      "joinphrase": "",
       "artist": {
-        "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-        "disambiguation": "",
         "country": "GB",
-        "type": "Group",
+        "disambiguation": "",
+        "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
         "name": "Fleetwood Mac",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "sort-name": "Fleetwood Mac"
+        "sort-name": "Fleetwood Mac",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Fleetwood Mac"
+    }
+  ],
+  "asin": null,
+  "barcode": "075990301024",
+  "country": "GB",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": false,
+    "count": 1,
+    "darkened": false,
+    "front": true
+  },
+  "date": "1984-04-24",
+  "disambiguation": "",
+  "id": "1a8c4ac3-6f47-4570-aedb-f1928a0498ea",
+  "label-info": [
+    {
+      "catalog-number": "03010-2",
+      "label": {
+        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
+        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
+        "label-code": 392,
+        "name": "Warner Bros. Records",
+        "sort-name": "Warner Bros. Records",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    },
+    {
+      "catalog-number": "256 344",
+      "label": {
+        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
+        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
+        "label-code": 392,
+        "name": "Warner Bros. Records",
+        "sort-name": "Warner Bros. Records",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    },
+    {
+      "catalog-number": "3010-2",
+      "label": {
+        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
+        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
+        "label-code": 392,
+        "name": "Warner Bros. Records",
+        "sort-name": "Warner Bros. Records",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
       }
     }
   ],
-  "id": "1a8c4ac3-6f47-4570-aedb-f1928a0498ea",
-  "asin": null,
-  "disambiguation": "",
   "media": [
     {
       "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "aa232d5f-d3c5-38d8-8d8e-be3a43843ae2",
       "position": 1,
       "title": "",
+      "track-count": 11,
       "track-offset": 0,
-      "id": "aa232d5f-d3c5-38d8-8d8e-be3a43843ae2",
       "tracks": [
         {
-          "title": "Second Hand News",
-          "id": "938db19d-de3b-4ce5-9104-6e91a1633074",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Fleetwood Mac",
               "artist": {
-                "name": "Fleetwood Mac",
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
                 "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
+          "id": "938db19d-de3b-4ce5-9104-6e91a1633074",
+          "length": 173666,
+          "number": "1",
+          "position": 1,
           "recording": {
-            "id": "b25f351b-206f-4297-95bd-78459b704144",
-            "first-release-date": "1977",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
+                  "country": "GB",
                   "disambiguation": "",
-                  "country": "GB"
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Fleetwood Mac",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "title": "Second Hand News",
             "disambiguation": "extra \u201cyeah yeah\u201d at end",
-            "video": false,
-            "length": 173666,
+            "first-release-date": "1977",
+            "id": "b25f351b-206f-4297-95bd-78459b704144",
             "isrcs": [
               "USWB10101367",
               "USWB10202616",
               "USWB10400045",
               "USWB11301110",
               "USWB19900177"
-            ]
+            ],
+            "length": 173666,
+            "title": "Second Hand News",
+            "video": false
           },
-          "position": 1,
-          "length": 173666,
-          "number": "1"
+          "title": "Second Hand News"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Fleetwood Mac",
               "artist": {
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type": "Group",
-                "name": "Fleetwood Mac",
                 "country": "GB",
                 "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
                 "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
           "id": "8dc43013-67d1-4ba3-b69d-9f9c850b3063",
-          "title": "Dreams",
-          "number": "2",
           "length": 257533,
+          "number": "2",
           "position": 2,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "248cc9d1-97ea-493e-84d4-4c5ec718683b",
             "isrcs": [
               "USRH11802580",
               "USWB10101368",
@@ -112,47 +175,50 @@
               "USWB19900178"
             ],
             "length": 257000,
-            "disambiguation": "",
-            "video": false,
-            "first-release-date": "1977-02-04",
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
-                  "disambiguation": "",
-                  "country": "GB"
-                }
-              }
-            ],
-            "id": "248cc9d1-97ea-493e-84d4-4c5ec718683b",
-            "title": "Dreams"
-          }
+            "title": "Dreams",
+            "video": false
+          },
+          "title": "Dreams"
         },
         {
-          "id": "963ca4eb-2da5-4ce4-b702-a567a1f8f83e",
           "artist-credit": [
             {
               "artist": {
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                 "name": "Fleetwood Mac",
                 "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "title": "Never Going Back Again",
+          "id": "963ca4eb-2da5-4ce4-b702-a567a1f8f83e",
+          "length": 135133,
+          "number": "3",
+          "position": 3,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977",
+            "id": "0b304971-9f84-485b-9f34-50f12004cf0d",
             "isrcs": [
               "USWB10101369",
               "USWB10202610",
@@ -162,40 +228,20 @@
             ],
             "length": 134426,
             "title": "Never Going Back Again",
-            "first-release-date": "1977",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Fleetwood Mac",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "country": "GB",
-                  "disambiguation": ""
-                }
-              }
-            ],
-            "id": "0b304971-9f84-485b-9f34-50f12004cf0d",
-            "video": false,
-            "disambiguation": ""
+            "video": false
           },
-          "length": 135133,
-          "number": "3",
-          "position": 3
+          "title": "Never Going Back Again"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "",
                 "country": "GB",
-                "type": "Group",
-                "name": "Fleetwood Mac",
+                "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
                 "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
@@ -203,32 +249,28 @@
             }
           ],
           "id": "a643b1b8-24a3-45fb-a50c-7da8f630caa1",
-          "title": "Don\u2019t Stop",
-          "number": "4",
           "length": 193973,
+          "number": "4",
           "position": 4,
           "recording": {
-            "id": "1c0a78be-b883-4c5d-93f2-4f48405dbcb2",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Fleetwood Mac",
                 "artist": {
-                  "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "",
                   "country": "GB",
-                  "type": "Group",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-                }
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "first-release-date": "1977-02-04",
-            "title": "Don\u2019t Stop",
             "disambiguation": "",
-            "video": false,
-            "length": 192666,
+            "first-release-date": "1977-02-04",
+            "id": "1c0a78be-b883-4c5d-93f2-4f48405dbcb2",
             "isrcs": [
               "USRH11802582",
               "USWB10101370",
@@ -236,49 +278,52 @@
               "USWB10400049",
               "USWB11301113",
               "USWB19900180"
-            ]
-          }
+            ],
+            "length": 192666,
+            "title": "Don\u2019t Stop",
+            "video": false
+          },
+          "title": "Don\u2019t Stop"
         },
         {
-          "id": "beaa98c0-32c9-41f0-8204-e9f357e1c131",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Fleetwood Mac",
               "artist": {
-                "sort-name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                 "name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-              }
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "title": "Go Your Own Way",
+          "id": "beaa98c0-32c9-41f0-8204-e9f357e1c131",
+          "length": 220226,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "id": "66908b7f-050f-4e8d-82b0-a768a3d80c63",
-            "first-release-date": "1976-12-20",
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
                 "artist": {
-                  "disambiguation": "",
                   "country": "GB",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
+                  "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac"
-                }
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "title": "Go Your Own Way",
             "disambiguation": "",
-            "video": false,
-            "length": 219373,
+            "first-release-date": "1976-12-20",
+            "id": "66908b7f-050f-4e8d-82b0-a768a3d80c63",
             "isrcs": [
               "USLIC0601867",
               "USRE11000837",
@@ -288,35 +333,52 @@
               "USWB10400050",
               "USWB11301114",
               "USWB19900181"
-            ]
+            ],
+            "length": 219373,
+            "title": "Go Your Own Way",
+            "video": false
           },
-          "length": 220226,
-          "number": "5",
-          "position": 5
+          "title": "Go Your Own Way"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "name": "Fleetwood Mac",
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac"
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
           "id": "69fd4d6d-d6ba-4668-be01-c47c9a1ef40d",
-          "title": "Songbird",
-          "number": "6",
           "length": 203200,
+          "number": "6",
           "position": 6,
           "recording": {
-            "length": 200813,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "70b64435-e956-4141-9149-789b19ebcf9f",
             "isrcs": [
               "USWB10101378",
               "USWB10202615",
@@ -325,33 +387,51 @@
               "USWB11301115",
               "USWB19900182"
             ],
-            "disambiguation": "",
-            "video": false,
-            "id": "70b64435-e956-4141-9149-789b19ebcf9f",
-            "first-release-date": "1977-02-04",
+            "length": 200813,
+            "title": "Songbird",
+            "video": false
+          },
+          "title": "Songbird"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "4b91c1a0-1ca5-4c09-839d-7b903e2e8fde",
+          "length": 271000,
+          "number": "7",
+          "position": 7,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "country": "GB",
                   "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
                   "type": "Group",
-                  "name": "Fleetwood Mac"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "title": "Songbird"
-          }
-        },
-        {
-          "position": 7,
-          "number": "7",
-          "length": 271000,
-          "recording": {
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "cd06c484-9319-4376-a104-504871e19756",
             "isrcs": [
               "USRH11802583",
               "USWB10101373",
@@ -361,51 +441,50 @@
               "USWB19900183"
             ],
             "length": 269400,
-            "video": false,
-            "disambiguation": "",
             "title": "The Chain",
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
-                "artist": {
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "first-release-date": "1977-02-04",
-            "id": "cd06c484-9319-4376-a104-504871e19756"
+            "video": false
           },
-          "title": "The Chain",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Fleetwood Mac",
-              "artist": {
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type": "Group",
-                "name": "Fleetwood Mac",
-                "country": "GB",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "id": "4b91c1a0-1ca5-4c09-839d-7b903e2e8fde"
+          "title": "The Chain"
         },
         {
-          "position": 8,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "25ef7ef5-9579-4918-95af-28d302f142c8",
           "length": 213106,
           "number": "8",
+          "position": 8,
           "recording": {
-            "length": 213106,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "cce551a1-5a6c-494b-89fe-6dfac5e8aed1",
             "isrcs": [
               "USWB10101374",
               "USWB10202604",
@@ -413,47 +492,51 @@
               "USWB11301117",
               "USWB19900184"
             ],
-            "disambiguation": "",
-            "video": false,
-            "id": "cce551a1-5a6c-494b-89fe-6dfac5e8aed1",
-            "first-release-date": "1977-02-04",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Fleetwood Mac",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "type": "Group",
-                  "name": "Fleetwood Mac"
-                }
-              }
-            ],
-            "title": "You Make Loving Fun"
+            "length": 213106,
+            "title": "You Make Loving Fun",
+            "video": false
           },
-          "title": "You Make Loving Fun",
-          "id": "25ef7ef5-9579-4918-95af-28d302f142c8",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Fleetwood Mac",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "name": "Fleetwood Mac",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": ""
-              }
-            }
-          ]
+          "title": "You Make Loving Fun"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "7d449bb6-b0ea-4a34-b33f-b4f7c9a7f565",
+          "length": 195493,
+          "number": "9",
+          "position": 9,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "fc53705e-f3d6-4246-b0e3-23d1acc8f1d1",
             "isrcs": [
               "USWB10101375",
               "USWB10400055",
@@ -461,248 +544,165 @@
               "USWB19900185"
             ],
             "length": 195493,
-            "first-release-date": "1977-02-04",
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "name": "Fleetwood Mac",
-                  "type": "Group"
-                }
-              }
-            ],
-            "id": "fc53705e-f3d6-4246-b0e3-23d1acc8f1d1",
             "title": "I Don\u2019t Want to Know",
-            "disambiguation": "",
             "video": false
           },
-          "length": 195493,
-          "number": "9",
-          "position": 9,
-          "id": "7d449bb6-b0ea-4a34-b33f-b4f7c9a7f565",
-          "artist-credit": [
-            {
-              "artist": {
-                "disambiguation": "",
-                "country": "GB",
-                "type": "Group",
-                "name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac"
-              },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
-            }
-          ],
           "title": "I Don\u2019t Want to Know"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "68192aca-41c5-4b7d-aef8-2b0a849cbad5",
+          "length": 237506,
+          "number": "10",
+          "position": 10,
           "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "Oh Daddy",
-            "id": "0c9684a3-1109-44cb-ac8c-808168ae8715",
             "artist-credit": [
               {
                 "artist": {
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Fleetwood Mac",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "1977-02-04",
-            "length": 236226,
+            "id": "0c9684a3-1109-44cb-ac8c-808168ae8715",
             "isrcs": [
               "USWB10101376",
               "USWB10400056",
               "USWB11301119",
               "USWB19900186"
-            ]
+            ],
+            "length": 236226,
+            "title": "Oh Daddy",
+            "video": false
           },
-          "length": 237506,
-          "number": "10",
-          "position": 10,
-          "id": "68192aca-41c5-4b7d-aef8-2b0a849cbad5",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac",
-                "type": "Group",
-                "name": "Fleetwood Mac",
-                "disambiguation": "",
-                "country": "GB",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-              },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
-            }
-          ],
           "title": "Oh Daddy"
         },
         {
-          "number": "11",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "87c199f1-43f5-449d-8a87-bf8654c5be18",
           "length": 302400,
+          "number": "11",
           "position": 11,
           "recording": {
-            "id": "6eda00db-318c-495b-96a1-494d249b04f5",
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
                 "artist": {
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "disambiguation": "",
                   "country": "GB",
+                  "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "first-release-date": "1977",
-            "title": "Gold Dust Woman",
             "disambiguation": "hard start, glass break, soft howling",
-            "video": false,
-            "length": 302000,
+            "first-release-date": "1977",
+            "id": "6eda00db-318c-495b-96a1-494d249b04f5",
             "isrcs": [
               "USWB10101377",
               "USWB10400057",
               "USWB11301120",
               "USWB19900187"
-            ]
+            ],
+            "length": 302000,
+            "title": "Gold Dust Woman",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "name": "Fleetwood Mac",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": ""
-              },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
-            }
-          ],
-          "id": "87c199f1-43f5-449d-8a87-bf8654c5be18",
           "title": "Gold Dust Woman"
         }
-      ],
-      "track-count": 11,
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31"
+      ]
     }
   ],
-  "cover-art-archive": {
-    "back": false,
-    "front": true,
-    "artwork": true,
-    "count": 1,
-    "darkened": false
-  },
+  "packaging": "Jewel Case",
   "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
   "release-events": [
     {
       "area": {
-        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
         "disambiguation": "",
+        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
         "iso-3166-1-codes": [
           "GB"
         ],
         "name": "United Kingdom",
+        "sort-name": "United Kingdom",
         "type": null,
-        "type-id": null,
-        "sort-name": "United Kingdom"
+        "type-id": null
       },
       "date": "1984-04-24"
     }
   ],
-  "title": "Rumours",
-  "packaging": "Jewel Case",
-  "status": "Official",
   "release-group": {
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "primary-type": "Album",
-    "secondary-type-ids": [],
-    "title": "Rumours",
-    "secondary-types": [],
-    "id": "416bb5e5-c7d1-3977-8fd7-7c9daf6c2be6",
     "artist-credit": [
       {
         "artist": {
-          "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-          "type": "Group",
-          "name": "Fleetwood Mac",
-          "disambiguation": "",
           "country": "GB",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "sort-name": "Fleetwood Mac"
+          "disambiguation": "",
+          "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+          "name": "Fleetwood Mac",
+          "sort-name": "Fleetwood Mac",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
         },
-        "name": "Fleetwood Mac",
-        "joinphrase": ""
+        "joinphrase": "",
+        "name": "Fleetwood Mac"
       }
     ],
+    "disambiguation": "",
     "first-release-date": "1977-02-04",
-    "disambiguation": ""
+    "id": "416bb5e5-c7d1-3977-8fd7-7c9daf6c2be6",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Rumours"
   },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "text-representation": {
-    "script": "Latn",
-    "language": "eng"
+    "language": "eng",
+    "script": "Latn"
   },
-  "label-info": [
-    {
-      "label": {
-        "sort-name": "Warner Bros. Records",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "type": "Imprint",
-        "name": "Warner Bros. Records",
-        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
-        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
-        "label-code": 392
-      },
-      "catalog-number": "03010-2"
-    },
-    {
-      "catalog-number": "256 344",
-      "label": {
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "sort-name": "Warner Bros. Records",
-        "label-code": 392,
-        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
-        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
-        "name": "Warner Bros. Records",
-        "type": "Imprint"
-      }
-    },
-    {
-      "label": {
-        "label-code": 392,
-        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
-        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
-        "name": "Warner Bros. Records",
-        "type": "Imprint",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "sort-name": "Warner Bros. Records"
-      },
-      "catalog-number": "3010-2"
-    }
-  ],
-  "country": "GB"
+  "title": "Rumours"
 }

--- a/scripts/eval_matching/corpus/eval_release_20b2dd9a.json
+++ b/scripts/eval_matching/corpus/eval_release_20b2dd9a.json
@@ -1,492 +1,492 @@
 {
-  "release-events": [
+  "artist-credit": [
     {
-      "area": {
-        "type-id": null,
-        "name": "United Kingdom",
-        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
-        "iso-3166-1-codes": [
-          "GB"
-        ],
+      "artist": {
+        "country": "GB",
         "disambiguation": "",
-        "sort-name": "United Kingdom",
-        "type": null
+        "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+        "name": "Radiohead",
+        "sort-name": "Radiohead",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
-      "date": "1994-09-24"
+      "joinphrase": "",
+      "name": "Radiohead"
     }
   ],
-  "disambiguation": "",
-  "status": "Official",
-  "title": "My Iron Lung",
+  "asin": "B000007361",
+  "barcode": "724383147823",
+  "country": "GB",
   "cover-art-archive": {
     "artwork": true,
-    "count": 6,
     "back": true,
-    "front": true,
-    "darkened": false
+    "count": 6,
+    "darkened": false,
+    "front": true
   },
-  "packaging": "Jewel Case",
-  "country": "GB",
-  "barcode": "724383147823",
+  "date": "1994-09-24",
+  "disambiguation": "",
+  "id": "20b2dd9a-cee1-4767-8bc1-5b3b08cfcae5",
+  "label-info": [
+    {
+      "catalog-number": "7243 8 31478 2 3",
+      "label": {
+        "disambiguation": "",
+        "id": "df7d1c7f-ef95-425f-8eef-445b3d7bcbd9",
+        "label-code": 299,
+        "name": "Parlophone",
+        "sort-name": "Parlophone",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
+      }
+    }
+  ],
   "media": [
     {
+      "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "7ff8e57b-561a-37a6-8e68-a837a05c2755",
-      "title": "",
       "position": 1,
+      "title": "",
+      "track-count": 8,
+      "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "disambiguation": "",
                 "country": "GB",
-                "type": "Group",
-                "sort-name": "Radiohead",
+                "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "number": "1",
           "id": "27a96f1f-ddf6-37c6-8e0c-5624424b78fd",
           "length": 277133,
-          "title": "My Iron Lung",
+          "number": "1",
           "position": 1,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Radiohead",
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "sort-name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
-                }
-              }
-            ],
-            "first-release-date": "1994-09-24",
-            "disambiguation": "",
-            "video": false,
-            "isrcs": [
-              "GBAYE9400065"
-            ],
-            "title": "My Iron Lung",
-            "id": "938ecadc-f343-4c06-a754-c9f262be1088",
-            "length": 276440
-          }
-        },
-        {
-          "number": "2",
-          "artist-credit": [
-            {
-              "artist": {
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "country": "GB",
-                "type": "Group",
-                "disambiguation": ""
-              },
-              "name": "Radiohead",
-              "joinphrase": ""
-            }
-          ],
-          "recording": {
-            "length": 280466,
-            "id": "6b0f5a78-9809-4561-96c7-0775aa9a94fa",
-            "title": "The Trickster",
-            "video": false,
-            "isrcs": [
-              "GBAYE9400673"
-            ],
-            "disambiguation": "",
-            "first-release-date": "1994-09-24",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Radiohead",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "name": "Radiohead",
-                  "disambiguation": "",
-                  "type": "Group",
-                  "country": "GB"
-                },
-                "name": "Radiohead",
-                "joinphrase": ""
-              }
-            ]
-          },
-          "position": 2,
-          "title": "The Trickster",
-          "length": 280466,
-          "id": "7f7e38a5-c3fa-3e7a-89bd-8e3788e3192a"
-        },
-        {
-          "number": "3",
-          "artist-credit": [
-            {
-              "artist": {
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "country": "GB",
-                "type": "Group",
-                "disambiguation": ""
-              },
-              "name": "Radiohead",
-              "joinphrase": ""
-            }
-          ],
-          "recording": {
-            "title": "Lewis (Mistreated)",
-            "isrcs": [
-              "GBAYE9400670"
-            ],
-            "video": false,
-            "length": 199026,
-            "id": "c9035ae4-3234-4880-98db-5a676ce61d98",
-            "disambiguation": "",
-            "first-release-date": "1994-09-24",
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "",
-                  "country": "GB",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "sort-name": "Radiohead",
-                  "name": "Radiohead",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Radiohead",
-                "joinphrase": ""
-              }
-            ]
-          },
-          "position": 3,
-          "title": "Lewis (Mistreated)",
-          "length": 199026,
-          "id": "c95798ea-222c-307e-994d-6a561a6b17ca"
-        },
-        {
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Radiohead",
-              "artist": {
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "",
-                "country": "GB",
-                "type": "Group"
-              }
-            }
-          ],
-          "number": "4",
-          "recording": {
-            "disambiguation": "",
-            "id": "92f7944c-463c-4b0a-88e9-5d93107abd5f",
-            "length": 280306,
-            "isrcs": [
-              "GBAYE9400674"
-            ],
-            "video": false,
-            "title": "Punchdrunk Lovesick Singalong",
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "sort-name": "Radiohead",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": ""
-                },
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1994-09-24"
-          },
-          "id": "885176c3-f0e9-3b97-a59a-18454e85f242",
-          "length": 280306,
-          "title": "Punchdrunk Lovesick Singalong",
-          "position": 4
-        },
-        {
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Radiohead",
-              "artist": {
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "",
-                "country": "GB",
-                "type": "Group"
-              }
-            }
-          ],
-          "number": "5",
-          "recording": {
-            "artist-credit": [
-              {
                 "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "sort-name": "Radiohead",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": ""
-                },
                 "name": "Radiohead"
               }
             ],
-            "first-release-date": "1994-09-24",
             "disambiguation": "",
-            "title": "Permanent Daylight",
+            "first-release-date": "1994-09-24",
+            "id": "938ecadc-f343-4c06-a754-c9f262be1088",
+            "isrcs": [
+              "GBAYE9400065"
+            ],
+            "length": 276440,
+            "title": "My Iron Lung",
+            "video": false
+          },
+          "title": "My Iron Lung"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "7f7e38a5-c3fa-3e7a-89bd-8e3788e3192a",
+          "length": 280466,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-09-24",
+            "id": "6b0f5a78-9809-4561-96c7-0775aa9a94fa",
+            "isrcs": [
+              "GBAYE9400673"
+            ],
+            "length": 280466,
+            "title": "The Trickster",
+            "video": false
+          },
+          "title": "The Trickster"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "c95798ea-222c-307e-994d-6a561a6b17ca",
+          "length": 199026,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-09-24",
+            "id": "c9035ae4-3234-4880-98db-5a676ce61d98",
+            "isrcs": [
+              "GBAYE9400670"
+            ],
+            "length": 199026,
+            "title": "Lewis (Mistreated)",
+            "video": false
+          },
+          "title": "Lewis (Mistreated)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "885176c3-f0e9-3b97-a59a-18454e85f242",
+          "length": 280306,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-09-24",
+            "id": "92f7944c-463c-4b0a-88e9-5d93107abd5f",
+            "isrcs": [
+              "GBAYE9400674"
+            ],
+            "length": 280306,
+            "title": "Punchdrunk Lovesick Singalong",
+            "video": false
+          },
+          "title": "Punchdrunk Lovesick Singalong"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "baf748f6-ae3f-3227-b2e9-d77b92c68743",
+          "length": 168226,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-09-24",
+            "id": "9f1c1235-6120-4784-a513-ed89c69f9296",
             "isrcs": [
               "GBAYE9400671"
             ],
-            "video": false,
             "length": 168240,
-            "id": "9f1c1235-6120-4784-a513-ed89c69f9296"
+            "title": "Permanent Daylight",
+            "video": false
           },
-          "length": 168226,
-          "id": "baf748f6-ae3f-3227-b2e9-d77b92c68743",
-          "title": "Permanent Daylight",
-          "position": 5
+          "title": "Permanent Daylight"
         },
         {
-          "recording": {
-            "disambiguation": "",
-            "id": "83eadb97-276d-4583-8a9f-bd2720a1e654",
-            "length": 136200,
-            "video": false,
-            "isrcs": [
-              "GBAYE9400675"
-            ],
-            "title": "Lozenge of Love",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Radiohead",
-                "artist": {
-                  "disambiguation": "",
-                  "type": "Group",
-                  "country": "GB",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead"
-                }
-              }
-            ],
-            "first-release-date": "1994-09-24"
-          },
-          "id": "3cd35768-68fc-3319-8624-cd2dc58023f5",
-          "length": 136200,
-          "position": 6,
-          "title": "Lozenge of Love",
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "disambiguation": "",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "sort-name": "Radiohead",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "number": "6"
-        },
-        {
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Radiohead",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": ""
-              },
-              "name": "Radiohead",
-              "joinphrase": ""
-            }
-          ],
-          "number": "7",
+          "id": "3cd35768-68fc-3319-8624-cd2dc58023f5",
+          "length": 136200,
+          "number": "6",
+          "position": 6,
           "recording": {
-            "length": 104440,
-            "id": "96260de9-fc67-4fc9-80b7-5a7ca4707be4",
-            "title": "You Never Wash Up After Yourself",
-            "video": false,
-            "isrcs": [
-              "GBAYE9400672"
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
             ],
             "disambiguation": "",
             "first-release-date": "1994-09-24",
+            "id": "83eadb97-276d-4583-8a9f-bd2720a1e654",
+            "isrcs": [
+              "GBAYE9400675"
+            ],
+            "length": 136200,
+            "title": "Lozenge of Love",
+            "video": false
+          },
+          "title": "Lozenge of Love"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "349e3464-e554-3c50-9420-1ed4d3e37dfd",
+          "length": 104466,
+          "number": "7",
+          "position": 7,
+          "recording": {
             "artist-credit": [
               {
-                "name": "Radiohead",
                 "artist": {
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "sort-name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
-            ]
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-09-24",
+            "id": "96260de9-fc67-4fc9-80b7-5a7ca4707be4",
+            "isrcs": [
+              "GBAYE9400672"
+            ],
+            "length": 104440,
+            "title": "You Never Wash Up After Yourself",
+            "video": false
           },
-          "length": 104466,
-          "id": "349e3464-e554-3c50-9420-1ed4d3e37dfd",
-          "position": 7,
           "title": "You Never Wash Up After Yourself"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Radiohead",
+                "country": "GB",
                 "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
                 "type": "Group",
-                "country": "GB"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Radiohead",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "number": "8",
-          "length": 259066,
           "id": "7a723173-fb70-3110-8d77-38e848acceb9",
-          "title": "Creep (acoustic)",
+          "length": 259066,
+          "number": "8",
           "position": 8,
           "recording": {
-            "first-release-date": "1994-06-01",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Radiohead",
+                  "country": "GB",
+                  "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "type": "Group"
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "video": false,
+            "disambiguation": "live, 1993-07-13: KROQ Studios, Burbank, CA, USA",
+            "first-release-date": "1994-06-01",
+            "id": "7cdf2e8e-f52c-4008-a493-d37b41fc1004",
             "isrcs": [
               "GBAYE9300465"
             ],
-            "title": "Creep (acoustic)",
-            "id": "7cdf2e8e-f52c-4008-a493-d37b41fc1004",
             "length": 259066,
-            "disambiguation": "live, 1993-07-13: KROQ Studios, Burbank, CA, USA"
-          }
+            "title": "Creep (acoustic)",
+            "video": false
+          },
+          "title": "Creep (acoustic)"
         }
-      ],
-      "track-offset": 0,
-      "track-count": 8,
-      "format": "CD"
+      ]
     }
   ],
+  "packaging": "Jewel Case",
   "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "asin": "B000007361",
-  "label-info": [
+  "quality": "normal",
+  "release-events": [
     {
-      "label": {
-        "sort-name": "Parlophone",
-        "id": "df7d1c7f-ef95-425f-8eef-445b3d7bcbd9",
-        "name": "Parlophone",
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "label-code": 299,
+      "area": {
         "disambiguation": "",
-        "type": "Original Production"
+        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+        "iso-3166-1-codes": [
+          "GB"
+        ],
+        "name": "United Kingdom",
+        "sort-name": "United Kingdom",
+        "type": null,
+        "type-id": null
       },
-      "catalog-number": "7243 8 31478 2 3"
+      "date": "1994-09-24"
     }
   ],
-  "date": "1994-09-24",
-  "quality": "normal",
-  "id": "20b2dd9a-cee1-4767-8bc1-5b3b08cfcae5",
   "release-group": {
     "artist-credit": [
       {
-        "name": "Radiohead",
         "artist": {
-          "type": "Group",
           "country": "GB",
           "disambiguation": "",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+          "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
           "name": "Radiohead",
           "sort-name": "Radiohead",
-          "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
         },
-        "joinphrase": ""
+        "joinphrase": "",
+        "name": "Radiohead"
       }
     ],
-    "primary-type-id": "6d0c5bf6-7a33-3420-a519-44fc63eedebf",
-    "first-release-date": "1994-09-24",
     "disambiguation": "",
-    "secondary-type-ids": [],
+    "first-release-date": "1994-09-24",
     "id": "99445a2b-578a-321e-851e-c6539bfbbd7f",
+    "primary-type": "EP",
+    "primary-type-id": "6d0c5bf6-7a33-3420-a519-44fc63eedebf",
+    "secondary-type-ids": [],
     "secondary-types": [],
-    "title": "My Iron Lung",
-    "primary-type": "EP"
+    "title": "My Iron Lung"
   },
+  "status": "Official",
   "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "artist-credit": [
-    {
-      "joinphrase": "",
-      "artist": {
-        "name": "Radiohead",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-        "sort-name": "Radiohead",
-        "country": "GB",
-        "type": "Group",
-        "disambiguation": ""
-      },
-      "name": "Radiohead"
-    }
-  ],
   "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  }
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "My Iron Lung"
 }

--- a/scripts/eval_matching/corpus/eval_release_2529f558.json
+++ b/scripts/eval_matching/corpus/eval_release_2529f558.json
@@ -1,268 +1,247 @@
 {
-  "packaging-id": null,
-  "cover-art-archive": {
-    "artwork": true,
-    "back": true,
-    "darkened": false,
-    "front": true,
-    "count": 6
-  },
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "country": "CA",
-  "quality": "high",
-  "barcode": "075596111324",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "packaging": null,
-  "asin": "B000002H97",
-  "release-group": {
-    "title": "Metallica",
-    "disambiguation": "\u201cThe Black Album\u201d",
-    "id": "e8f70201-8899-3f0c-9e07-5d6495bc8046",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "first-release-date": "1991-08-12",
-    "secondary-types": [],
-    "secondary-type-ids": [],
-    "primary-type": "Album",
-    "artist-credit": [
-      {
-        "name": "Metallica",
-        "joinphrase": "",
-        "artist": {
-          "country": "US",
-          "type": "Group",
-          "disambiguation": "",
-          "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-          "sort-name": "Metallica",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "name": "Metallica"
-        }
-      }
-    ]
-  },
-  "status": "Official",
   "artist-credit": [
     {
-      "joinphrase": "",
       "artist": {
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "name": "Metallica",
-        "type": "Group",
         "country": "US",
-        "sort-name": "Metallica",
         "disambiguation": "",
-        "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab"
+        "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+        "name": "Metallica",
+        "sort-name": "Metallica",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
+      "joinphrase": "",
       "name": "Metallica"
     }
   ],
-  "id": "2529f558-970b-33d2-a42c-41ab15a970c6",
+  "asin": "B000002H97",
+  "barcode": "075596111324",
+  "country": "CA",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 6,
+    "darkened": false,
+    "front": true
+  },
+  "date": "1991-08-12",
   "disambiguation": "",
-  "release-events": [
+  "id": "2529f558-970b-33d2-a42c-41ab15a970c6",
+  "label-info": [
     {
-      "date": "1991-08-12",
-      "area": {
-        "sort-name": "Canada",
-        "iso-3166-1-codes": [
-          "CA"
-        ],
-        "disambiguation": "",
-        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
-        "type": null,
-        "name": "Canada",
-        "type-id": null
+      "catalog-number": "CD 61113",
+      "label": {
+        "disambiguation": "all releases with \u201cElektra\u201d or \u201cElektra Entertainment\u201d logo, 1950 to present",
+        "id": "873f9f75-af68-4872-98e2-431058e4c9a9",
+        "label-code": 192,
+        "name": "Elektra",
+        "sort-name": "Elektra",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
       }
     }
   ],
-  "title": "Metallica",
   "media": [
     {
-      "title": "",
-      "position": 1,
-      "id": "199080de-4dff-315d-8d7d-5647e43ec595",
       "format": "CD",
-      "track-offset": 0,
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "199080de-4dff-315d-8d7d-5647e43ec595",
+      "position": 1,
+      "title": "",
+      "track-count": 12,
+      "track-offset": 0,
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Metallica"
+            }
+          ],
+          "id": "6922eea8-b448-3e99-b889-0ebf920f0ce9",
           "length": 331600,
+          "number": "1",
           "position": 1,
           "recording": {
             "artist-credit": [
               {
-                "name": "Metallica",
                 "artist": {
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "US",
                   "disambiguation": "",
                   "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
                   "sort-name": "Metallica",
-                  "country": "US",
-                  "type": "Group"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Metallica"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1990",
+            "id": "fe4a0608-cf7f-444a-a932-a1b77c766673",
             "isrcs": [
               "GBF089190013",
               "QMKHM1900001",
               "QMKHM1900218",
               "USEE10001992"
             ],
-            "id": "fe4a0608-cf7f-444a-a932-a1b77c766673",
-            "disambiguation": "",
-            "title": "Enter Sandman",
             "length": 331560,
-            "first-release-date": "1990",
+            "title": "Enter Sandman",
             "video": false
           },
-          "title": "Enter Sandman",
-          "id": "6922eea8-b448-3e99-b889-0ebf920f0ce9",
-          "artist-credit": [
-            {
-              "name": "Metallica",
-              "joinphrase": "",
-              "artist": {
-                "country": "US",
-                "type": "Group",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "disambiguation": "",
-                "sort-name": "Metallica",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Metallica"
-              }
-            }
-          ],
-          "number": "1"
+          "title": "Enter Sandman"
         },
         {
           "artist-credit": [
             {
-              "name": "Metallica",
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Metallica",
-                "type": "Group",
                 "country": "US",
-                "sort-name": "Metallica",
                 "disambiguation": "",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab"
-              }
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Metallica"
             }
           ],
-          "number": "2",
+          "id": "bcf3f888-3a23-33d7-a2d6-84ade2fbd55e",
           "length": 324600,
+          "number": "2",
           "position": 2,
           "recording": {
-            "video": false,
-            "first-release-date": "1990",
-            "length": 324666,
-            "title": "Sad but True",
-            "id": "a105dba3-a35b-464f-8f46-b18c21c13809",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Metallica"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1990",
+            "id": "a105dba3-a35b-464f-8f46-b18c21c13809",
             "isrcs": [
               "GBF089190014",
               "QMKHM1900002",
               "QMKHM1900219",
               "USEE10001993"
             ],
-            "artist-credit": [
-              {
-                "name": "Metallica",
-                "artist": {
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "",
-                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                  "sort-name": "Metallica",
-                  "country": "US",
-                  "type": "Group"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "length": 324666,
+            "title": "Sad but True",
+            "video": false
           },
-          "title": "Sad but True",
-          "id": "bcf3f888-3a23-33d7-a2d6-84ade2fbd55e"
+          "title": "Sad but True"
         },
         {
-          "title": "Holier Than Thou",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Metallica"
+            }
+          ],
+          "id": "5f999a4c-e11c-32e4-921e-0af2f4285c8e",
+          "length": 227533,
+          "number": "3",
           "position": 3,
           "recording": {
-            "length": 227640,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Metallica"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1990",
-            "video": false,
+            "id": "51bd242e-0a50-4e0b-8472-13399f7d98e6",
             "isrcs": [
               "GBF089190015",
               "QMKHM1900003",
               "QMKHM1900220",
               "USEE10001994"
             ],
-            "id": "51bd242e-0a50-4e0b-8472-13399f7d98e6",
-            "disambiguation": "",
+            "length": 227640,
             "title": "Holier Than Thou",
+            "video": false
+          },
+          "title": "Holier Than Thou"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Metallica"
+            }
+          ],
+          "id": "746511f7-d602-357d-814e-e81b735e9e43",
+          "length": 387266,
+          "number": "4",
+          "position": 4,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Metallica",
+                  "country": "US",
                   "disambiguation": "",
                   "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
                   "type": "Group",
-                  "country": "US"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Metallica"
               }
-            ]
-          },
-          "id": "5f999a4c-e11c-32e4-921e-0af2f4285c8e",
-          "length": 227533,
-          "number": "3",
-          "artist-credit": [
-            {
-              "name": "Metallica",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Metallica",
-                "disambiguation": "",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "type": "Group",
-                "country": "US",
-                "name": "Metallica",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ]
-        },
-        {
-          "number": "4",
-          "artist-credit": [
-            {
-              "name": "Metallica",
-              "artist": {
-                "name": "Metallica",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "disambiguation": "",
-                "sort-name": "Metallica",
-                "country": "US",
-                "type": "Group"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "position": 4,
-          "title": "The Unforgiven",
-          "recording": {
-            "length": 387093,
-            "video": false,
+            ],
+            "disambiguation": "",
             "first-release-date": "1990",
-            "title": "The Unforgiven",
             "id": "51d82245-53de-4f1a-864b-ca1960692ac3",
             "isrcs": [
               "GBF089190016",
@@ -270,85 +249,101 @@
               "QMKHM1900221",
               "USEE10001995"
             ],
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "name": "Metallica",
-                "joinphrase": "",
-                "artist": {
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                  "disambiguation": "",
-                  "sort-name": "Metallica",
-                  "country": "US",
-                  "type": "Group"
-                }
-              }
-            ]
+            "length": 387093,
+            "title": "The Unforgiven",
+            "video": false
           },
-          "id": "746511f7-d602-357d-814e-e81b735e9e43",
-          "length": 387266
+          "title": "The Unforgiven"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Metallica"
+            }
+          ],
+          "id": "63f38a59-46e9-3445-ba86-4d5d52af8e6a",
+          "length": 404266,
+          "number": "5",
           "position": 5,
-          "title": "Wherever I May Roam",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
                   "country": "US",
-                  "type": "Group",
-                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
                   "disambiguation": "",
+                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
                   "sort-name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Metallica"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Metallica"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "1990",
-            "video": false,
-            "length": 404200,
-            "title": "Wherever I May Roam",
+            "id": "8889c63e-dc63-479b-91dc-209bb15995df",
             "isrcs": [
               "GBF089190017",
               "QMKHM1900005",
               "QMKHM1900222",
               "USEE10001996"
             ],
-            "id": "8889c63e-dc63-479b-91dc-209bb15995df",
-            "disambiguation": ""
+            "length": 404200,
+            "title": "Wherever I May Roam",
+            "video": false
           },
-          "id": "63f38a59-46e9-3445-ba86-4d5d52af8e6a",
-          "length": 404266,
-          "number": "5",
-          "artist-credit": [
-            {
-              "name": "Metallica",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Metallica",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "disambiguation": "",
-                "type": "Group",
-                "country": "US",
-                "name": "Metallica",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ]
+          "title": "Wherever I May Roam"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Metallica"
+            }
+          ],
           "id": "8167cdc4-b6c5-330a-b3cc-3bc3195062cf",
-          "title": "Don\u2019t Tread on Me",
+          "length": 240160,
+          "number": "6",
           "position": 6,
           "recording": {
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Metallica"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1990",
-            "length": 240333,
             "id": "a130f313-bb4c-49dd-812e-976c88afa28c",
             "isrcs": [
               "GBF089190018",
@@ -356,60 +351,50 @@
               "QMKHM1900223",
               "USEE10001997"
             ],
-            "disambiguation": "",
+            "length": 240333,
             "title": "Don\u2019t Tread on Me",
+            "video": false
+          },
+          "title": "Don\u2019t Tread on Me"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Metallica"
+            }
+          ],
+          "id": "ea6b54d1-3a61-3636-bd6e-f8bac894fe8e",
+          "length": 244506,
+          "number": "7",
+          "position": 7,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "US",
                   "disambiguation": "",
                   "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
                   "sort-name": "Metallica",
-                  "country": "US",
-                  "type": "Group"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Metallica"
               }
-            ]
-          },
-          "length": 240160,
-          "number": "6",
-          "artist-credit": [
-            {
-              "artist": {
-                "type": "Group",
-                "country": "US",
-                "sort-name": "Metallica",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "disambiguation": "",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Metallica"
-              },
-              "joinphrase": "",
-              "name": "Metallica"
-            }
-          ]
-        },
-        {
-          "number": "7",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Metallica",
-                "type": "Group",
-                "country": "US",
-                "sort-name": "Metallica",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "disambiguation": ""
-              },
-              "name": "Metallica"
-            }
-          ],
-          "recording": {
+            ],
+            "disambiguation": "",
+            "first-release-date": "1990",
             "id": "d225a408-8c00-4aa2-84ef-c3aa03f4158e",
             "isrcs": [
               "GBF089190019",
@@ -417,106 +402,101 @@
               "QMKHM1900224",
               "USEE10001998"
             ],
-            "disambiguation": "",
-            "title": "Through the Never",
             "length": 244373,
-            "first-release-date": "1990",
-            "video": false,
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Metallica",
-                  "type": "Group",
-                  "country": "US",
-                  "sort-name": "Metallica",
-                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                  "disambiguation": ""
-                },
-                "joinphrase": "",
-                "name": "Metallica"
-              }
-            ]
+            "title": "Through the Never",
+            "video": false
           },
-          "position": 7,
-          "title": "Through the Never",
-          "id": "ea6b54d1-3a61-3636-bd6e-f8bac894fe8e",
-          "length": 244506
+          "title": "Through the Never"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Metallica"
+            }
+          ],
+          "id": "d5005602-fafc-366b-84fc-c09d633f4bfe",
           "length": 388760,
+          "number": "8",
           "position": 8,
           "recording": {
             "artist-credit": [
               {
-                "name": "Metallica",
                 "artist": {
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Metallica",
+                  "country": "US",
                   "disambiguation": "",
                   "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
                   "type": "Group",
-                  "country": "US"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Metallica"
               }
             ],
-            "length": 388760,
+            "disambiguation": "",
             "first-release-date": "1990",
-            "video": false,
-            "title": "Nothing Else Matters",
+            "id": "83ed6eb7-f421-4ddd-83f2-f8be52bdee6e",
             "isrcs": [
               "GBF089190020",
               "QMKHM1900008",
               "QMKHM1900225",
               "USEE10001999"
             ],
-            "id": "83ed6eb7-f421-4ddd-83f2-f8be52bdee6e",
-            "disambiguation": ""
+            "length": 388760,
+            "title": "Nothing Else Matters",
+            "video": false
           },
-          "title": "Nothing Else Matters",
-          "id": "d5005602-fafc-366b-84fc-c09d633f4bfe",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Metallica",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "disambiguation": "",
-                "type": "Group",
-                "country": "US",
-                "name": "Metallica",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "name": "Metallica"
-            }
-          ],
-          "number": "8"
+          "title": "Nothing Else Matters"
         },
         {
           "artist-credit": [
             {
-              "name": "Metallica",
               "artist": {
+                "country": "US",
                 "disambiguation": "",
                 "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "sort-name": "Metallica",
-                "country": "US",
-                "type": "Group",
                 "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Metallica"
             }
           ],
-          "number": "9",
-          "length": 256640,
           "id": "6ce57c0d-2b39-3142-9c91-b443a4e2293e",
-          "title": "Of Wolf and Man",
+          "length": 256640,
+          "number": "9",
           "position": 9,
           "recording": {
-            "title": "Of Wolf and Man",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Metallica"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1990",
             "id": "188abe05-15ee-4323-b2b2-ab3b3b946683",
             "isrcs": [
               "GBF089190021",
@@ -524,118 +504,101 @@
               "QMKHM1900226",
               "USEE10002000"
             ],
-            "disambiguation": "",
             "length": 256573,
-            "first-release-date": "1990",
-            "video": false,
-            "artist-credit": [
-              {
-                "name": "Metallica",
-                "joinphrase": "",
-                "artist": {
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "",
-                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                  "sort-name": "Metallica",
-                  "country": "US",
-                  "type": "Group"
-                }
-              }
-            ]
-          }
+            "title": "Of Wolf and Man",
+            "video": false
+          },
+          "title": "Of Wolf and Man"
         },
         {
-          "number": "10",
           "artist-credit": [
             {
               "artist": {
-                "name": "Metallica",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "disambiguation": "",
-                "sort-name": "Metallica",
                 "country": "US",
-                "type": "Group"
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Metallica"
             }
           ],
-          "title": "The God That Failed",
+          "id": "4cd99961-e6f2-3afa-956c-d94a98c2f3ce",
+          "length": 308466,
+          "number": "10",
           "position": 10,
           "recording": {
-            "length": 308533,
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Metallica"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1990",
-            "title": "The God That Failed",
+            "id": "9c8ec683-c755-4f1b-a919-7618c657ea05",
             "isrcs": [
               "GBF089190022",
               "QMKHM1900010",
               "QMKHM1900227",
               "USEE10002001"
             ],
-            "id": "9c8ec683-c755-4f1b-a919-7618c657ea05",
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "name": "Metallica",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Metallica",
-                  "disambiguation": "",
-                  "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                  "type": "Group",
-                  "country": "US",
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ]
+            "length": 308533,
+            "title": "The God That Failed",
+            "video": false
           },
-          "id": "4cd99961-e6f2-3afa-956c-d94a98c2f3ce",
-          "length": 308466
+          "title": "The God That Failed"
         },
         {
           "artist-credit": [
             {
-              "name": "Metallica",
-              "joinphrase": "",
               "artist": {
-                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "disambiguation": "",
-                "sort-name": "Metallica",
                 "country": "US",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
                 "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Metallica"
             }
           ],
-          "number": "11",
-          "length": 409626,
           "id": "4625552d-a790-345f-b067-49815518a1cb",
+          "length": 409626,
+          "number": "11",
           "position": 11,
-          "title": "My Friend of Misery",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Metallica",
                   "country": "US",
-                  "type": "Group",
                   "disambiguation": "",
                   "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                  "sort-name": "Metallica"
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Metallica"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "1990",
-            "video": false,
-            "length": 409666,
             "id": "25670127-8733-44db-b956-66b36ee8c3e2",
             "isrcs": [
               "GBF089190023",
@@ -643,49 +606,50 @@
               "QMKHM1900228",
               "USEE10002002"
             ],
-            "disambiguation": "",
-            "title": "My Friend of Misery"
-          }
+            "length": 409666,
+            "title": "My Friend of Misery",
+            "video": false
+          },
+          "title": "My Friend of Misery"
         },
         {
-          "number": "12",
           "artist-credit": [
             {
-              "name": "Metallica",
               "artist": {
+                "country": "US",
                 "disambiguation": "",
                 "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
-                "sort-name": "Metallica",
-                "country": "US",
-                "type": "Group",
                 "name": "Metallica",
+                "sort-name": "Metallica",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Metallica"
             }
           ],
           "id": "362369a1-be03-3c1a-b525-6ad97d3c0724",
-          "title": "The Struggle Within",
+          "length": 233906,
+          "number": "12",
+          "position": 12,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "name": "Metallica",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Metallica",
+                  "country": "US",
                   "disambiguation": "",
                   "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+                  "name": "Metallica",
+                  "sort-name": "Metallica",
                   "type": "Group",
-                  "country": "US"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Metallica"
               }
             ],
-            "length": 233906,
-            "video": false,
-            "first-release-date": "1990",
             "disambiguation": "",
+            "first-release-date": "1990",
             "id": "b7cc2172-6de7-4072-9eee-09b0f393db31",
             "isrcs": [
               "GBF089190024",
@@ -693,28 +657,64 @@
               "QMKHM1900229",
               "USEE10002003"
             ],
-            "title": "The Struggle Within"
+            "length": 233906,
+            "title": "The Struggle Within",
+            "video": false
           },
-          "position": 12,
-          "length": 233906
+          "title": "The Struggle Within"
         }
-      ],
-      "track-count": 12
+      ]
     }
   ],
-  "label-info": [
+  "packaging": null,
+  "packaging-id": null,
+  "quality": "high",
+  "release-events": [
     {
-      "label": {
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "label-code": 192,
-        "name": "Elektra",
-        "type": "Imprint",
-        "sort-name": "Elektra",
-        "id": "873f9f75-af68-4872-98e2-431058e4c9a9",
-        "disambiguation": "all releases with \u201cElektra\u201d or \u201cElektra Entertainment\u201d logo, 1950 to present"
+      "area": {
+        "disambiguation": "",
+        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
+        "iso-3166-1-codes": [
+          "CA"
+        ],
+        "name": "Canada",
+        "sort-name": "Canada",
+        "type": null,
+        "type-id": null
       },
-      "catalog-number": "CD 61113"
+      "date": "1991-08-12"
     }
   ],
-  "date": "1991-08-12"
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "",
+          "id": "65f4f0c5-ef9e-490c-aee3-909e7ae6b2ab",
+          "name": "Metallica",
+          "sort-name": "Metallica",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Metallica"
+      }
+    ],
+    "disambiguation": "\u201cThe Black Album\u201d",
+    "first-release-date": "1991-08-12",
+    "id": "e8f70201-8899-3f0c-9e07-5d6495bc8046",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Metallica"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Metallica"
 }

--- a/scripts/eval_matching/corpus/eval_release_2810aeef.json
+++ b/scripts/eval_matching/corpus/eval_release_2810aeef.json
@@ -1,1888 +1,1888 @@
 {
-  "country": "XE",
-  "date": "2004-11-29",
-  "packaging-id": "8f931351-d2e2-310f-afc6-37b89ddba246",
-  "cover-art-archive": {
-    "darkened": false,
-    "back": true,
-    "artwork": true,
-    "count": 29,
-    "front": true
-  },
-  "release-events": [
-    {
-      "area": {
-        "type-id": null,
-        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
-        "type": null,
-        "name": "Europe",
-        "iso-3166-1-codes": [
-          "XE"
-        ],
-        "sort-name": "Europe",
-        "disambiguation": ""
-      },
-      "date": "2004-11-29"
-    }
-  ],
-  "packaging": "Digipak",
   "artist-credit": [
     {
-      "name": "Jay\u2010Z",
       "artist": {
-        "type": "Person",
-        "name": "JAY\u2010Z",
-        "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
         "country": "US",
+        "disambiguation": "US rapper",
+        "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+        "name": "JAY\u2010Z",
         "sort-name": "JAY\u2010Z",
-        "disambiguation": "US rapper"
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
       },
-      "joinphrase": " / "
+      "joinphrase": " / ",
+      "name": "Jay\u2010Z"
     },
     {
-      "joinphrase": "",
       "artist": {
+        "country": "US",
+        "disambiguation": "American rock band",
         "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
         "name": "Linkin Park",
-        "type": "Group",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "country": "US",
         "sort-name": "Linkin Park",
-        "disambiguation": "American rock band"
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
+      "joinphrase": "",
       "name": "Linkin Park"
     }
   ],
+  "asin": "B00069A6P4",
   "barcode": "093624896227",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "country": "XE",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 29,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2004-11-29",
+  "disambiguation": "",
+  "id": "2810aeef-eaf4-4ea3-a0ee-fd41f8e64285",
+  "label-info": [
+    {
+      "catalog-number": "9362-48962-2",
+      "label": {
+        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
+        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
+        "label-code": 392,
+        "name": "Warner Bros. Records",
+        "sort-name": "Warner Bros. Records",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    }
+  ],
   "media": [
     {
       "data-tracks": [
         {
-          "id": "0f479fc4-ef0e-4799-a4cb-c8a74e7df910",
-          "recording": {
-            "disambiguation": "",
-            "title": "[data track]",
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z"
-                },
-                "joinphrase": " / "
-              },
-              {
-                "artist": {
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US"
-                },
-                "name": "Linkin Park",
-                "joinphrase": ""
-              }
-            ],
-            "length": null,
-            "isrcs": [],
-            "video": false,
-            "id": "564d4588-5242-4095-b95c-dbf757d01a72",
-            "first-release-date": "2004-11-29"
-          },
-          "position": 7,
-          "title": "[data track]",
-          "number": "7",
-          "length": null,
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
               "artist": {
-                "name": "JAY\u2010Z",
-                "type": "Person",
+                "country": "US",
+                "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
+                "name": "JAY\u2010Z",
                 "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " / "
-            },
-            {
-              "joinphrase": "",
-              "name": "Linkin Park",
-              "artist": {
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "type": "Group",
-                "name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ]
-        }
-      ],
-      "id": "946baadc-4bde-32e8-b38e-4c3001f04e54",
-      "track-count": 6,
-      "track-offset": 0,
-      "format": "Enhanced CD",
-      "title": "",
-      "position": 1,
-      "format-id": "8a08dc62-1aa2-34de-a904-fa467c53052c",
-      "tracks": [
-        {
-          "number": "1",
-          "position": 1,
-          "title": "Dirt Off Your Shoulder / Lying From You",
-          "artist-credit": [
-            {
               "joinphrase": " / ",
-              "name": "Jay\u2010Z",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-              }
-            },
-            {
-              "artist": {
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "name": "Linkin Park",
-                "type": "Group"
-              },
-              "name": "Linkin Park",
-              "joinphrase": ""
-            }
-          ],
-          "length": 244693,
-          "recording": {
-            "disambiguation": "explicit",
-            "title": "Dirt Off Your Shoulder / Lying From You",
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
-                }
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type": "Group",
-                  "name": "Linkin Park"
-                },
-                "name": "Linkin Park"
-              }
-            ],
-            "length": 244693,
-            "video": false,
-            "isrcs": [
-              "USWB10403678"
-            ],
-            "id": "3dfe34e4-2768-4179-8b3f-a8e0b3e80006",
-            "first-release-date": "2004-11-15"
-          },
-          "id": "286718cc-5def-47a7-8bd9-cb561bfd5f65"
-        },
-        {
-          "recording": {
-            "disambiguation": "explicit",
-            "title": "Big Pimpin\u2019 / Papercut",
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper"
-                },
-                "joinphrase": " / "
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type": "Group",
-                  "name": "Linkin Park"
-                }
-              }
-            ],
-            "length": 156320,
-            "video": false,
-            "isrcs": [
-              "USWB10403679"
-            ],
-            "id": "648f62a1-8786-45a6-90fb-d9fd5a136bd6",
-            "first-release-date": "2004-11-29"
-          },
-          "id": "a9e2866f-bfe3-4924-b726-bf53219bec08",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z"
-              },
-              "joinphrase": " / "
-            },
-            {
-              "name": "Linkin Park",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "name": "Linkin Park",
-                "type": "Group",
-                "disambiguation": "American rock band",
-                "sort-name": "Linkin Park"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "length": 156320,
-          "number": "2",
-          "title": "Big Pimpin\u2019 / Papercut",
-          "position": 2
-        },
-        {
-          "recording": {
-            "disambiguation": "explicit",
-            "title": "Jigga What / Faint",
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": " / "
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "name": "Linkin Park",
-                  "type": "Group"
-                }
-              }
-            ],
-            "length": 211173,
-            "video": false,
-            "isrcs": [
-              "USWB10403680"
-            ],
-            "id": "5d8d54f1-db6b-4b84-9a8e-4b68122b063e",
-            "first-release-date": "2004-11-29"
-          },
-          "id": "9bf01a68-04e0-4b7b-8ad3-93caa06d628f",
-          "number": "3",
-          "position": 3,
-          "title": "Jigga What / Faint",
-          "artist-credit": [
-            {
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z",
-              "artist": {
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper"
-              }
-            },
-            {
-              "artist": {
-                "type": "Group",
-                "name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band"
-              },
-              "name": "Linkin Park",
-              "joinphrase": ""
-            }
-          ],
-          "length": 211173
-        },
-        {
-          "id": "ed23e1d1-ce41-45ff-b56a-180e09086b32",
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "artist": {
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-                },
-                "name": "Jay\u2010Z"
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band"
-                }
-              }
-            ],
-            "length": 205280,
-            "disambiguation": "explicit",
-            "title": "Numb / Encore",
-            "first-release-date": "2004-11-29",
-            "isrcs": [
-              "USWB10403681",
-              "USWB12400678"
-            ],
-            "video": false,
-            "id": "daccb724-8023-432a-854c-e0accb6c8678"
-          },
-          "position": 4,
-          "title": "Numb / Encore",
-          "number": "4",
-          "length": 205280,
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
-              },
-              "joinphrase": " / "
-            },
-            {
-              "joinphrase": "",
-              "name": "Linkin Park",
-              "artist": {
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "name": "Linkin Park",
-                "type": "Group",
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band"
-              }
-            }
-          ]
-        },
-        {
-          "id": "25663c9c-7c09-4b18-beea-481c9b99929d",
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z"
-                },
-                "name": "Jay\u2010Z"
-              },
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band"
-                },
-                "name": "Linkin Park",
-                "joinphrase": ""
-              }
-            ],
-            "length": 164866,
-            "disambiguation": "explicit",
-            "title": "Izzo / In the End",
-            "first-release-date": "2004-11-29",
-            "video": false,
-            "isrcs": [
-              "USWB10403682"
-            ],
-            "id": "9be2b5c5-717f-4bf5-9f12-4c14a96fde58"
-          },
-          "length": 164866,
-          "artist-credit": [
-            {
-              "joinphrase": " / ",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-              },
               "name": "Jay\u2010Z"
             },
             {
               "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
                 "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                 "name": "Linkin Park",
+                "sort-name": "Linkin Park",
                 "type": "Group",
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "American rock band",
-                "sort-name": "Linkin Park"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Linkin Park",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
-          "title": "Izzo / In the End",
-          "position": 5,
-          "number": "5"
-        },
-        {
+          "id": "0f479fc4-ef0e-4799-a4cb-c8a74e7df910",
+          "length": null,
+          "number": "7",
+          "position": 7,
           "recording": {
-            "length": 295826,
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
+                  "disambiguation": "US rapper",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
                   "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Jay\u2010Z",
-                "joinphrase": " / "
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
               },
               {
-                "joinphrase": "",
-                "name": "Linkin Park",
                 "artist": {
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Linkin Park",
-                  "type": "Group",
+                  "disambiguation": "American rock band",
                   "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
                   "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band"
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
               }
             ],
-            "title": "Points of Authority / 99 Problems / One Step Closer",
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "564d4588-5242-4095-b95c-dbf757d01a72",
+            "isrcs": [],
+            "length": null,
+            "title": "[data track]",
+            "video": false
+          },
+          "title": "[data track]"
+        }
+      ],
+      "format": "Enhanced CD",
+      "format-id": "8a08dc62-1aa2-34de-a904-fa467c53052c",
+      "id": "946baadc-4bde-32e8-b38e-4c3001f04e54",
+      "position": 1,
+      "title": "",
+      "track-count": 6,
+      "track-offset": 0,
+      "tracks": [
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "286718cc-5def-47a7-8bd9-cb561bfd5f65",
+          "length": 244693,
+          "number": "1",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-15",
+            "id": "3dfe34e4-2768-4179-8b3f-a8e0b3e80006",
+            "isrcs": [
+              "USWB10403678"
+            ],
+            "length": 244693,
+            "title": "Dirt Off Your Shoulder / Lying From You",
+            "video": false
+          },
+          "title": "Dirt Off Your Shoulder / Lying From You"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "a9e2866f-bfe3-4924-b726-bf53219bec08",
+          "length": 156320,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-29",
+            "id": "648f62a1-8786-45a6-90fb-d9fd5a136bd6",
+            "isrcs": [
+              "USWB10403679"
+            ],
+            "length": 156320,
+            "title": "Big Pimpin\u2019 / Papercut",
+            "video": false
+          },
+          "title": "Big Pimpin\u2019 / Papercut"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "9bf01a68-04e0-4b7b-8ad3-93caa06d628f",
+          "length": 211173,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-29",
+            "id": "5d8d54f1-db6b-4b84-9a8e-4b68122b063e",
+            "isrcs": [
+              "USWB10403680"
+            ],
+            "length": 211173,
+            "title": "Jigga What / Faint",
+            "video": false
+          },
+          "title": "Jigga What / Faint"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "ed23e1d1-ce41-45ff-b56a-180e09086b32",
+          "length": 205280,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-29",
+            "id": "daccb724-8023-432a-854c-e0accb6c8678",
+            "isrcs": [
+              "USWB10403681",
+              "USWB12400678"
+            ],
+            "length": 205280,
+            "title": "Numb / Encore",
+            "video": false
+          },
+          "title": "Numb / Encore"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "25663c9c-7c09-4b18-beea-481c9b99929d",
+          "length": 164866,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-29",
+            "id": "9be2b5c5-717f-4bf5-9f12-4c14a96fde58",
+            "isrcs": [
+              "USWB10403682"
+            ],
+            "length": 164866,
+            "title": "Izzo / In the End",
+            "video": false
+          },
+          "title": "Izzo / In the End"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "3f94fe03-bdde-482d-b844-8b862b80337d",
+          "length": 295826,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
             "disambiguation": "explicit",
             "first-release-date": "2004-11-15",
             "id": "d6199ea7-fe69-45c7-b455-59bdaa58f257",
             "isrcs": [
               "USWB10403683"
             ],
+            "length": 295826,
+            "title": "Points of Authority / 99 Problems / One Step Closer",
             "video": false
           },
-          "id": "3f94fe03-bdde-482d-b844-8b862b80337d",
-          "number": "6",
-          "position": 6,
-          "title": "Points of Authority / 99 Problems / One Step Closer",
-          "artist-credit": [
-            {
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper"
-              }
-            },
-            {
-              "name": "Linkin Park",
-              "artist": {
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "name": "Linkin Park",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "length": 295826
+          "title": "Points of Authority / 99 Problems / One Step Closer"
         }
       ]
     },
     {
+      "format": "DVD-Video",
       "format-id": "bb71fd58-ff93-32b4-a201-4ad1b2a80e5f",
+      "id": "5859dccf-ef96-371b-bcdd-9bb66a5bedfc",
+      "position": 2,
+      "title": "",
+      "track-count": 17,
+      "track-offset": 0,
       "tracks": [
         {
-          "number": "1",
-          "position": 1,
-          "title": "Intro",
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
               "artist": {
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
-                "name": "JAY\u2010Z",
                 "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " / "
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
             },
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "US",
-                "type": "Group",
-                "name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                 "disambiguation": "American rock band",
-                "sort-name": "Linkin Park"
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Linkin Park"
             }
           ],
+          "id": "9629fcdc-843d-4cff-afad-cd712cf11f5d",
           "length": 33000,
+          "number": "1",
+          "position": 1,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                   "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z"
-                }
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park"
-                }
-              }
-            ],
-            "length": 33000,
-            "disambiguation": "",
-            "title": "Intro",
-            "first-release-date": "2004-11-29",
-            "isrcs": [],
-            "video": true,
-            "id": "9ca8d9d8-9d5a-4852-9733-9f4747632125"
-          },
-          "id": "9629fcdc-843d-4cff-afad-cd712cf11f5d"
-        },
-        {
-          "id": "049f2ec5-1bdb-4d8f-b5a6-a8c0269ad0c5",
-          "recording": {
-            "disambiguation": "",
-            "title": "In the Studio",
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "artist": {
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
                   "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "name": "JAY\u2010Z",
                   "type": "Person",
-                  "country": "US",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " / ",
                 "name": "Jay\u2010Z"
               },
               {
-                "name": "Linkin Park",
                 "artist": {
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band",
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                   "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
                   "type": "Group",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Linkin Park"
               }
             ],
-            "length": 240000,
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "9ca8d9d8-9d5a-4852-9733-9f4747632125",
             "isrcs": [],
-            "video": true,
-            "id": "15dc6429-0d49-498d-908a-6d3d5e2f2eb9",
-            "first-release-date": "2004-11-29"
+            "length": 33000,
+            "title": "Intro",
+            "video": true
           },
-          "title": "In The Studio",
-          "position": 2,
-          "number": "2",
-          "length": 240000,
+          "title": "Intro"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": " / ",
               "artist": {
-                "sort-name": "JAY\u2010Z",
+                "country": "US",
                 "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
                 "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " / ",
               "name": "Jay\u2010Z"
             },
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "US",
+                "disambiguation": "American rock band",
                 "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type": "Group",
                 "name": "Linkin Park",
                 "sort-name": "Linkin Park",
-                "disambiguation": "American rock band"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Linkin Park",
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "number": "3",
-          "title": "Jay\u2010Z Arrives",
-          "position": 3,
-          "artist-credit": [
-            {
-              "artist": {
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper"
-              },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
-            },
-            {
               "joinphrase": "",
-              "artist": {
-                "type": "Group",
-                "name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band"
-              },
               "name": "Linkin Park"
             }
           ],
-          "length": 461000,
+          "id": "049f2ec5-1bdb-4d8f-b5a6-a8c0269ad0c5",
+          "length": 240000,
+          "number": "2",
+          "position": 2,
           "recording": {
-            "isrcs": [],
-            "video": true,
-            "id": "2f0fa361-84d4-442b-8a95-d42c952d30d3",
-            "first-release-date": "2004-11-29",
-            "disambiguation": "",
-            "title": "Jay\u2010Z Arrives",
             "artist-credit": [
               {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
-                },
-                "joinphrase": " / "
-              },
-              {
-                "joinphrase": "",
                 "artist": {
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park"
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
                 "name": "Linkin Park"
               }
             ],
-            "length": 461000
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "15dc6429-0d49-498d-908a-6d3d5e2f2eb9",
+            "isrcs": [],
+            "length": 240000,
+            "title": "In the Studio",
+            "video": true
           },
-          "id": "0ef91683-35e8-49ae-83cd-866220c3a7ae"
+          "title": "In The Studio"
         },
         {
-          "length": 153000,
           "artist-credit": [
             {
-              "joinphrase": " / ",
               "artist": {
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
                 "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
                 "type": "Person",
-                "name": "JAY\u2010Z"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " / ",
               "name": "Jay\u2010Z"
             },
             {
-              "joinphrase": "",
-              "name": "Linkin Park",
               "artist": {
-                "disambiguation": "American rock band",
-                "sort-name": "Linkin Park",
                 "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "disambiguation": "American rock band",
                 "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
                 "type": "Group",
-                "name": "Linkin Park"
-              }
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
-          "title": "Rehearsal",
-          "position": 4,
-          "number": "4",
-          "id": "d439eab4-665a-4116-8049-86882465ce5e",
+          "id": "0ef91683-35e8-49ae-83cd-866220c3a7ae",
+          "length": 461000,
+          "number": "3",
+          "position": 3,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "2f0fa361-84d4-442b-8a95-d42c952d30d3",
+            "isrcs": [],
+            "length": 461000,
+            "title": "Jay\u2010Z Arrives",
+            "video": true
+          },
+          "title": "Jay\u2010Z Arrives"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "d439eab4-665a-4116-8049-86882465ce5e",
+          "length": 153000,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2004-11-29",
             "id": "7f0a32b7-fe93-4a5f-810f-917169e97bd6",
             "isrcs": [],
-            "video": true,
             "length": 153000,
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper"
-                },
-                "joinphrase": " / "
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-                }
-              }
-            ],
             "title": "Rehearsal",
-            "disambiguation": ""
-          }
+            "video": true
+          },
+          "title": "Rehearsal"
         },
         {
-          "title": "Sound Check",
-          "position": 5,
-          "number": "5",
-          "length": 96000,
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
                 "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "name": "JAY\u2010Z",
-                "type": "Person"
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
             },
             {
-              "joinphrase": "",
-              "name": "Linkin Park",
               "artist": {
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "US",
+                "disambiguation": "American rock band",
                 "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                 "name": "Linkin Park",
-                "type": "Group"
-              }
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
           "id": "8a816e51-0ef1-41f8-b654-c68a3fa16772",
+          "length": 96000,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "title": "Sound Check",
-            "disambiguation": "",
-            "length": 96000,
             "artist-credit": [
               {
-                "joinphrase": " / ",
                 "artist": {
+                  "country": "US",
                   "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
                   "sort-name": "JAY\u2010Z",
                   "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "country": "US",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " / ",
                 "name": "Jay\u2010Z"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
                   "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Linkin Park"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
             "id": "3e9911dd-9c7f-40bb-bf50-b7940cbd8216",
             "isrcs": [],
-            "video": true,
-            "first-release-date": "2004-11-29"
-          }
+            "length": 96000,
+            "title": "Sound Check",
+            "video": true
+          },
+          "title": "Sound Check"
         },
         {
-          "id": "3ed15d8d-d538-4a2b-9b26-383af9c39ffc",
-          "recording": {
-            "id": "c4d62c71-0506-4fea-a6be-20161a3a3a45",
-            "isrcs": [],
-            "video": true,
-            "first-release-date": "2004-11-29",
-            "title": "Dirt Off Your Shoulder / Lying From You",
-            "disambiguation": "",
-            "length": 268000,
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "name": "Jay\u2010Z",
-                "joinphrase": " / "
-              },
-              {
-                "artist": {
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band"
-                },
-                "name": "Linkin Park",
-                "joinphrase": ""
-              }
-            ]
-          },
-          "position": 6,
-          "title": "Dirt Off Your Shoulder / Lying From You",
-          "number": "6",
-          "length": 268000,
           "artist-credit": [
             {
-              "joinphrase": " / ",
               "artist": {
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Jay\u2010Z"
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "type": "Group",
-                "name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band"
-              },
-              "name": "Linkin Park"
-            }
-          ]
-        },
-        {
-          "number": "7",
-          "title": "Big Pimpin\u2019 / Papercut",
-          "position": 7,
-          "artist-credit": [
-            {
               "joinphrase": " / ",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person"
-              },
               "name": "Jay\u2010Z"
             },
             {
-              "joinphrase": "",
               "artist": {
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band",
                 "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "disambiguation": "American rock band",
                 "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                 "name": "Linkin Park",
-                "type": "Group"
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Linkin Park"
             }
           ],
-          "length": 156000,
+          "id": "3ed15d8d-d538-4a2b-9b26-383af9c39ffc",
+          "length": 268000,
+          "number": "6",
+          "position": 6,
           "recording": {
-            "disambiguation": "",
-            "title": "Big Pimpin\u2019 / Papercut",
             "artist-credit": [
               {
                 "artist": {
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
-                },
-                "name": "Jay\u2010Z",
-                "joinphrase": " / "
-              },
-              {
-                "name": "Linkin Park",
-                "artist": {
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "US",
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 156000,
-            "isrcs": [],
-            "video": true,
-            "id": "e5403a7c-cf01-42a7-a5e5-71db0eedadf3",
-            "first-release-date": "2004-11-29"
-          },
-          "id": "db253f1b-23bc-44d2-9c1e-f60598b28ec7"
-        },
-        {
-          "number": "8",
-          "title": "Jigga What / Faint",
-          "position": 8,
-          "artist-credit": [
-            {
-              "artist": {
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
-              },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
-            },
-            {
-              "artist": {
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "name": "Linkin Park",
-                "type": "Group",
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band"
-              },
-              "name": "Linkin Park",
-              "joinphrase": ""
-            }
-          ],
-          "length": 248000,
-          "recording": {
-            "length": 248000,
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "artist": {
                   "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
                   "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " / ",
                 "name": "Jay\u2010Z"
               },
               {
-                "name": "Linkin Park",
                 "artist": {
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "US",
+                  "disambiguation": "American rock band",
                   "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                   "name": "Linkin Park",
-                  "type": "Group"
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Linkin Park"
               }
             ],
-            "title": "Jigga What / Faint",
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "c4d62c71-0506-4fea-a6be-20161a3a3a45",
+            "isrcs": [],
+            "length": 268000,
+            "title": "Dirt Off Your Shoulder / Lying From You",
+            "video": true
+          },
+          "title": "Dirt Off Your Shoulder / Lying From You"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "db253f1b-23bc-44d2-9c1e-f60598b28ec7",
+          "length": 156000,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "e5403a7c-cf01-42a7-a5e5-71db0eedadf3",
+            "isrcs": [],
+            "length": 156000,
+            "title": "Big Pimpin\u2019 / Papercut",
+            "video": true
+          },
+          "title": "Big Pimpin\u2019 / Papercut"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "c9a2b410-04f7-4ad5-82fb-9a350101fccd",
+          "length": 248000,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
             "disambiguation": "",
             "first-release-date": "2004-11-29",
             "id": "7cd76b0b-73fd-4e48-a691-41a0c91b3256",
-            "video": true,
-            "isrcs": []
-          },
-          "id": "c9a2b410-04f7-4ad5-82fb-9a350101fccd"
-        },
-        {
-          "id": "92e3de04-6af8-4209-a6b2-d98b28d07756",
-          "recording": {
-            "first-release-date": "2004-11-29",
-            "id": "bc264735-06dd-41a5-b755-924567f2258c",
             "isrcs": [],
-            "video": true,
-            "length": 209000,
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "artist": {
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper"
-                },
-                "name": "Jay\u2010Z"
-              },
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park"
-                },
-                "name": "Linkin Park",
-                "joinphrase": ""
-              }
-            ],
-            "title": "Numb / Encore",
-            "disambiguation": ""
+            "length": 248000,
+            "title": "Jigga What / Faint",
+            "video": true
           },
-          "title": "Numb / Encore",
-          "position": 9,
-          "number": "9",
-          "length": 209000,
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper"
-              },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type": "Group",
-                "name": "Linkin Park"
-              },
-              "name": "Linkin Park"
-            }
-          ]
+          "title": "Jigga What / Faint"
         },
         {
-          "number": "10",
-          "position": 10,
-          "title": "Izzo / In the End",
           "artist-credit": [
             {
-              "joinphrase": " / ",
               "artist": {
                 "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
                 "name": "JAY\u2010Z",
                 "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " / ",
               "name": "Jay\u2010Z"
             },
             {
-              "name": "Linkin Park",
               "artist": {
-                "type": "Group",
-                "name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
                 "sort-name": "Linkin Park",
-                "disambiguation": "American rock band"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
-          "length": 160000,
+          "id": "92e3de04-6af8-4209-a6b2-d98b28d07756",
+          "length": 209000,
+          "number": "9",
+          "position": 9,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "bc264735-06dd-41a5-b755-924567f2258c",
+            "isrcs": [],
+            "length": 209000,
+            "title": "Numb / Encore",
+            "video": true
+          },
+          "title": "Numb / Encore"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "81a2a07a-e413-4c93-8b40-0bb6d3719c8c",
+          "length": 160000,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2004-11-29",
             "id": "917b11f9-2e42-4662-a326-e45329493b74",
             "isrcs": [],
-            "video": true,
             "length": 160000,
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "artist": {
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
-                },
-                "name": "Jay\u2010Z"
-              },
-              {
-                "name": "Linkin Park",
-                "artist": {
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-                },
-                "joinphrase": ""
-              }
-            ],
             "title": "Izzo / In the End",
-            "disambiguation": ""
+            "video": true
           },
-          "id": "81a2a07a-e413-4c93-8b40-0bb6d3719c8c"
+          "title": "Izzo / In the End"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "name": "JAY\u2010Z",
-                "type": "Person"
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
             },
             {
               "artist": {
+                "country": "US",
                 "disambiguation": "American rock band",
-                "sort-name": "Linkin Park",
                 "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                 "name": "Linkin Park",
+                "sort-name": "Linkin Park",
                 "type": "Group",
-                "country": "US",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Linkin Park",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
+          "id": "9168784b-6096-467d-94d7-8704a3f82bcb",
           "length": 467000,
           "number": "11",
           "position": 11,
-          "title": "Points of Authority / 99 Problems / One Step Closer",
           "recording": {
-            "title": "Points of Authority / 99 Problems / One Step Closer",
-            "disambiguation": "",
-            "length": 467000,
             "artist-credit": [
               {
-                "name": "Jay\u2010Z",
                 "artist": {
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
                   "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z"
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "joinphrase": " / "
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
               },
               {
-                "name": "Linkin Park",
                 "artist": {
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "disambiguation": "American rock band",
                   "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type": "Group",
                   "name": "Linkin Park",
                   "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Linkin Park"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
             "id": "db93cea0-25e7-4549-bb35-cbac518cb1fd",
             "isrcs": [],
-            "video": true,
-            "first-release-date": "2004-11-29"
+            "length": 467000,
+            "title": "Points of Authority / 99 Problems / One Step Closer",
+            "video": true
           },
-          "id": "9168784b-6096-467d-94d7-8704a3f82bcb"
+          "title": "Points of Authority / 99 Problems / One Step Closer"
         },
         {
-          "title": "End Credits",
-          "position": 12,
-          "number": "12",
-          "length": 205000,
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z"
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " / "
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
             },
             {
-              "name": "Linkin Park",
               "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
                 "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                 "name": "Linkin Park",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
                 "sort-name": "Linkin Park",
-                "disambiguation": "American rock band"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
           "id": "0f0f608f-fe3b-4614-babd-cf76477ad4f6",
+          "length": 205000,
+          "number": "12",
+          "position": 12,
           "recording": {
-            "title": "End Credits",
-            "disambiguation": "",
-            "length": 205000,
             "artist-credit": [
               {
-                "joinphrase": " / ",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
+                  "disambiguation": "US rapper",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                   "name": "JAY\u2010Z",
-                  "type": "Person",
                   "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " / ",
                 "name": "Jay\u2010Z"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "US",
-                  "type": "Group",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                   "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Linkin Park"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
             "id": "afe909fe-ca37-481c-b8be-8e66992457f0",
             "isrcs": [],
-            "video": true,
-            "first-release-date": "2004-11-29"
-          }
+            "length": 205000,
+            "title": "End Credits",
+            "video": true
+          },
+          "title": "End Credits"
         },
         {
-          "recording": {
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z"
-                },
-                "joinphrase": " / "
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park"
-                }
-              }
-            ],
-            "length": 84000,
-            "disambiguation": "",
-            "title": "It\u2019s Going Down (MTV Ultimate Mash\u2010Ups)",
-            "first-release-date": "2004-11-29",
-            "video": true,
-            "isrcs": [],
-            "id": "b4e7d3fe-fc3b-458a-a3f2-56996df18789"
-          },
-          "id": "312e4d4f-4e21-4b08-96cf-c208864273b2",
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
               "artist": {
+                "country": "US",
                 "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
                 "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " / "
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
             },
             {
-              "name": "Linkin Park",
               "artist": {
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "US",
-                "type": "Group",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                 "name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
+          "id": "312e4d4f-4e21-4b08-96cf-c208864273b2",
           "length": 84000,
           "number": "13",
           "position": 13,
-          "title": "It\u2019s Going Down (MTV Ultimate Mash\u2010Ups)"
-        },
-        {
           "recording": {
-            "first-release-date": "2004-11-29",
-            "isrcs": [],
-            "video": true,
-            "id": "f816d75e-2230-423b-af69-ed6979ff892d",
             "artist-credit": [
               {
-                "joinphrase": " / ",
                 "artist": {
+                  "country": "US",
                   "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
                   "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " / ",
                 "name": "Jay\u2010Z"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park",
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "disambiguation": "American rock band",
                   "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
                   "type": "Group",
-                  "name": "Linkin Park"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Linkin Park"
               }
             ],
-            "length": 288000,
             "disambiguation": "",
-            "title": "Dirt Off Your Shoulder / Lying From You (MTV Ultimate Mash\u2010Ups)"
+            "first-release-date": "2004-11-29",
+            "id": "b4e7d3fe-fc3b-458a-a3f2-56996df18789",
+            "isrcs": [],
+            "length": 84000,
+            "title": "It\u2019s Going Down (MTV Ultimate Mash\u2010Ups)",
+            "video": true
           },
-          "id": "ec70285d-658a-4cb0-8465-9edca8a6c187",
+          "title": "It\u2019s Going Down (MTV Ultimate Mash\u2010Ups)"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "name": "JAY\u2010Z",
-                "type": "Person"
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
             },
             {
-              "joinphrase": "",
-              "name": "Linkin Park",
               "artist": {
-                "disambiguation": "American rock band",
-                "sort-name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type": "Group",
-                "name": "Linkin Park",
                 "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
+          "id": "ec70285d-658a-4cb0-8465-9edca8a6c187",
           "length": 288000,
           "number": "14",
           "position": 14,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "f816d75e-2230-423b-af69-ed6979ff892d",
+            "isrcs": [],
+            "length": 288000,
+            "title": "Dirt Off Your Shoulder / Lying From You (MTV Ultimate Mash\u2010Ups)",
+            "video": true
+          },
           "title": "Dirt Off Your Shoulder / Lying From You (MTV Ultimate Mash\u2010Ups)"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "d72d2940-a743-4c55-b111-b241fcd7401e",
+          "length": 280000,
           "number": "15",
           "position": 15,
-          "title": "Jigga What / Faint (MTV Ultimate Mash\u2010Ups)",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-              },
-              "joinphrase": " / "
-            },
-            {
-              "joinphrase": "",
-              "name": "Linkin Park",
-              "artist": {
-                "disambiguation": "American rock band",
-                "sort-name": "Linkin Park",
-                "name": "Linkin Park",
-                "type": "Group",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "length": 280000,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": " / ",
                 "artist": {
-                  "sort-name": "JAY\u2010Z",
+                  "country": "US",
                   "disambiguation": "US rapper",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-                },
-                "name": "Jay\u2010Z"
-              },
-              {
-                "artist": {
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Linkin Park",
-                "joinphrase": ""
-              }
-            ],
-            "length": 280000,
-            "disambiguation": "",
-            "title": "Jigga What / Faint (MTV Ultimate Mash\u2010Ups)",
-            "first-release-date": "2004-11-29",
-            "isrcs": [],
-            "video": true,
-            "id": "5517e8e9-8fb9-4de1-bd83-f55e1f52ac89"
-          },
-          "id": "d72d2940-a743-4c55-b111-b241fcd7401e"
-        },
-        {
-          "id": "fc20e410-d498-4465-be17-bd7b755add48",
-          "recording": {
-            "first-release-date": "2004-11-29",
-            "video": true,
-            "isrcs": [],
-            "id": "336a0e1d-bd90-4f56-8a3f-dc81f79efc3f",
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "artist": {
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                   "name": "JAY\u2010Z",
-                  "type": "Person"
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " / ",
                 "name": "Jay\u2010Z"
               },
               {
-                "joinphrase": "",
-                "name": "Linkin Park",
                 "artist": {
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                   "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
               }
             ],
-            "length": 229000,
             "disambiguation": "",
-            "title": "Numb / Encore (MTV Ultimate Mash\u2010Ups)"
+            "first-release-date": "2004-11-29",
+            "id": "5517e8e9-8fb9-4de1-bd83-f55e1f52ac89",
+            "isrcs": [],
+            "length": 280000,
+            "title": "Jigga What / Faint (MTV Ultimate Mash\u2010Ups)",
+            "video": true
           },
-          "length": 229000,
-          "artist-credit": [
-            {
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person"
-              }
-            },
-            {
-              "artist": {
-                "disambiguation": "American rock band",
-                "sort-name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "name": "Linkin Park",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US"
-              },
-              "name": "Linkin Park",
-              "joinphrase": ""
-            }
-          ],
-          "position": 16,
-          "title": "Numb / Encore (MTV Ultimate Mash\u2010Ups)",
-          "number": "16"
+          "title": "Jigga What / Faint (MTV Ultimate Mash\u2010Ups)"
         },
         {
-          "position": 17,
-          "title": "Points of Authority / 99 Problems / One Step Closer (MTV Ultimate Mash\u2010Ups)",
-          "number": "17",
-          "length": 414000,
           "artist-credit": [
             {
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
-                "name": "JAY\u2010Z",
                 "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z"
-              }
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
             },
             {
-              "joinphrase": "",
-              "name": "Linkin Park",
               "artist": {
-                "sort-name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "US",
+                "disambiguation": "American rock band",
                 "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
                 "name": "Linkin Park",
-                "type": "Group"
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "fc20e410-d498-4465-be17-bd7b755add48",
+          "length": 229000,
+          "number": "16",
+          "position": 16,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
               }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "336a0e1d-bd90-4f56-8a3f-dc81f79efc3f",
+            "isrcs": [],
+            "length": 229000,
+            "title": "Numb / Encore (MTV Ultimate Mash\u2010Ups)",
+            "video": true
+          },
+          "title": "Numb / Encore (MTV Ultimate Mash\u2010Ups)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
             }
           ],
           "id": "3918bdcd-d2cc-41f4-bc40-4b4148c2f5f0",
+          "length": 414000,
+          "number": "17",
+          "position": 17,
           "recording": {
-            "title": "Points of Authority / 99 Problems / One Step Closer (MTV Ultimate Mash\u2010Ups)",
-            "disambiguation": "",
-            "length": 414000,
             "artist-credit": [
               {
-                "joinphrase": " / ",
                 "artist": {
                   "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
+                  "disambiguation": "US rapper",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
                   "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " / ",
                 "name": "Jay\u2010Z"
               },
               {
                 "artist": {
+                  "country": "US",
                   "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
                   "sort-name": "Linkin Park",
                   "type": "Group",
-                  "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Linkin Park",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Linkin Park"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
             "id": "173498c2-0244-4698-bbb0-644305655095",
             "isrcs": [],
-            "video": true,
-            "first-release-date": "2004-11-29"
-          }
+            "length": 414000,
+            "title": "Points of Authority / 99 Problems / One Step Closer (MTV Ultimate Mash\u2010Ups)",
+            "video": true
+          },
+          "title": "Points of Authority / 99 Problems / One Step Closer (MTV Ultimate Mash\u2010Ups)"
         }
-      ],
-      "track-offset": 0,
-      "position": 2,
-      "title": "",
-      "format": "DVD-Video",
-      "track-count": 17,
-      "id": "5859dccf-ef96-371b-bcdd-9bb66a5bedfc"
+      ]
     }
   ],
+  "packaging": "Digipak",
+  "packaging-id": "8f931351-d2e2-310f-afc6-37b89ddba246",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+        "iso-3166-1-codes": [
+          "XE"
+        ],
+        "name": "Europe",
+        "sort-name": "Europe",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2004-11-29"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "US rapper",
+          "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+          "name": "JAY\u2010Z",
+          "sort-name": "JAY\u2010Z",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": " / ",
+        "name": "Jay\u2010Z"
+      },
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "American rock band",
+          "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+          "name": "Linkin Park",
+          "sort-name": "Linkin Park",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Linkin Park"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2004-11-29",
+    "id": "8ef859e3-feb2-4dd1-93da-22b91280d768",
+    "primary-type": "EP",
+    "primary-type-id": "6d0c5bf6-7a33-3420-a519-44fc63eedebf",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Collision Course"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "text-representation": {
     "language": "eng",
     "script": "Latn"
   },
-  "asin": "B00069A6P4",
-  "title": "MTV Ultimate Mash\u2010Ups Presents: Collision Course",
-  "release-group": {
-    "secondary-type-ids": [],
-    "primary-type-id": "6d0c5bf6-7a33-3420-a519-44fc63eedebf",
-    "artist-credit": [
-      {
-        "joinphrase": " / ",
-        "name": "Jay\u2010Z",
-        "artist": {
-          "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-          "type": "Person",
-          "name": "JAY\u2010Z",
-          "country": "US",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "disambiguation": "US rapper",
-          "sort-name": "JAY\u2010Z"
-        }
-      },
-      {
-        "name": "Linkin Park",
-        "artist": {
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "country": "US",
-          "type": "Group",
-          "name": "Linkin Park",
-          "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-          "disambiguation": "American rock band",
-          "sort-name": "Linkin Park"
-        },
-        "joinphrase": ""
-      }
-    ],
-    "title": "Collision Course",
-    "disambiguation": "",
-    "first-release-date": "2004-11-29",
-    "secondary-types": [],
-    "primary-type": "EP",
-    "id": "8ef859e3-feb2-4dd1-93da-22b91280d768"
-  },
-  "label-info": [
-    {
-      "catalog-number": "9362-48962-2",
-      "label": {
-        "type": "Imprint",
-        "name": "Warner Bros. Records",
-        "label-code": 392,
-        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
-        "sort-name": "Warner Bros. Records"
-      }
-    }
-  ],
-  "id": "2810aeef-eaf4-4ea3-a0ee-fd41f8e64285",
-  "disambiguation": "",
-  "quality": "normal",
-  "status": "Official"
+  "title": "MTV Ultimate Mash\u2010Ups Presents: Collision Course"
 }

--- a/scripts/eval_matching/corpus/eval_release_2c5e4198.json
+++ b/scripts/eval_matching/corpus/eval_release_2c5e4198.json
@@ -1,1576 +1,1331 @@
 {
-  "asin": "B000078JKX",
-  "release-group": {
-    "artist-credit": [
-      {
-        "name": "Jay\u2010Z",
-        "joinphrase": "",
-        "artist": {
-          "country": "US",
-          "type": "Person",
-          "disambiguation": "US rapper",
-          "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-          "sort-name": "JAY\u2010Z",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "name": "JAY\u2010Z"
-        }
-      }
-    ],
-    "secondary-types": [],
-    "secondary-type-ids": [],
-    "primary-type": "Album",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "first-release-date": "2002-11-12",
-    "title": "The Blueprint\u00b2: The Gift & The Curse",
-    "id": "c0cdbbdd-006d-3f4a-90bb-31e259d839e4",
-    "disambiguation": ""
-  },
-  "status": "Official",
   "artist-credit": [
     {
-      "joinphrase": "",
       "artist": {
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "name": "JAY\u2010Z",
-        "type": "Person",
         "country": "US",
-        "sort-name": "JAY\u2010Z",
         "disambiguation": "US rapper",
-        "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
+        "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+        "name": "JAY\u2010Z",
+        "sort-name": "JAY\u2010Z",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
       },
+      "joinphrase": "",
       "name": "Jay\u2010Z"
     }
   ],
+  "asin": "B000078JKX",
+  "barcode": "044006338026",
+  "country": "US",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 4,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2002-11-12",
   "disambiguation": "clean/edited",
   "id": "2c5e4198-24cf-3c95-a16e-83be8e877dfa",
-  "release-events": [
+  "label-info": [
     {
-      "date": "2002-11-12",
-      "area": {
-        "type": null,
+      "catalog-number": "440 063 380-2",
+      "label": {
         "disambiguation": "",
-        "id": "489ce91b-6658-3307-9877-795b68554c98",
-        "iso-3166-1-codes": [
-          "US"
-        ],
-        "sort-name": "United States",
-        "type-id": null,
-        "name": "United States"
+        "id": "4cccc72a-0bd0-433a-905e-dad87871397d",
+        "label-code": null,
+        "name": "Roc\u2010A\u2010Fella Records",
+        "sort-name": "Roc\u2010A\u2010Fella Records",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
-  "title": "The Blueprint\u00b2: The Gift & The Curse",
   "media": [
     {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "43ad3795-a9d6-3daf-8c59-610c30281d58",
       "position": 1,
       "title": "The Gift",
       "track-count": 11,
+      "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
-              "joinphrase": " feat. ",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z",
                 "country": "US",
-                "type": "Person",
                 "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "sort-name": "JAY\u2010Z"
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " feat. ",
               "name": "Jay\u2010Z"
             },
             {
-              "name": "Faith Evans",
               "artist": {
-                "name": "Faith Evans",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "ebcd0bad-75ef-4203-b7b3-7af38a9ef198",
-                "disambiguation": "",
-                "sort-name": "Evans, Faith",
                 "country": "US",
-                "type": "Person"
+                "disambiguation": "",
+                "id": "ebcd0bad-75ef-4203-b7b3-7af38a9ef198",
+                "name": "Faith Evans",
+                "sort-name": "Evans, Faith",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " & "
+              "joinphrase": " & ",
+              "name": "Faith Evans"
             },
             {
-              "joinphrase": "",
               "artist": {
                 "country": "US",
-                "type": "Person",
                 "disambiguation": "",
                 "id": "d5d97b2b-b83b-4976-814a-056d9076c8c3",
+                "name": "The Notorious B.I.G.",
                 "sort-name": "Notorious B.I.G., The",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "The Notorious B.I.G."
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Notorious B.I.G."
             }
           ],
-          "number": "1",
+          "id": "925e6d02-fb7a-3a12-9fba-65b427432527",
           "length": 252093,
+          "number": "1",
           "position": 1,
-          "title": "A Dream",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "country": "US",
                   "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
                   "type": "Person",
-                  "country": "US"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": " feat. ",
                 "name": "Jay\u2010Z"
               },
               {
                 "artist": {
-                  "type": "Person",
                   "country": "US",
-                  "sort-name": "Evans, Faith",
-                  "id": "ebcd0bad-75ef-4203-b7b3-7af38a9ef198",
                   "disambiguation": "",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Faith Evans"
+                  "id": "ebcd0bad-75ef-4203-b7b3-7af38a9ef198",
+                  "name": "Faith Evans",
+                  "sort-name": "Evans, Faith",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": " & ",
                 "name": "Faith Evans"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "The Notorious B.I.G.",
-                  "type": "Person",
                   "country": "US",
-                  "sort-name": "Notorious B.I.G., The",
                   "disambiguation": "",
-                  "id": "d5d97b2b-b83b-4976-814a-056d9076c8c3"
+                  "id": "d5d97b2b-b83b-4976-814a-056d9076c8c3",
+                  "name": "The Notorious B.I.G.",
+                  "sort-name": "Notorious B.I.G., The",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Notorious B.I.G."
               }
             ],
-            "length": 252027,
+            "disambiguation": "clean",
             "first-release-date": "2002-11-12",
-            "video": false,
             "id": "71e2504d-dbe4-45e7-84ce-a2545dec9686",
             "isrcs": [
               "USDJ20201185"
             ],
-            "disambiguation": "clean",
-            "title": "A Dream"
+            "length": 252027,
+            "title": "A Dream",
+            "video": false
           },
-          "id": "925e6d02-fb7a-3a12-9fba-65b427432527"
+          "title": "A Dream"
         },
         {
-          "number": "2",
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
-              "joinphrase": "",
               "artist": {
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
                 "country": "US",
-                "type": "Person",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
             }
           ],
-          "title": "Hovi Baby",
+          "id": "773e1142-cc95-32b3-8c46-a1036656be6e",
+          "length": 261000,
+          "number": "2",
           "position": 2,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "0bace7a1-0d0a-4c5e-95a6-248ffbf10265",
             "isrcs": [
               "USDJ20201182"
             ],
-            "id": "0bace7a1-0d0a-4c5e-95a6-248ffbf10265",
-            "disambiguation": "clean",
-            "title": "Hovi Baby",
-            "first-release-date": "2002-11-12",
-            "video": false,
             "length": 260853,
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "title": "Hovi Baby",
+            "video": false
           },
-          "id": "773e1142-cc95-32b3-8c46-a1036656be6e",
-          "length": 261000
+          "title": "Hovi Baby"
         },
         {
-          "title": "The Watcher 2",
-          "recording": {
-            "title": "The Watcher 2",
-            "id": "5c6f0678-fdc9-4e5c-b342-5986c1df4f97",
-            "isrcs": [
-              "USDJ20201187"
-            ],
-            "disambiguation": "clean",
-            "first-release-date": "2002-11-12",
-            "video": false,
-            "length": 357240,
-            "artist-credit": [
-              {
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "country": "US"
-                },
-                "joinphrase": " feat. ",
-                "name": "Jay\u2010Z"
-              },
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "id": "5f6ab597-f57a-40da-be9e-adad48708203",
-                  "disambiguation": "Andre Young, rap producer",
-                  "sort-name": "Dre, Dr.",
-                  "country": "US",
-                  "type": "Person",
-                  "name": "Dr. Dre",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "name": "Dr. Dre"
-              },
-              {
-                "joinphrase": " & ",
-                "artist": {
-                  "id": "2792b097-0b1d-4c50-97f6-f7f097f86438",
-                  "disambiguation": "William Michael Griffin Jr., American rapper",
-                  "sort-name": "Rakim",
-                  "country": "US",
-                  "type": "Person",
-                  "name": "Rakim",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "name": "Rakim"
-              },
-              {
-                "name": "Truth Hurts",
-                "artist": {
-                  "sort-name": "Truth Hurts",
-                  "disambiguation": "US R&B singer",
-                  "id": "c42d7b98-e57f-4ff2-86f2-bc77b51d3c1e",
-                  "type": "Person",
-                  "country": "US",
-                  "name": "Truth Hurts",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": ""
-              }
-            ]
-          },
-          "position": 3,
-          "id": "324aac4f-710a-39ad-9970-1d4aea04a6f5",
-          "length": 357240,
-          "number": "3",
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
               "artist": {
                 "country": "US",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
                 "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " feat. "
+              "joinphrase": " feat. ",
+              "name": "Jay\u2010Z"
             },
             {
               "artist": {
-                "name": "Dr. Dre",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Dre, Dr.",
-                "id": "5f6ab597-f57a-40da-be9e-adad48708203",
+                "country": "US",
                 "disambiguation": "Andre Young, rap producer",
+                "id": "5f6ab597-f57a-40da-be9e-adad48708203",
+                "name": "Dr. Dre",
+                "sort-name": "Dre, Dr.",
                 "type": "Person",
-                "country": "US"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": ", ",
               "name": "Dr. Dre"
             },
             {
-              "name": "Rakim",
               "artist": {
+                "country": "US",
                 "disambiguation": "William Michael Griffin Jr., American rapper",
                 "id": "2792b097-0b1d-4c50-97f6-f7f097f86438",
-                "sort-name": "Rakim",
-                "country": "US",
-                "type": "Person",
                 "name": "Rakim",
+                "sort-name": "Rakim",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " & "
+              "joinphrase": " & ",
+              "name": "Rakim"
             },
             {
-              "name": "Truth Hurts",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Truth Hurts",
-                "type": "Person",
                 "country": "US",
-                "sort-name": "Truth Hurts",
                 "disambiguation": "US R&B singer",
-                "id": "c42d7b98-e57f-4ff2-86f2-bc77b51d3c1e"
-              },
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "id": "c42d7b98-e57f-4ff2-86f2-bc77b51d3c1e",
+                "name": "Truth Hurts",
+                "sort-name": "Truth Hurts",
                 "type": "Person",
-                "country": "US",
-                "name": "JAY\u2010Z",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " feat. ",
-              "name": "Jay\u2010Z"
-            },
-            {
               "joinphrase": "",
-              "artist": {
-                "country": "US",
-                "type": "Person",
-                "disambiguation": "",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "sort-name": "Beyonc\u00e9",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Beyonc\u00e9"
-              },
-              "name": "Beyonc\u00e9 Knowles"
+              "name": "Truth Hurts"
             }
           ],
-          "number": "4",
-          "length": 205560,
-          "title": "\u201903 Bonnie & Clyde",
-          "position": 4,
+          "id": "324aac4f-710a-39ad-9970-1d4aea04a6f5",
+          "length": 357240,
+          "number": "3",
+          "position": 3,
           "recording": {
-            "video": false,
-            "first-release-date": "2002-11-12",
-            "length": 205520,
-            "title": "\u201903 Bonnie & Clyde",
-            "id": "5d49a6b8-779b-4fbc-96dd-809c26b9c69c",
-            "disambiguation": "clean",
-            "isrcs": [
-              "USDJ20201109"
-            ],
             "artist-credit": [
               {
-                "name": "Jay\u2010Z",
-                "joinphrase": " feat. ",
                 "artist": {
+                  "country": "US",
                   "disambiguation": "US rapper",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person",
                   "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              },
-              {
-                "name": "Beyonc\u00e9 Knowles",
-                "artist": {
-                  "type": "Person",
-                  "country": "US",
-                  "sort-name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "disambiguation": "",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Beyonc\u00e9"
-                },
-                "joinphrase": ""
-              }
-            ]
-          },
-          "id": "23516243-87ad-34de-aa9b-13962b6c623b"
-        },
-        {
-          "title": "Excuse Me Miss",
-          "position": 5,
-          "recording": {
-            "isrcs": [
-              "USDJ20201203"
-            ],
-            "id": "865d7866-8aa1-42d0-b838-fcb2e8198520",
-            "disambiguation": "clean",
-            "title": "Excuse Me Miss",
-            "length": 281000,
-            "video": false,
-            "first-release-date": "2002-11-12",
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z"
-                }
-              }
-            ]
-          },
-          "id": "7bbb2407-479c-33c0-a8e2-1f191aa70a25",
-          "length": 281266,
-          "number": "5",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "country": "US",
-                "type": "Person",
-                "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z"
-              },
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "artist-credit": [
-            {
-              "joinphrase": " feat. ",
-              "artist": {
-                "name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "type": "Person",
-                "country": "US"
-              },
-              "name": "Jay\u2010Z"
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Sean Paul",
-                "country": "JM",
-                "type": "Person",
-                "disambiguation": "Jamaican reggae/dancehall",
-                "id": "c3da3346-2643-48a7-93cd-011f6834b3d7",
-                "sort-name": "Sean Paul"
-              },
-              "name": "Sean Paul"
-            }
-          ],
-          "number": "6",
-          "length": 293973,
-          "id": "814d5392-4798-3e3b-9e20-525f72593153",
-          "recording": {
-            "first-release-date": "2002-11-12",
-            "video": false,
-            "length": 294000,
-            "isrcs": [
-              "USDJ20201205"
-            ],
-            "id": "4c03db1b-6ed1-403a-8267-6eef98829d64",
-            "disambiguation": "clean",
-            "title": "What They Gonna Do",
-            "artist-credit": [
-              {
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "country": "US"
                 },
                 "joinphrase": " feat. ",
                 "name": "Jay\u2010Z"
               },
               {
-                "name": "Sean Paul",
-                "joinphrase": "",
                 "artist": {
-                  "country": "JM",
+                  "country": "US",
+                  "disambiguation": "Andre Young, rap producer",
+                  "id": "5f6ab597-f57a-40da-be9e-adad48708203",
+                  "name": "Dr. Dre",
+                  "sort-name": "Dre, Dr.",
                   "type": "Person",
-                  "disambiguation": "Jamaican reggae/dancehall",
-                  "id": "c3da3346-2643-48a7-93cd-011f6834b3d7",
-                  "sort-name": "Sean Paul",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Sean Paul"
-                }
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Dr. Dre"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "William Michael Griffin Jr., American rapper",
+                  "id": "2792b097-0b1d-4c50-97f6-f7f097f86438",
+                  "name": "Rakim",
+                  "sort-name": "Rakim",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Rakim"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US R&B singer",
+                  "id": "c42d7b98-e57f-4ff2-86f2-bc77b51d3c1e",
+                  "name": "Truth Hurts",
+                  "sort-name": "Truth Hurts",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Truth Hurts"
               }
-            ]
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "5c6f0678-fdc9-4e5c-b342-5986c1df4f97",
+            "isrcs": [
+              "USDJ20201187"
+            ],
+            "length": 357240,
+            "title": "The Watcher 2",
+            "video": false
           },
-          "title": "What They Gonna Do",
-          "position": 6
+          "title": "The Watcher 2"
         },
         {
-          "position": 7,
-          "title": "All Around the World",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " feat. ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9 Knowles"
+            }
+          ],
+          "id": "23516243-87ad-34de-aa9b-13962b6c623b",
+          "length": 205560,
+          "number": "4",
+          "position": 4,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " feat. ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9 Knowles"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "5d49a6b8-779b-4fbc-96dd-809c26b9c69c",
+            "isrcs": [
+              "USDJ20201109"
+            ],
+            "length": 205520,
+            "title": "\u201903 Bonnie & Clyde",
+            "video": false
+          },
+          "title": "\u201903 Bonnie & Clyde"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
+          "id": "7bbb2407-479c-33c0-a8e2-1f191aa70a25",
+          "length": 281266,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "865d7866-8aa1-42d0-b838-fcb2e8198520",
+            "isrcs": [
+              "USDJ20201203"
+            ],
+            "length": 281000,
+            "title": "Excuse Me Miss",
+            "video": false
+          },
+          "title": "Excuse Me Miss"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " feat. ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "JM",
+                "disambiguation": "Jamaican reggae/dancehall",
+                "id": "c3da3346-2643-48a7-93cd-011f6834b3d7",
+                "name": "Sean Paul",
+                "sort-name": "Sean Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Sean Paul"
+            }
+          ],
+          "id": "814d5392-4798-3e3b-9e20-525f72593153",
+          "length": 293973,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " feat. ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "JM",
+                  "disambiguation": "Jamaican reggae/dancehall",
+                  "id": "c3da3346-2643-48a7-93cd-011f6834b3d7",
+                  "name": "Sean Paul",
+                  "sort-name": "Sean Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Sean Paul"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "4c03db1b-6ed1-403a-8267-6eef98829d64",
+            "isrcs": [
+              "USDJ20201205"
+            ],
+            "length": 294000,
+            "title": "What They Gonna Do",
+            "video": false
+          },
+          "title": "What They Gonna Do"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " feat. ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "ea5103ad-44ee-486b-a90e-b052beb5e87b",
+                "name": "LaToiya Williams",
+                "sort-name": "Williams, LaToiya",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "LaToiya Williams"
+            }
+          ],
+          "id": "ae0aca8c-4a70-3ad7-b455-e39279dd6c70",
+          "length": 232666,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " feat. ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "ea5103ad-44ee-486b-a90e-b052beb5e87b",
+                  "name": "LaToiya Williams",
+                  "sort-name": "Williams, LaToiya",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "LaToiya Williams"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
             "id": "fedb0e4d-ee4e-482e-b4c4-afb38ddcaf72",
             "isrcs": [
               "USDJ20201207"
             ],
-            "disambiguation": "clean",
-            "title": "All Around the World",
             "length": 232680,
-            "video": false,
-            "first-release-date": "2002-11-12",
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "joinphrase": " feat. ",
-                "artist": {
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "type": "Person",
-                  "country": "US",
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              },
-              {
-                "name": "LaToiya Williams",
-                "joinphrase": "",
-                "artist": {
-                  "type": "Person",
-                  "country": "US",
-                  "sort-name": "Williams, LaToiya",
-                  "disambiguation": "",
-                  "id": "ea5103ad-44ee-486b-a90e-b052beb5e87b",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "LaToiya Williams"
-                }
-              }
-            ]
+            "title": "All Around the World",
+            "video": false
           },
-          "id": "ae0aca8c-4a70-3ad7-b455-e39279dd6c70",
-          "length": 232666,
-          "number": "7",
+          "title": "All Around the World"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": " feat. ",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z",
                 "country": "US",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z"
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " feat. ",
               "name": "Jay\u2010Z"
             },
             {
-              "name": "LaToiya Williams",
               "artist": {
-                "name": "LaToiya Williams",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Williams, LaToiya",
-                "id": "ea5103ad-44ee-486b-a90e-b052beb5e87b",
+                "country": "US",
                 "disambiguation": "",
-                "type": "Person",
-                "country": "US"
-              },
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "id": "30b7d7b7-2b7b-32d4-86b7-3a5c9c411fcd",
-          "title": "Poppin\u2019 Tags",
-          "position": 8,
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": " feat. ",
-                "artist": {
-                  "country": "US",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z"
-                },
-                "name": "Jay\u2010Z"
-              },
-              {
-                "name": "Big Boi",
-                "artist": {
-                  "sort-name": "Big Boi",
-                  "id": "9724aa19-fdf9-49d0-9f9d-944e462e2a5c",
-                  "disambiguation": "",
-                  "type": "Person",
-                  "country": "US",
-                  "name": "Big Boi",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": ", "
-              },
-              {
-                "artist": {
-                  "type": "Person",
-                  "country": "US",
-                  "sort-name": "Killer Mike",
-                  "id": "47864525-aea7-439a-800f-17c57e51cbcc",
-                  "disambiguation": "",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Killer Mike"
-                },
-                "joinphrase": " & ",
-                "name": "Killer Mike"
-              },
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Twista",
-                  "country": "US",
-                  "type": "Person",
-                  "id": "0bc858a1-3573-4216-9423-c96dd8c72919",
-                  "disambiguation": "US rapper",
-                  "sort-name": "Twista"
-                },
-                "joinphrase": "",
-                "name": "Twista"
-              }
-            ],
-            "length": 360333,
-            "first-release-date": "2002-11-12",
-            "video": false,
-            "title": "Poppin\u2019 Tags",
-            "id": "95866eac-fcf3-46dd-81e2-407b148066ac",
-            "isrcs": [
-              "USDJ20201209"
-            ],
-            "disambiguation": "clean"
-          },
-          "length": 360333,
-          "number": "8",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "type": "Person",
-                "country": "US",
-                "name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": " feat. "
-            },
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Big Boi",
-                "type": "Person",
-                "country": "US",
-                "sort-name": "Big Boi",
                 "id": "9724aa19-fdf9-49d0-9f9d-944e462e2a5c",
-                "disambiguation": ""
+                "name": "Big Boi",
+                "sort-name": "Big Boi",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": ", ",
               "name": "Big Boi"
             },
             {
               "artist": {
-                "id": "47864525-aea7-439a-800f-17c57e51cbcc",
-                "disambiguation": "",
-                "sort-name": "Killer Mike",
                 "country": "US",
-                "type": "Person",
+                "disambiguation": "",
+                "id": "47864525-aea7-439a-800f-17c57e51cbcc",
                 "name": "Killer Mike",
+                "sort-name": "Killer Mike",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": " & ",
               "name": "Killer Mike"
             },
             {
-              "name": "Twista",
-              "joinphrase": "",
               "artist": {
-                "sort-name": "Twista",
+                "country": "US",
                 "disambiguation": "US rapper",
                 "id": "0bc858a1-3573-4216-9423-c96dd8c72919",
-                "type": "Person",
-                "country": "US",
                 "name": "Twista",
+                "sort-name": "Twista",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
+              },
+              "joinphrase": "",
+              "name": "Twista"
             }
-          ]
+          ],
+          "id": "30b7d7b7-2b7b-32d4-86b7-3a5c9c411fcd",
+          "length": 360333,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " feat. ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "9724aa19-fdf9-49d0-9f9d-944e462e2a5c",
+                  "name": "Big Boi",
+                  "sort-name": "Big Boi",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Big Boi"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "47864525-aea7-439a-800f-17c57e51cbcc",
+                  "name": "Killer Mike",
+                  "sort-name": "Killer Mike",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Killer Mike"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "0bc858a1-3573-4216-9423-c96dd8c72919",
+                  "name": "Twista",
+                  "sort-name": "Twista",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Twista"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "95866eac-fcf3-46dd-81e2-407b148066ac",
+            "isrcs": [
+              "USDJ20201209"
+            ],
+            "length": 360333,
+            "title": "Poppin\u2019 Tags",
+            "video": false
+          },
+          "title": "Poppin\u2019 Tags"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
                 "country": "US",
-                "type": "Person",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "",
               "name": "Jay\u2010Z"
             }
           ],
-          "number": "9",
-          "length": 259200,
           "id": "cc4cb29b-d269-3d42-bd86-44350e8fc7db",
+          "length": 259200,
+          "number": "9",
           "position": 9,
-          "title": "F**k All Nite",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
                   "country": "US",
-                  "type": "Person",
                   "disambiguation": "US rapper",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "sort-name": "JAY\u2010Z"
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": "",
                 "name": "Jay\u2010Z"
               }
             ],
-            "title": "F**k All Nite",
             "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
             "id": "98e3df7e-bba2-4fe4-8fa7-c8efb7703987",
             "isrcs": [
               "USDJ20201211"
             ],
             "length": 259027,
-            "first-release-date": "2002-11-12",
+            "title": "F**k All Nite",
             "video": false
-          }
+          },
+          "title": "F**k All Nite"
         },
         {
-          "length": 258533,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
           "id": "c17bf1b3-2b0b-3ddc-a1e4-4dff09f3f4b3",
+          "length": 258533,
+          "number": "10",
           "position": 10,
-          "title": "The Bounce",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
                   "country": "US",
-                  "sort-name": "JAY\u2010Z",
+                  "disambiguation": "US rapper",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper"
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": "",
                 "name": "Jay\u2010Z"
               }
             ],
-            "title": "The Bounce",
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "688f5492-66e2-4ed5-a0f5-7a45c2ebb89a",
             "isrcs": [
               "USDJ20201213"
             ],
-            "id": "688f5492-66e2-4ed5-a0f5-7a45c2ebb89a",
-            "disambiguation": "clean",
             "length": 258717,
-            "video": false,
-            "first-release-date": "2002-11-12"
+            "title": "The Bounce",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "joinphrase": "",
-              "artist": {
-                "name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "country": "US",
-                "type": "Person"
-              }
-            }
-          ],
-          "number": "10"
+          "title": "The Bounce"
         },
         {
-          "length": 222266,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
           "id": "ff0b7481-9c18-34df-af27-3a824cb8aab0",
+          "length": 222266,
+          "number": "11",
+          "position": 11,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
             "id": "76f9d52b-ba0b-42d8-a7e8-0c9c1eb6adcf",
             "isrcs": [
               "USDJ20201215"
             ],
-            "disambiguation": "clean",
-            "title": "I Did It My Way",
             "length": 222853,
-            "first-release-date": "2002-11-12",
-            "video": false,
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "title": "I Did It My Way",
+            "video": false
           },
-          "title": "I Did It My Way",
-          "position": 11,
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "country": "US",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "number": "11"
+          "title": "I Did It My Way"
         }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "track-offset": 0,
-      "format": "CD"
+      ]
     },
     {
-      "track-count": 14,
+      "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "412c27aa-3365-3a72-bf4b-d7312390da8f",
+      "position": 2,
+      "title": "The Curse",
+      "track-count": 14,
+      "track-offset": 0,
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
+          "id": "1dd8baa4-d355-34f9-b8b8-ccd888776f71",
           "length": 235600,
+          "number": "1",
           "position": 1,
-          "title": "Diamond Is Forever",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
             "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
             "id": "5395d51e-ee03-44f3-9c5b-514c19aeaecd",
             "isrcs": [
               "USDJ20201217"
             ],
-            "title": "Diamond Is Forever",
-            "first-release-date": "2002-11-12",
-            "video": false,
             "length": 235600,
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "US rapper",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ]
+            "title": "Diamond Is Forever",
+            "video": false
           },
-          "id": "1dd8baa4-d355-34f9-b8b8-ccd888776f71",
+          "title": "Diamond Is Forever"
+        },
+        {
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
               "artist": {
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "type": "Person",
                 "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
-            }
-          ],
-          "number": "1"
-        },
-        {
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
-                "country": "US"
-              },
-              "joinphrase": " feat. "
-            },
-            {
-              "name": "Lenny Kravitz",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Lenny Kravitz",
-                "type": "Person",
-                "country": "US",
-                "sort-name": "Kravitz, Lenny",
-                "disambiguation": "",
-                "id": "0ef3f425-9bd2-4216-9dd2-219d2fe90f1f"
-              }
-            }
-          ],
-          "number": "2",
-          "length": 265493,
-          "position": 2,
-          "title": "Guns & Roses",
-          "recording": {
-            "video": false,
-            "first-release-date": "2002-11-12",
-            "length": 265493,
-            "title": "Guns & Roses",
-            "isrcs": [
-              "USDJ20201241"
-            ],
-            "id": "d3d66222-8c2e-48f4-83cf-b11bed73d126",
-            "disambiguation": "clean",
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "joinphrase": " feat. ",
-                "artist": {
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "type": "Person",
-                  "country": "US",
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              },
-              {
-                "name": "Lenny Kravitz",
-                "artist": {
-                  "type": "Person",
-                  "country": "US",
-                  "sort-name": "Kravitz, Lenny",
-                  "disambiguation": "",
-                  "id": "0ef3f425-9bd2-4216-9dd2-219d2fe90f1f",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Lenny Kravitz"
-                },
-                "joinphrase": ""
-              }
-            ]
-          },
-          "id": "0051093e-802f-37aa-8e50-284f4b239241"
-        },
-        {
-          "number": "3",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
               "joinphrase": " feat. ",
-              "artist": {
-                "type": "Person",
-                "country": "US",
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z"
-              }
+              "name": "Jay\u2010Z"
             },
             {
-              "name": "M.O.P.",
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "M.O.P.",
                 "country": "US",
-                "type": "Group",
-                "disambiguation": "New York hip hop duo Billy Danze and Lil\u2019 Fame",
-                "id": "dbe35fab-1b3a-469b-87f0-6a54ef8de3c4",
-                "sort-name": "M.O.P."
-              }
+                "disambiguation": "",
+                "id": "0ef3f425-9bd2-4216-9dd2-219d2fe90f1f",
+                "name": "Lenny Kravitz",
+                "sort-name": "Kravitz, Lenny",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Lenny Kravitz"
             }
           ],
-          "title": "U Don\u2019t Know (remix)",
-          "position": 3,
+          "id": "0051093e-802f-37aa-8e50-284f4b239241",
+          "length": 265493,
+          "number": "2",
+          "position": 2,
           "recording": {
-            "title": "U Don\u2019t Know (remix)",
-            "isrcs": [
-              "USDJ20201178"
-            ],
-            "id": "c2e5f363-c446-48b4-843b-85aeea144cc3",
-            "disambiguation": "clean",
-            "video": false,
-            "first-release-date": "2002-11-12",
-            "length": 267240,
             "artist-credit": [
               {
-                "joinphrase": " feat. ",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
                   "country": "US",
-                  "sort-name": "JAY\u2010Z",
                   "disambiguation": "US rapper",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " feat. ",
                 "name": "Jay\u2010Z"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "M.O.P.",
-                  "type": "Group",
                   "country": "US",
-                  "sort-name": "M.O.P.",
-                  "id": "dbe35fab-1b3a-469b-87f0-6a54ef8de3c4",
-                  "disambiguation": "New York hip hop duo Billy Danze and Lil\u2019 Fame"
+                  "disambiguation": "",
+                  "id": "0ef3f425-9bd2-4216-9dd2-219d2fe90f1f",
+                  "name": "Lenny Kravitz",
+                  "sort-name": "Kravitz, Lenny",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "M.O.P."
+                "joinphrase": "",
+                "name": "Lenny Kravitz"
               }
-            ]
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "d3d66222-8c2e-48f4-83cf-b11bed73d126",
+            "isrcs": [
+              "USDJ20201241"
+            ],
+            "length": 265493,
+            "title": "Guns & Roses",
+            "video": false
           },
-          "id": "73768e33-6dd6-373c-9288-513147df6f21",
-          "length": 267240
+          "title": "Guns & Roses"
         },
         {
-          "id": "4456503e-9b12-30d2-8682-0537280a14c9",
-          "position": 4,
-          "recording": {
-            "length": 298867,
-            "first-release-date": "2002-11-12",
-            "video": false,
-            "isrcs": [
-              "USDJ20201240"
-            ],
-            "id": "9a997c31-8d0e-454e-9441-fe587d496c8d",
-            "disambiguation": "clean",
-            "title": "Meet the Parents",
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "country": "US"
-                },
-                "joinphrase": ""
-              }
-            ]
-          },
-          "title": "Meet the Parents",
-          "length": 298826,
-          "number": "4",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "sort-name": "JAY\u2010Z",
+                "country": "US",
                 "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
-                "country": "US",
                 "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Jay\u2010Z"
-            }
-          ]
-        },
-        {
-          "number": "5",
-          "artist-credit": [
-            {
               "joinphrase": " feat. ",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "country": "US",
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper"
-              },
               "name": "Jay\u2010Z"
             },
             {
               "artist": {
-                "name": "Beanie Sigel",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sigel, Beanie",
-                "id": "b544133a-b262-451e-84b6-7bea2e61ce60",
-                "disambiguation": "",
+                "country": "US",
+                "disambiguation": "New York hip hop duo Billy Danze and Lil\u2019 Fame",
+                "id": "dbe35fab-1b3a-469b-87f0-6a54ef8de3c4",
+                "name": "M.O.P.",
+                "sort-name": "M.O.P.",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "M.O.P."
+            }
+          ],
+          "id": "73768e33-6dd6-373c-9288-513147df6f21",
+          "length": 267240,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " feat. ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "New York hip hop duo Billy Danze and Lil\u2019 Fame",
+                  "id": "dbe35fab-1b3a-469b-87f0-6a54ef8de3c4",
+                  "name": "M.O.P.",
+                  "sort-name": "M.O.P.",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "M.O.P."
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "c2e5f363-c446-48b4-843b-85aeea144cc3",
+            "isrcs": [
+              "USDJ20201178"
+            ],
+            "length": 267240,
+            "title": "U Don\u2019t Know (remix)",
+            "video": false
+          },
+          "title": "U Don\u2019t Know (remix)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
                 "type": "Person",
-                "country": "US"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
+          "id": "4456503e-9b12-30d2-8682-0537280a14c9",
+          "length": 298826,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "9a997c31-8d0e-454e-9441-fe587d496c8d",
+            "isrcs": [
+              "USDJ20201240"
+            ],
+            "length": 298867,
+            "title": "Meet the Parents",
+            "video": false
+          },
+          "title": "Meet the Parents"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " feat. ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "b544133a-b262-451e-84b6-7bea2e61ce60",
+                "name": "Beanie Sigel",
+                "sort-name": "Sigel, Beanie",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": " & ",
               "name": "Beanie Sigel"
             },
             {
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Scarface",
                 "country": "US",
-                "type": "Person",
                 "disambiguation": "US rapper Brad Jordan",
                 "id": "7d0b6027-8132-4417-8c4c-ef0bbf9161c0",
-                "sort-name": "Scarface"
+                "name": "Scarface",
+                "sort-name": "Scarface",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "",
               "name": "Scarface"
             }
           ],
+          "id": "bc24ea03-901d-39e9-8b65-ba685dc4d935",
+          "length": 337640,
+          "number": "5",
           "position": 5,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
                   "country": "US",
-                  "sort-name": "JAY\u2010Z",
                   "disambiguation": "US rapper",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": " feat. ",
                 "name": "Jay\u2010Z"
               },
               {
-                "joinphrase": " & ",
                 "artist": {
-                  "name": "Beanie Sigel",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "b544133a-b262-451e-84b6-7bea2e61ce60",
-                  "disambiguation": "",
-                  "sort-name": "Sigel, Beanie",
                   "country": "US",
-                  "type": "Person"
+                  "disambiguation": "",
+                  "id": "b544133a-b262-451e-84b6-7bea2e61ce60",
+                  "name": "Beanie Sigel",
+                  "sort-name": "Sigel, Beanie",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " & ",
                 "name": "Beanie Sigel"
               },
               {
-                "name": "Scarface",
                 "artist": {
-                  "name": "Scarface",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "7d0b6027-8132-4417-8c4c-ef0bbf9161c0",
+                  "country": "US",
                   "disambiguation": "US rapper Brad Jordan",
+                  "id": "7d0b6027-8132-4417-8c4c-ef0bbf9161c0",
+                  "name": "Scarface",
                   "sort-name": "Scarface",
-                  "country": "US",
-                  "type": "Person"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 337600,
-            "first-release-date": "2002-11-12",
-            "video": false,
-            "title": "Some How Some Way",
-            "id": "0307f2a0-5654-4bc0-a201-2ceb092d2f91",
-            "disambiguation": "clean",
-            "isrcs": [
-              "USDJ20201242"
-            ]
-          },
-          "title": "Some How Some Way",
-          "id": "bc24ea03-901d-39e9-8b65-ba685dc4d935",
-          "length": 337640
-        },
-        {
-          "id": "f790dd78-da03-3b7e-a462-d0f5304368aa",
-          "title": "Some People Hate",
-          "position": 6,
-          "recording": {
-            "artist-credit": [
-              {
-                "artist": {
                   "type": "Person",
-                  "country": "US",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": "",
-                "name": "Jay\u2010Z"
+                "name": "Scarface"
               }
             ],
-            "title": "Some People Hate",
-            "id": "9789c144-f0a4-48a8-9c12-4205601b014d",
             "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "0307f2a0-5654-4bc0-a201-2ceb092d2f91",
             "isrcs": [
-              "USDJ20201234"
+              "USDJ20201242"
             ],
-            "length": 271867,
-            "video": false,
-            "first-release-date": "2002-11-12"
+            "length": 337600,
+            "title": "Some How Some Way",
+            "video": false
           },
-          "length": 271866,
-          "number": "6",
+          "title": "Some How Some Way"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
+                "country": "US",
                 "disambiguation": "US rapper",
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "sort-name": "JAY\u2010Z",
-                "country": "US",
-                "type": "Person",
                 "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "",
               "name": "Jay\u2010Z"
             }
-          ]
-        },
-        {
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
-                "country": "US"
-              },
-              "joinphrase": ""
-            }
           ],
-          "number": "7",
-          "length": 289373,
-          "id": "0c3c6415-82e3-3eac-876d-82cee5a7b837",
+          "id": "f790dd78-da03-3b7e-a462-d0f5304368aa",
+          "length": 271866,
+          "number": "6",
+          "position": 6,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
+                  "country": "US",
                   "disambiguation": "US rapper",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
                   "type": "Person",
-                  "country": "US"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": "",
                 "name": "Jay\u2010Z"
               }
             ],
+            "disambiguation": "clean",
             "first-release-date": "2002-11-12",
-            "video": false,
-            "length": 289360,
-            "title": "Blueprint\u00b2",
+            "id": "9789c144-f0a4-48a8-9c12-4205601b014d",
+            "isrcs": [
+              "USDJ20201234"
+            ],
+            "length": 271867,
+            "title": "Some People Hate",
+            "video": false
+          },
+          "title": "Some People Hate"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
+          "id": "0c3c6415-82e3-3eac-876d-82cee5a7b837",
+          "length": 289373,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
             "id": "7718e4e9-bb02-408f-821a-f3adbc2a5b26",
             "isrcs": [
               "USDJ20201232"
             ],
-            "disambiguation": "clean"
+            "length": 289360,
+            "title": "Blueprint\u00b2",
+            "video": false
           },
-          "position": 7,
           "title": "Blueprint\u00b2"
         },
         {
-          "id": "ef7fc5ea-3bf3-30b3-80f9-f8ce4fa96b95",
-          "title": "N***a Please",
-          "recording": {
-            "isrcs": [
-              "USDJ20201230"
-            ],
-            "id": "ef08a74c-a60b-44d3-a0a5-c2670dd80d3e",
-            "disambiguation": "clean",
-            "title": "N***a Please",
-            "length": 278000,
-            "first-release-date": "2002-11-12",
-            "video": false,
-            "artist-credit": [
-              {
-                "joinphrase": " feat. ",
-                "artist": {
-                  "country": "US",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z"
-                },
-                "name": "Jay\u2010Z"
-              },
-              {
-                "name": "Young Chris",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Young Chris",
-                  "id": "b9692402-8b5e-4d30-807f-1fda7db397b3",
-                  "disambiguation": "US rapper Chris Ries",
-                  "type": "Person",
-                  "country": "US",
-                  "name": "Young Chris",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ]
-          },
-          "position": 8,
-          "length": 277986,
-          "number": "8",
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z",
-                "type": "Person",
                 "country": "US",
-                "sort-name": "JAY\u2010Z",
                 "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-              },
-              "joinphrase": " feat. "
-            },
-            {
-              "name": "Young Chris",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Young Chris",
-                "country": "US",
-                "type": "Person",
-                "id": "b9692402-8b5e-4d30-807f-1fda7db397b3",
-                "disambiguation": "US rapper Chris Ries",
-                "sort-name": "Young Chris"
-              },
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "recording": {
-            "id": "c5b0bb16-0907-4d60-bfc7-c9c58769895d",
-            "isrcs": [
-              "USDJ20201221"
-            ],
-            "disambiguation": "clean",
-            "title": "2 Many Hoes",
-            "length": 214373,
-            "video": false,
-            "first-release-date": "2002-11-12",
-            "artist-credit": [
-              {
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person"
-                },
-                "joinphrase": "",
-                "name": "Jay\u2010Z"
-              }
-            ]
-          },
-          "title": "2 Many Hoes",
-          "position": 9,
-          "id": "01221efa-eab1-3405-9a9b-ae773d9429d5",
-          "length": 214373,
-          "number": "9",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "joinphrase": "",
-              "artist": {
                 "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "country": "US",
-                "type": "Person",
                 "name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
-            }
-          ]
-        },
-        {
-          "id": "1ea47394-0a26-3fc3-a8d1-575da5a488fe",
-          "title": "As One",
-          "position": 10,
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": " feat. ",
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "US rapper",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person"
-                },
-                "name": "Jay\u2010Z"
-              },
-              {
-                "name": "Memphis Bleek",
-                "artist": {
-                  "sort-name": "Bleek, Memphis",
-                  "id": "48db8d53-98c7-4ec8-8d49-00a89ebad8d4",
-                  "disambiguation": "",
-                  "type": "Person",
-                  "country": "US",
-                  "name": "Memphis Bleek",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": ", "
-              },
-              {
-                "artist": {
-                  "disambiguation": "US rapper Leslie Pridgen",
-                  "id": "5d008bf9-2958-4640-a5de-dcdcebe711a4",
-                  "sort-name": "Freeway",
-                  "country": "US",
-                  "type": "Person",
-                  "name": "Freeway",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": ", ",
-                "name": "Freeway"
-              },
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "sort-name": "Young Gunz",
-                  "id": "41762041-1e55-48c8-8f77-45e342e52ba9",
-                  "disambiguation": "US rap duo",
-                  "type": "Group",
-                  "country": "US",
-                  "name": "Young Gunz",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Young Gunz"
-              },
-              {
-                "name": "Peedi Crakk",
-                "joinphrase": ", ",
-                "artist": {
-                  "sort-name": "Peedi Crakk",
-                  "disambiguation": "a.k.a. Peedi Peedi",
-                  "id": "412e1375-4ff4-4026-9be1-d9307a7dfa0e",
-                  "type": "Person",
-                  "country": "US",
-                  "name": "Peedi Crakk",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              },
-              {
-                "name": "Sparks",
-                "artist": {
-                  "country": "US",
-                  "type": "Person",
-                  "disambiguation": "US rapper Kenneth Johnson, previously \"Sparks\"",
-                  "id": "d93f0584-b950-4a24-b45a-129d410fc417",
-                  "sort-name": "Omillio Sparks",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Omillio Sparks"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Rell",
-                  "disambiguation": "US R&B singer on Roc-a-Fella",
-                  "id": "e99e2d8a-4516-4b22-ab93-65ded3b58297",
-                  "type": "Person",
-                  "country": "US",
-                  "name": "Rell",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "name": "Rell"
-              }
-            ],
-            "title": "As One",
-            "id": "c843d501-139f-45c8-83f6-2040856f5900",
-            "disambiguation": "clean",
-            "isrcs": [
-              "USDJ20201226"
-            ],
-            "first-release-date": "2002-11-12",
-            "video": false,
-            "length": 227400
-          },
-          "length": 228800,
-          "number": "10",
-          "artist-credit": [
-            {
-              "artist": {
                 "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
                 "type": "Person",
-                "country": "US",
-                "name": "JAY\u2010Z",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": " feat. ",
@@ -1578,314 +1333,559 @@
             },
             {
               "artist": {
-                "id": "48db8d53-98c7-4ec8-8d49-00a89ebad8d4",
-                "disambiguation": "",
-                "sort-name": "Bleek, Memphis",
                 "country": "US",
+                "disambiguation": "US rapper Chris Ries",
+                "id": "b9692402-8b5e-4d30-807f-1fda7db397b3",
+                "name": "Young Chris",
+                "sort-name": "Young Chris",
                 "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Young Chris"
+            }
+          ],
+          "id": "ef7fc5ea-3bf3-30b3-80f9-f8ce4fa96b95",
+          "length": 277986,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " feat. ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper Chris Ries",
+                  "id": "b9692402-8b5e-4d30-807f-1fda7db397b3",
+                  "name": "Young Chris",
+                  "sort-name": "Young Chris",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Young Chris"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "ef08a74c-a60b-44d3-a0a5-c2670dd80d3e",
+            "isrcs": [
+              "USDJ20201230"
+            ],
+            "length": 278000,
+            "title": "N***a Please",
+            "video": false
+          },
+          "title": "N***a Please"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
+          "id": "01221efa-eab1-3405-9a9b-ae773d9429d5",
+          "length": 214373,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "c5b0bb16-0907-4d60-bfc7-c9c58769895d",
+            "isrcs": [
+              "USDJ20201221"
+            ],
+            "length": 214373,
+            "title": "2 Many Hoes",
+            "video": false
+          },
+          "title": "2 Many Hoes"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " feat. ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "48db8d53-98c7-4ec8-8d49-00a89ebad8d4",
                 "name": "Memphis Bleek",
+                "sort-name": "Bleek, Memphis",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": ", ",
               "name": "Memphis Bleek"
             },
             {
-              "name": "Freeway",
-              "joinphrase": ", ",
               "artist": {
-                "name": "Freeway",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Freeway",
+                "country": "US",
                 "disambiguation": "US rapper Leslie Pridgen",
                 "id": "5d008bf9-2958-4640-a5de-dcdcebe711a4",
+                "name": "Freeway",
+                "sort-name": "Freeway",
                 "type": "Person",
-                "country": "US"
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Freeway"
             },
             {
-              "name": "Young Gunz",
               "artist": {
-                "sort-name": "Young Gunz",
+                "country": "US",
                 "disambiguation": "US rap duo",
                 "id": "41762041-1e55-48c8-8f77-45e342e52ba9",
-                "type": "Group",
-                "country": "US",
                 "name": "Young Gunz",
+                "sort-name": "Young Gunz",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ", "
+              "joinphrase": ", ",
+              "name": "Young Gunz"
             },
             {
-              "joinphrase": ", ",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Peedi Crakk",
-                "type": "Person",
                 "country": "US",
-                "sort-name": "Peedi Crakk",
                 "disambiguation": "a.k.a. Peedi Peedi",
-                "id": "412e1375-4ff4-4026-9be1-d9307a7dfa0e"
+                "id": "412e1375-4ff4-4026-9be1-d9307a7dfa0e",
+                "name": "Peedi Crakk",
+                "sort-name": "Peedi Crakk",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": ", ",
               "name": "Peedi Crakk"
             },
             {
-              "name": "Sparks",
               "artist": {
-                "name": "Omillio Sparks",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Omillio Sparks",
-                "id": "d93f0584-b950-4a24-b45a-129d410fc417",
+                "country": "US",
                 "disambiguation": "US rapper Kenneth Johnson, previously \"Sparks\"",
+                "id": "d93f0584-b950-4a24-b45a-129d410fc417",
+                "name": "Omillio Sparks",
+                "sort-name": "Omillio Sparks",
                 "type": "Person",
-                "country": "US"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " & "
+              "joinphrase": " & ",
+              "name": "Sparks"
             },
             {
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Rell",
-                "type": "Person",
                 "country": "US",
-                "sort-name": "Rell",
                 "disambiguation": "US R&B singer on Roc-a-Fella",
-                "id": "e99e2d8a-4516-4b22-ab93-65ded3b58297"
+                "id": "e99e2d8a-4516-4b22-ab93-65ded3b58297",
+                "name": "Rell",
+                "sort-name": "Rell",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "",
               "name": "Rell"
             }
-          ]
+          ],
+          "id": "1ea47394-0a26-3fc3-a8d1-575da5a488fe",
+          "length": 228800,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " feat. ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "48db8d53-98c7-4ec8-8d49-00a89ebad8d4",
+                  "name": "Memphis Bleek",
+                  "sort-name": "Bleek, Memphis",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Memphis Bleek"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper Leslie Pridgen",
+                  "id": "5d008bf9-2958-4640-a5de-dcdcebe711a4",
+                  "name": "Freeway",
+                  "sort-name": "Freeway",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Freeway"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rap duo",
+                  "id": "41762041-1e55-48c8-8f77-45e342e52ba9",
+                  "name": "Young Gunz",
+                  "sort-name": "Young Gunz",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": ", ",
+                "name": "Young Gunz"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "a.k.a. Peedi Peedi",
+                  "id": "412e1375-4ff4-4026-9be1-d9307a7dfa0e",
+                  "name": "Peedi Crakk",
+                  "sort-name": "Peedi Crakk",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Peedi Crakk"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper Kenneth Johnson, previously \"Sparks\"",
+                  "id": "d93f0584-b950-4a24-b45a-129d410fc417",
+                  "name": "Omillio Sparks",
+                  "sort-name": "Omillio Sparks",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Sparks"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US R&B singer on Roc-a-Fella",
+                  "id": "e99e2d8a-4516-4b22-ab93-65ded3b58297",
+                  "name": "Rell",
+                  "sort-name": "Rell",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Rell"
+              }
+            ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "c843d501-139f-45c8-83f6-2040856f5900",
+            "isrcs": [
+              "USDJ20201226"
+            ],
+            "length": 227400,
+            "title": "As One",
+            "video": false
+          },
+          "title": "As One"
         },
         {
-          "title": "A Ballad for the Fallen Soldier",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
+          "id": "82ad6eb9-d47c-35b2-813d-725fcad0f4ea",
+          "length": 281991,
+          "number": "11",
           "position": 11,
           "recording": {
             "artist-credit": [
               {
-                "name": "Jay\u2010Z",
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
                   "country": "US",
-                  "sort-name": "JAY\u2010Z",
+                  "disambiguation": "US rapper",
                   "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper"
-                }
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
               }
             ],
+            "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
+            "id": "0226adf7-1181-45ef-a307-9d83a261d5f6",
             "isrcs": [
               "USDJ20201224"
             ],
-            "id": "0226adf7-1181-45ef-a307-9d83a261d5f6",
-            "disambiguation": "clean",
-            "title": "A Ballad for the Fallen Soldier",
             "length": 282000,
-            "video": false,
-            "first-release-date": "2002-11-12"
+            "title": "A Ballad for the Fallen Soldier",
+            "video": false
           },
-          "id": "82ad6eb9-d47c-35b2-813d-725fcad0f4ea",
-          "length": 281991,
-          "number": "11",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "joinphrase": "",
-              "artist": {
-                "country": "US",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z"
-              }
-            }
-          ]
+          "title": "A Ballad for the Fallen Soldier"
         },
         {
-          "length": 178702,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
+            }
+          ],
           "id": "3cbd6220-d7c6-3332-bcfe-274037e31494",
-          "title": "Show You How",
+          "length": 178702,
+          "number": "12",
           "position": 12,
           "recording": {
             "artist-credit": [
               {
-                "name": "Jay\u2010Z",
                 "artist": {
-                  "type": "Person",
                   "country": "US",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                   "disambiguation": "US rapper",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "JAY\u2010Z"
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
               }
             ],
+            "disambiguation": "clean",
             "first-release-date": "2002-11-12",
-            "video": false,
-            "length": 176427,
+            "id": "a7f368f6-ed1b-4c0c-b3c7-9f2006810b8d",
             "isrcs": [
               "USDJ20201243"
             ],
-            "id": "a7f368f6-ed1b-4c0c-b3c7-9f2006810b8d",
-            "disambiguation": "clean",
-            "title": "Show You How"
+            "length": 176427,
+            "title": "Show You How",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "type": "Person",
-                "country": "US",
-                "name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "number": "12"
+          "title": "Show You How"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z",
                 "country": "US",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z"
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Jay\u2010Z"
             }
           ],
-          "number": "13",
+          "id": "78df5ec3-3958-3057-855b-ed3818827543",
           "length": 158840,
+          "number": "13",
           "position": 13,
-          "title": "B*****s & Sisters",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
             "disambiguation": "clean",
+            "first-release-date": "2002-11-12",
             "id": "1975dad9-3919-4ddf-b750-9ba8cdd06583",
             "isrcs": [
               "USDJ20201228"
             ],
-            "title": "B*****s & Sisters",
-            "video": false,
-            "first-release-date": "2002-11-12",
             "length": 157533,
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "joinphrase": "",
-                "artist": {
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person"
-                }
-              }
-            ]
+            "title": "B*****s & Sisters",
+            "video": false
           },
-          "id": "78df5ec3-3958-3057-855b-ed3818827543"
+          "title": "B*****s & Sisters"
         },
         {
           "artist-credit": [
             {
-              "name": "Jay\u2010Z",
-              "joinphrase": "",
               "artist": {
-                "type": "Person",
                 "country": "US",
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
                 "disambiguation": "US rapper",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "JAY\u2010Z"
-              }
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Jay\u2010Z"
             }
           ],
-          "number": "14",
+          "id": "f55dca32-083d-39ce-822d-11806c0540ce",
           "length": 226995,
-          "title": "What They Gonna Do, Part II",
+          "number": "14",
           "position": 14,
           "recording": {
-            "length": 227000,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Jay\u2010Z"
+              }
+            ],
+            "disambiguation": "clean",
             "first-release-date": "2002-11-12",
-            "video": false,
+            "id": "ecb38083-5776-45de-9fa5-8136bdbade99",
             "isrcs": [
               "USDJ20201244"
             ],
-            "id": "ecb38083-5776-45de-9fa5-8136bdbade99",
-            "disambiguation": "clean",
+            "length": 227000,
             "title": "What They Gonna Do, Part II",
-            "artist-credit": [
-              {
-                "name": "Jay\u2010Z",
-                "joinphrase": "",
-                "artist": {
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ]
+            "video": false
           },
-          "id": "f55dca32-083d-39ce-822d-11806c0540ce"
+          "title": "What They Gonna Do, Part II"
         }
-      ],
-      "track-offset": 0,
-      "format": "CD",
-      "id": "412c27aa-3365-3a72-bf4b-d7312390da8f",
-      "title": "The Curse",
-      "position": 2
+      ]
     }
   ],
-  "label-info": [
-    {
-      "catalog-number": "440 063 380-2",
-      "label": {
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "label-code": null,
-        "name": "Roc\u2010A\u2010Fella Records",
-        "type": "Original Production",
-        "sort-name": "Roc\u2010A\u2010Fella Records",
-        "disambiguation": "",
-        "id": "4cccc72a-0bd0-433a-905e-dad87871397d"
-      }
-    }
-  ],
-  "date": "2002-11-12",
+  "packaging": null,
   "packaging-id": null,
-  "cover-art-archive": {
-    "artwork": true,
-    "count": 4,
-    "back": true,
-    "darkened": false,
-    "front": true
-  },
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "country": "US",
   "quality": "high",
-  "barcode": "044006338026",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
+        "iso-3166-1-codes": [
+          "US"
+        ],
+        "name": "United States",
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2002-11-12"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "US rapper",
+          "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+          "name": "JAY\u2010Z",
+          "sort-name": "JAY\u2010Z",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "",
+        "name": "Jay\u2010Z"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2002-11-12",
+    "id": "c0cdbbdd-006d-3f4a-90bb-31e259d839e4",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "The Blueprint\u00b2: The Gift & The Curse"
   },
-  "packaging": null
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "The Blueprint\u00b2: The Gift & The Curse"
 }

--- a/scripts/eval_matching/corpus/eval_release_3a8a6113.json
+++ b/scripts/eval_matching/corpus/eval_release_3a8a6113.json
@@ -1,597 +1,597 @@
 {
-  "date": "1994-05-10",
-  "barcode": "720642462928",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "artist-credit": [
     {
       "artist": {
-        "type": "Group",
-        "name": "Weezer",
         "country": "US",
         "disambiguation": "American rock band",
         "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+        "name": "Weezer",
         "sort-name": "Weezer",
+        "type": "Group",
         "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
-      "name": "Weezer",
-      "joinphrase": ""
+      "joinphrase": "",
+      "name": "Weezer"
     }
   ],
+  "asin": null,
+  "barcode": "720642462928",
+  "country": "US",
+  "cover-art-archive": {
+    "artwork": false,
+    "back": false,
+    "count": 0,
+    "darkened": false,
+    "front": false
+  },
+  "date": "1994-05-10",
+  "disambiguation": "blue album, JVC Pressing",
   "id": "3a8a6113-03dc-46a2-aa94-2b25e553fb64",
-  "quality": "normal",
+  "label-info": [
+    {
+      "catalog-number": "DGCD-24629",
+      "label": {
+        "disambiguation": "",
+        "id": "68803e28-86fe-4a95-985f-8e493795ab31",
+        "label-code": 6406,
+        "name": "DGC Records",
+        "sort-name": "DGC Records",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
+      }
+    }
+  ],
   "media": [
     {
+      "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "2714ee37-5c8f-3500-b2be-6880553650ab",
+      "position": 1,
+      "title": "",
+      "track-count": 10,
+      "track-offset": 0,
       "tracks": [
         {
-          "recording": {
-            "disambiguation": "",
-            "video": false,
-            "artist-credit": [
-              {
-                "artist": {
-                  "country": "US",
-                  "disambiguation": "American rock band",
-                  "type": "Group",
-                  "name": "Weezer",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Weezer"
-                },
-                "name": "Weezer",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1994-05-10",
-            "id": "392cea06-94c2-416b-80aa-f5b1e7d0fb1c",
-            "title": "My Name Is Jonas",
-            "isrcs": [
-              "USGF19562904",
-              "USGF19962901"
-            ],
-            "length": 204466
-          },
-          "number": "1",
-          "length": 205000,
-          "position": 1,
-          "artist-credit": [
-            {
-              "name": "Weezer",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Weezer",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Weezer",
-                "type": "Group",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
-              }
-            }
-          ],
-          "id": "1ceb1965-4183-44fa-bbb0-cdc728e918a4",
-          "title": "My Name Is Jonas"
-        },
-        {
-          "id": "6e88f4fa-c2e9-462b-9519-b5f7dff3c925",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Weezer",
-                "disambiguation": "American rock band",
                 "country": "US",
-                "type": "Group",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                 "name": "Weezer",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Weezer"
             }
           ],
-          "title": "No One Else",
+          "id": "1ceb1965-4183-44fa-bbb0-cdc728e918a4",
+          "length": 205000,
+          "number": "1",
+          "position": 1,
           "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "No One Else",
             "artist-credit": [
               {
                 "artist": {
                   "country": "US",
                   "disambiguation": "American rock band",
-                  "type": "Group",
-                  "name": "Weezer",
                   "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
                   "sort-name": "Weezer",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Weezer"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "392cea06-94c2-416b-80aa-f5b1e7d0fb1c",
+            "isrcs": [
+              "USGF19562904",
+              "USGF19962901"
+            ],
+            "length": 204466,
+            "title": "My Name Is Jonas",
+            "video": false
+          },
+          "title": "My Name Is Jonas"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "6e88f4fa-c2e9-462b-9519-b5f7dff3c925",
+          "length": 185000,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1994-05-10",
             "id": "271a81af-6c2d-44cf-a0b8-a25ad74c82f9",
             "isrcs": [
               "USGF19562905",
               "USGF19962902"
             ],
-            "length": 184666
+            "length": 184666,
+            "title": "No One Else",
+            "video": false
           },
-          "length": 185000,
-          "number": "2",
-          "position": 2
+          "title": "No One Else"
         },
         {
-          "title": "The World Has Turned and Left Me Here",
-          "id": "3d4a52ed-2fb2-46df-a1a4-dad2e44c05cf",
           "artist-credit": [
             {
               "artist": {
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                 "country": "US",
                 "disambiguation": "American rock band",
-                "type": "Group",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                 "name": "Weezer",
                 "sort-name": "Weezer",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "name": "Weezer",
-              "joinphrase": ""
-            }
-          ],
-          "recording": {
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "type": "Group",
-                  "name": "Weezer",
-                  "disambiguation": "American rock band",
-                  "country": "US"
-                },
-                "joinphrase": "",
-                "name": "Weezer"
-              }
-            ],
-            "first-release-date": "1994-05-10",
-            "id": "5d7e41b2-ec4b-44dd-b25a-a576d7a08adb",
-            "title": "The World Has Turned and Left Me Here",
-            "disambiguation": "",
-            "video": false,
-            "isrcs": [
-              "USGF19562906",
-              "USGF19962903"
-            ],
-            "length": 259266
-          },
-          "position": 3,
-          "length": 259266,
-          "number": "3"
-        },
-        {
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Weezer",
-                "name": "Weezer",
-                "type": "Group",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
-              },
-              "name": "Weezer",
-              "joinphrase": ""
-            }
-          ],
-          "id": "6a7eeae8-7550-4580-852f-58ad0cc564b3",
-          "title": "Buddy Holly",
-          "recording": {
-            "length": 160000,
-            "isrcs": [
-              "USGF19562907"
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "d615590b-1546-441d-9703-b3cf88487cbd",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Weezer",
-                "artist": {
-                  "sort-name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "name": "Weezer",
-                  "type": "Group",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
-                }
-              }
-            ],
-            "first-release-date": "1994-05-10",
-            "title": "Buddy Holly"
-          },
-          "number": "4",
-          "length": 159400,
-          "position": 4
-        },
-        {
-          "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "Undone \u2013 The Sweater Song",
-            "id": "48908d8b-3a40-46fa-bfee-3a88012c2689",
-            "first-release-date": "1994-05-10",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Weezer",
-                "artist": {
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "type": "Group",
-                  "name": "Weezer",
-                  "sort-name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "length": 305400,
-            "isrcs": [
-              "USGF19562908",
-              "USGF19962905"
-            ]
-          },
-          "length": 306000,
-          "number": "5",
-          "position": 5,
-          "id": "5a0e14c9-cce6-43eb-aa48-4ad79fd10121",
-          "artist-credit": [
-            {
-              "artist": {
-                "country": "US",
-                "disambiguation": "American rock band",
-                "type": "Group",
-                "name": "Weezer",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Weezer"
-              },
-              "name": "Weezer",
-              "joinphrase": ""
-            }
-          ],
-          "title": "Undone \u2013 The Sweater Song"
-        },
-        {
-          "title": "Surf Wax America",
-          "id": "dcdfdafa-3e5e-4fcf-8dc8-feae7cfdd704",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Weezer",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "country": "US",
-                "disambiguation": "American rock band",
-                "type": "Group",
-                "name": "Weezer"
               },
               "joinphrase": "",
               "name": "Weezer"
             }
           ],
-          "position": 6,
-          "length": 187000,
-          "number": "6",
+          "id": "3d4a52ed-2fb2-46df-a1a4-dad2e44c05cf",
+          "length": 259266,
+          "number": "3",
+          "position": 3,
           "recording": {
-            "disambiguation": "",
-            "video": false,
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Weezer",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Weezer",
-                  "disambiguation": "American rock band",
                   "country": "US",
-                  "type": "Group",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                   "name": "Weezer",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
-                }
-              }
-            ],
-            "first-release-date": "1994-05-10",
-            "id": "d8f04ba0-8f7e-4016-b818-5f07514d11e8",
-            "title": "Surf Wax America",
-            "isrcs": [
-              "USGF19562909"
-            ],
-            "length": 186506
-          }
-        },
-        {
-          "recording": {
-            "title": "Say It Ain\u2019t So",
-            "id": "e7ada1d0-0604-4ff2-9361-939ebf5b53af",
-            "first-release-date": "1994-05-10",
-            "artist-credit": [
-              {
-                "name": "Weezer",
-                "joinphrase": "",
-                "artist": {
                   "sort-name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                   "type": "Group",
-                  "name": "Weezer",
-                  "disambiguation": "American rock band",
-                  "country": "US"
-                }
-              }
-            ],
-            "video": false,
-            "disambiguation": "album version",
-            "length": 258800,
-            "isrcs": [
-              "USGF19562901",
-              "USGF19962907",
-              "USIR10400084"
-            ]
-          },
-          "position": 7,
-          "number": "7",
-          "length": 258800,
-          "title": "Say It Ain\u2019t So",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Weezer",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "type": "Group",
-                "name": "Weezer",
-                "disambiguation": "American rock band",
-                "country": "US"
-              },
-              "name": "Weezer",
-              "joinphrase": ""
-            }
-          ],
-          "id": "ad03b128-10c3-47cb-93e1-f4cbd4fe7eec"
-        },
-        {
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Weezer",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "type": "Group",
-                "name": "Weezer"
-              },
-              "name": "Weezer",
-              "joinphrase": ""
-            }
-          ],
-          "id": "f2b3dc6f-b944-4373-95e7-65389a7a32d5",
-          "title": "In the Garage",
-          "recording": {
-            "isrcs": [
-              "USGF19562911",
-              "USGF19962908"
-            ],
-            "length": 235760,
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "name": "Weezer",
-                  "type": "Group",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Weezer"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Weezer"
               }
             ],
-            "first-release-date": "1994-05-10",
-            "id": "3761f313-1239-46e9-b720-9d24b06da5ab",
-            "title": "In the Garage",
             "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "5d7e41b2-ec4b-44dd-b25a-a576d7a08adb",
+            "isrcs": [
+              "USGF19562906",
+              "USGF19962903"
+            ],
+            "length": 259266,
+            "title": "The World Has Turned and Left Me Here",
             "video": false
           },
-          "number": "8",
-          "length": 235760,
-          "position": 8
+          "title": "The World Has Turned and Left Me Here"
         },
         {
-          "id": "7829ae5f-a199-431c-8d22-48bf91d9fb84",
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "American rock band",
                 "country": "US",
-                "type": "Group",
-                "name": "Weezer",
+                "disambiguation": "American rock band",
                 "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
                 "sort-name": "Weezer",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Weezer",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Weezer"
             }
           ],
-          "title": "Holiday",
+          "id": "6a7eeae8-7550-4580-852f-58ad0cc564b3",
+          "length": 159400,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "d615590b-1546-441d-9703-b3cf88487cbd",
+            "isrcs": [
+              "USGF19562907"
+            ],
+            "length": 160000,
+            "title": "Buddy Holly",
+            "video": false
+          },
+          "title": "Buddy Holly"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "5a0e14c9-cce6-43eb-aa48-4ad79fd10121",
+          "length": 306000,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "48908d8b-3a40-46fa-bfee-3a88012c2689",
+            "isrcs": [
+              "USGF19562908",
+              "USGF19962905"
+            ],
+            "length": 305400,
+            "title": "Undone \u2013 The Sweater Song",
+            "video": false
+          },
+          "title": "Undone \u2013 The Sweater Song"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "dcdfdafa-3e5e-4fcf-8dc8-feae7cfdd704",
+          "length": 187000,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "d8f04ba0-8f7e-4016-b818-5f07514d11e8",
+            "isrcs": [
+              "USGF19562909"
+            ],
+            "length": 186506,
+            "title": "Surf Wax America",
+            "video": false
+          },
+          "title": "Surf Wax America"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "ad03b128-10c3-47cb-93e1-f4cbd4fe7eec",
+          "length": 258800,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "album version",
+            "first-release-date": "1994-05-10",
+            "id": "e7ada1d0-0604-4ff2-9361-939ebf5b53af",
+            "isrcs": [
+              "USGF19562901",
+              "USGF19962907",
+              "USIR10400084"
+            ],
+            "length": 258800,
+            "title": "Say It Ain\u2019t So",
+            "video": false
+          },
+          "title": "Say It Ain\u2019t So"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "f2b3dc6f-b944-4373-95e7-65389a7a32d5",
+          "length": 235760,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "3761f313-1239-46e9-b720-9d24b06da5ab",
+            "isrcs": [
+              "USGF19562911",
+              "USGF19962908"
+            ],
+            "length": 235760,
+            "title": "In the Garage",
+            "video": false
+          },
+          "title": "In the Garage"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "7829ae5f-a199-431c-8d22-48bf91d9fb84",
           "length": 204866,
           "number": "9",
           "position": 9,
           "recording": {
-            "title": "Holiday",
-            "id": "e5b7a191-79d2-41ca-aa96-2d041c741aac",
-            "first-release-date": "1994-05-10",
             "artist-credit": [
               {
-                "name": "Weezer",
-                "joinphrase": "",
                 "artist": {
-                  "name": "Weezer",
-                  "type": "Group",
-                  "disambiguation": "American rock band",
                   "country": "US",
+                  "disambiguation": "American rock band",
                   "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
                   "sort-name": "Weezer",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
-            "video": false,
             "disambiguation": "",
-            "length": 204866,
+            "first-release-date": "1994-05-10",
+            "id": "e5b7a191-79d2-41ca-aa96-2d041c741aac",
             "isrcs": [
               "USGF19562912",
               "USGF19962909"
-            ]
-          }
+            ],
+            "length": 204866,
+            "title": "Holiday",
+            "video": false
+          },
+          "title": "Holiday"
         },
         {
-          "number": "10",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "56753fed-b1a0-465d-9776-38c0fdecc70d",
           "length": 480000,
+          "number": "10",
           "position": 10,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "e1b7cd2e-bdf9-45d5-b52e-cc8a94d5d1da",
             "isrcs": [
               "USGF19562913",
               "USGF19962910"
             ],
             "length": 479000,
             "title": "Only in Dreams",
-            "artist-credit": [
-              {
-                "name": "Weezer",
-                "joinphrase": "",
-                "artist": {
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "country": "US",
-                  "disambiguation": "American rock band",
-                  "name": "Weezer",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Weezer"
-                }
-              }
-            ],
-            "first-release-date": "1994-05-10",
-            "id": "e1b7cd2e-bdf9-45d5-b52e-cc8a94d5d1da",
-            "video": false,
-            "disambiguation": ""
+            "video": false
           },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Weezer",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Weezer",
-                "name": "Weezer",
-                "type": "Group",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
-              }
-            }
-          ],
-          "id": "56753fed-b1a0-465d-9776-38c0fdecc70d",
           "title": "Only in Dreams"
         }
-      ],
-      "track-count": 10,
-      "track-offset": 0,
-      "id": "2714ee37-5c8f-3500-b2be-6880553650ab",
-      "format": "CD",
-      "title": "",
-      "position": 1
+      ]
     }
   ],
-  "disambiguation": "blue album, JVC Pressing",
-  "asin": null,
+  "packaging": "Jewel Case",
   "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "cover-art-archive": {
-    "count": 0,
-    "darkened": false,
-    "back": false,
-    "artwork": false,
-    "front": false
-  },
+  "quality": "normal",
   "release-events": [
     {
       "area": {
-        "sort-name": "United States",
-        "type-id": null,
-        "id": "489ce91b-6658-3307-9877-795b68554c98",
-        "type": null,
-        "name": "United States",
         "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
         "iso-3166-1-codes": [
           "US"
-        ]
+        ],
+        "name": "United States",
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
       },
       "date": "1994-05-10"
     }
   ],
-  "title": "Weezer",
-  "packaging": "Jewel Case",
-  "status": "Official",
-  "country": "US",
-  "label-info": [
-    {
-      "label": {
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "sort-name": "DGC Records",
-        "name": "DGC Records",
-        "type": "Original Production",
-        "disambiguation": "",
-        "label-code": 6406,
-        "id": "68803e28-86fe-4a95-985f-8e493795ab31"
-      },
-      "catalog-number": "DGCD-24629"
-    }
-  ],
   "release-group": {
-    "secondary-type-ids": [],
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "primary-type": "Album",
-    "disambiguation": "Blue Album",
-    "title": "Weezer",
-    "secondary-types": [],
-    "id": "c7b245c9-8099-32ea-af95-893acedde2cf",
-    "first-release-date": "1994-05-10",
     "artist-credit": [
       {
-        "joinphrase": "",
-        "name": "Weezer",
         "artist": {
-          "sort-name": "Weezer",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "disambiguation": "American rock band",
           "country": "US",
+          "disambiguation": "American rock band",
+          "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
           "name": "Weezer",
+          "sort-name": "Weezer",
           "type": "Group",
-          "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
-        }
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Weezer"
       }
-    ]
+    ],
+    "disambiguation": "Blue Album",
+    "first-release-date": "1994-05-10",
+    "id": "c7b245c9-8099-32ea-af95-893acedde2cf",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Weezer"
   },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  }
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Weezer"
 }

--- a/scripts/eval_matching/corpus/eval_release_3ac4a81e.json
+++ b/scripts/eval_matching/corpus/eval_release_3ac4a81e.json
@@ -1,279 +1,249 @@
 {
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "JP",
+        "disambiguation": "",
+        "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+        "name": "\u690e\u540d\u6797\u6a8e",
+        "sort-name": "Sheena, Ringo",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+      },
+      "joinphrase": "",
+      "name": "\u690e\u540d\u6797\u6a8e"
+    }
+  ],
+  "asin": null,
+  "barcode": "0602577684647",
+  "country": "JP",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": false,
+    "count": 1,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2019-05-27",
+  "disambiguation": "24bit/96kHz",
+  "id": "3ac4a81e-8106-4858-bce0-f7a78c6354b0",
   "label-info": [
     {
       "catalog-number": "00602577684647",
       "label": {
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "sort-name": "EMI Records",
-        "label-code": null,
-        "id": "a20eafb7-8512-446d-b5d8-7f5d31032e64",
         "disambiguation": "a J-Pop division of Universal Music Japan, 2014\u2013present. Do not use for American/European music!",
+        "id": "a20eafb7-8512-446d-b5d8-7f5d31032e64",
+        "label-code": null,
+        "name": "EMI Records",
+        "sort-name": "EMI Records",
         "type": "Original Production",
-        "name": "EMI Records"
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
-  "country": "JP",
-  "release-group": {
-    "secondary-type-ids": [],
-    "primary-type": "Album",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "disambiguation": "",
-    "secondary-types": [],
-    "title": "\u4e09\u6bd2\u53f2",
-    "first-release-date": "2019-05-27",
-    "artist-credit": [
-      {
-        "artist": {
-          "sort-name": "Sheena, Ringo",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-          "type": "Person",
-          "name": "\u690e\u540d\u6797\u6a8e",
-          "country": "JP",
-          "disambiguation": ""
-        },
-        "name": "\u690e\u540d\u6797\u6a8e",
-        "joinphrase": ""
-      }
-    ],
-    "id": "397121b6-85c7-4b9a-970c-be7fdc40eb58"
-  },
-  "text-representation": {
-    "language": "jpn",
-    "script": "Jpan"
-  },
-  "packaging": null,
-  "title": "\u4e09\u6bd2\u53f2",
-  "status": "Official",
-  "release-events": [
-    {
-      "date": "2019-05-27",
-      "area": {
-        "type-id": null,
-        "sort-name": "Japan",
-        "disambiguation": "",
-        "iso-3166-1-codes": [
-          "JP"
-        ],
-        "type": null,
-        "name": "Japan",
-        "id": "2db42837-c832-3c27-b4a3-08198f75693c"
-      }
-    }
-  ],
-  "packaging-id": null,
-  "cover-art-archive": {
-    "count": 1,
-    "darkened": false,
-    "back": false,
-    "artwork": true,
-    "front": true
-  },
-  "disambiguation": "24bit/96kHz",
   "media": [
     {
-      "title": "",
-      "position": 1,
       "format": "Digital Media",
+      "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
       "id": "eef5a1ed-833e-31b7-9282-95857cdee5e7",
-      "track-offset": 0,
+      "position": 1,
+      "title": "",
       "track-count": 13,
+      "track-offset": 0,
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "321a290a-3605-4dc5-b13f-c42c0fd84496",
+          "length": 182666,
+          "number": "1",
+          "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "e3363ad3-0cf1-419e-86fa-82aa7809b120",
             "isrcs": [
               "JPPO01900893"
             ],
             "length": 182666,
-            "video": false,
-            "disambiguation": "",
             "title": "\u9d8f\u3068\u86c7\u3068\u8c5a",
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-                }
-              }
-            ],
-            "id": "e3363ad3-0cf1-419e-86fa-82aa7809b120"
+            "video": false
           },
-          "position": 1,
-          "number": "1",
-          "length": 182666,
-          "title": "\u9d8f\u3068\u86c7\u3068\u8c5a",
-          "artist-credit": [
-            {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "country": "JP",
-                "disambiguation": ""
-              }
-            }
-          ],
-          "id": "321a290a-3605-4dc5-b13f-c42c0fd84496"
+          "title": "\u9d8f\u3068\u86c7\u3068\u8c5a"
         },
         {
-          "id": "5d268e6a-c046-498f-a55a-edc70417a302",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "disambiguation": "",
                 "country": "JP",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "\u3068",
               "name": "\u690e\u540d\u6797\u6a8e"
             },
             {
-              "joinphrase": "",
-              "name": "\u5bae\u672c\u6d69\u6b21",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Miyamoto, Koji",
-                "id": "1e8ef6ca-523c-4777-81b2-7811f2b485ae",
                 "country": "JP",
                 "disambiguation": "singer-songwriter",
+                "id": "1e8ef6ca-523c-4777-81b2-7811f2b485ae",
+                "name": "\u5bae\u672c\u6d69\u6b21",
+                "sort-name": "Miyamoto, Koji",
                 "type": "Person",
-                "name": "\u5bae\u672c\u6d69\u6b21"
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u5bae\u672c\u6d69\u6b21"
             }
           ],
-          "title": "\u7363\u3086\u304f\u7d30\u9053",
+          "id": "5d268e6a-c046-498f-a55a-edc70417a302",
           "length": 220346,
           "number": "2",
           "position": 2,
           "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "\u7363\u3086\u304f\u7d30\u9053",
-            "id": "419294a2-e332-4472-8d4b-7434046160fd",
-            "first-release-date": "2018-10-02",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "JP",
                   "disambiguation": "",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-                },
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": "\u3068"
-              },
-              {
-                "joinphrase": "",
-                "name": "\u5bae\u672c\u6d69\u6b21",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Miyamoto, Hiroji",
-                  "id": "15f27586-9157-4f6e-b469-557a414308b7",
-                  "disambiguation": "\u30a8\u30ec\u30d5\u30a1\u30f3\u30c8\u30ab\u30b7\u30de\u30b7",
-                  "country": "JP",
-                  "type": "Person",
-                  "name": "\u5bae\u672c\u6d69\u6b21"
-                }
-              }
-            ],
-            "length": 220346,
-            "isrcs": [
-              "JPPO01804549"
-            ]
-          }
-        },
-        {
-          "recording": {
-            "disambiguation": "",
-            "video": false,
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo",
                   "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                   "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
                   "type": "Person",
-                  "disambiguation": "",
-                  "country": "JP"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": ""
+                "joinphrase": "\u3068",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              },
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "\u30a8\u30ec\u30d5\u30a1\u30f3\u30c8\u30ab\u30b7\u30de\u30b7",
+                  "id": "15f27586-9157-4f6e-b469-557a414308b7",
+                  "name": "\u5bae\u672c\u6d69\u6b21",
+                  "sort-name": "Miyamoto, Hiroji",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u5bae\u672c\u6d69\u6b21"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2018-10-02",
+            "id": "419294a2-e332-4472-8d4b-7434046160fd",
+            "isrcs": [
+              "JPPO01804549"
+            ],
+            "length": 220346,
+            "title": "\u7363\u3086\u304f\u7d30\u9053",
+            "video": false
+          },
+          "title": "\u7363\u3086\u304f\u7d30\u9053"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "b75ea7f9-2e5e-4dd9-ab87-4384b424ed34",
+          "length": 218346,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
             "id": "07eca33e-af49-4ce8-9b65-f62431bc8f25",
-            "title": "\u30de\u30fb\u30b7\u30a7\u30ea",
             "isrcs": [
               "JPPO01900894"
             ],
-            "length": 218346
+            "length": 218346,
+            "title": "\u30de\u30fb\u30b7\u30a7\u30ea",
+            "video": false
           },
-          "position": 3,
-          "length": 218346,
-          "number": "3",
-          "title": "\u30de\u30fb\u30b7\u30a7\u30ea",
-          "id": "b75ea7f9-2e5e-4dd9-ab87-4384b424ed34",
-          "artist-credit": [
-            {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "country": "JP",
-                "disambiguation": "",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e"
-              }
-            }
-          ]
+          "title": "\u30de\u30fb\u30b7\u30a7\u30ea"
         },
         {
-          "title": "\u99c6\u3051\u843d\u3061\u8005",
           "artist-credit": [
             {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "\u3068",
               "artist": {
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "disambiguation": "",
                 "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                 "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
                 "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo"
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "\u3068",
+              "name": "\u690e\u540d\u6797\u6a8e"
             },
             {
               "artist": {
-                "id": "d3eef2da-a278-4633-bcfe-29df8e76a2f3",
-                "disambiguation": "",
                 "country": "JP",
-                "type": "Person",
+                "disambiguation": "",
+                "id": "d3eef2da-a278-4633-bcfe-29df8e76a2f3",
                 "name": "\u6afb\u4e95\u6566\u53f8",
                 "sort-name": "Sakurai, Atsushi",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "",
@@ -281,543 +251,573 @@
             }
           ],
           "id": "0f6174db-733d-4746-959e-3b2af032d32b",
-          "recording": {
-            "disambiguation": "",
-            "video": false,
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "",
-                  "country": "JP",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo"
-                }
-              }
-            ],
-            "id": "5e3a930e-965d-438e-b4f9-9da40f623bb4",
-            "title": "\u99c6\u3051\u843d\u3061\u8005",
-            "isrcs": [
-              "JPPO01900895"
-            ],
-            "length": 185093
-          },
-          "position": 4,
+          "length": 185093,
           "number": "4",
-          "length": 185093
-        },
-        {
-          "title": "\u3069\u3093\u5e95\u307e\u3067",
-          "id": "dc8705b9-c36b-4292-b78c-91b544a1bf8c",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "disambiguation": "",
-                "country": "JP",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-              },
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": ""
-            }
-          ],
+          "position": 4,
           "recording": {
-            "length": 140680,
-            "isrcs": [
-              "JPPO01900896"
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "5aab17cd-af63-481c-ab05-33a7a393b624",
             "artist-credit": [
               {
                 "artist": {
-                  "disambiguation": "",
                   "country": "JP",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "disambiguation": "",
                   "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
                   "sort-name": "Sheena, Ringo",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": "",
                 "name": "\u690e\u540d\u6797\u6a8e"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "2019-05-27",
-            "title": "\u3069\u3093\u5e95\u307e\u3067"
+            "id": "5e3a930e-965d-438e-b4f9-9da40f623bb4",
+            "isrcs": [
+              "JPPO01900895"
+            ],
+            "length": 185093,
+            "title": "\u99c6\u3051\u843d\u3061\u8005",
+            "video": false
           },
-          "position": 5,
-          "length": 140680,
-          "number": "5"
+          "title": "\u99c6\u3051\u843d\u3061\u8005"
         },
         {
-          "id": "d2f008c2-3ff6-42d4-8fef-949ffb0ed2ef",
           "artist-credit": [
             {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "\u3068",
               "artist": {
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
+                "country": "JP",
                 "disambiguation": "",
-                "country": "JP",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo"
-              }
-            },
-            {
-              "joinphrase": "",
-              "name": "\u5411\u4e95\u79c0\u5fb3",
-              "artist": {
-                "sort-name": "Mukai, Shuutoku",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "d5126b59-0914-4108-8768-be3ab9c578c0",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
                 "type": "Person",
-                "name": "\u5411\u4e95\u79c0\u5fb3",
-                "country": "JP",
-                "disambiguation": ""
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
             }
           ],
-          "title": "\u795e\u69d8\u3001\u4ecf\u69d8",
+          "id": "dc8705b9-c36b-4292-b78c-91b544a1bf8c",
+          "length": 140680,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "length": 217960,
-            "isrcs": [
-              "JPPO01900897"
-            ],
-            "video": false,
-            "disambiguation": "",
-            "title": "\u795e\u69d8\u3001\u4ecf\u69d8",
-            "id": "63eba6a3-82b1-4952-9602-8a3accbb566b",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "country": "JP",
+                  "disambiguation": "",
                   "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                   "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
                   "type": "Person",
-                  "country": "JP",
-                  "disambiguation": ""
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": "",
                 "name": "\u690e\u540d\u6797\u6a8e"
               }
             ],
-            "first-release-date": "2019-05-27"
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "5aab17cd-af63-481c-ab05-33a7a393b624",
+            "isrcs": [
+              "JPPO01900896"
+            ],
+            "length": 140680,
+            "title": "\u3069\u3093\u5e95\u307e\u3067",
+            "video": false
           },
-          "length": 217960,
-          "number": "6",
-          "position": 6
+          "title": "\u3069\u3093\u5e95\u307e\u3067"
         },
         {
-          "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "Tokyo",
-            "id": "1fd4f588-1f24-4634-bb69-4b095e705c67",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-                }
-              }
-            ],
-            "first-release-date": "2019-05-27",
-            "length": 223600,
-            "isrcs": [
-              "JPPO01900898"
-            ]
-          },
-          "position": 7,
-          "number": "7",
-          "length": 223600,
-          "title": "TOKYO",
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
                 "country": "JP",
                 "disambiguation": "",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": ""
+              "joinphrase": "\u3068",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            },
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "d5126b59-0914-4108-8768-be3ab9c578c0",
+                "name": "\u5411\u4e95\u79c0\u5fb3",
+                "sort-name": "Mukai, Shuutoku",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u5411\u4e95\u79c0\u5fb3"
             }
           ],
-          "id": "c4f103eb-a1b3-466a-8b9d-f76ed462846a"
-        },
-        {
+          "id": "d2f008c2-3ff6-42d4-8fef-949ffb0ed2ef",
+          "length": 217960,
+          "number": "6",
+          "position": 6,
           "recording": {
-            "disambiguation": "",
-            "video": false,
-            "first-release-date": "2015-07-10",
             "artist-credit": [
               {
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                   "country": "JP",
                   "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                   "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person"
-                }
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
               }
             ],
-            "id": "92236c0d-c0ed-474b-aba5-8d2ab22b3233",
-            "title": "\u9577\u304f\u77ed\u3044\u796d",
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "63eba6a3-82b1-4952-9602-8a3accbb566b",
             "isrcs": [
-              "JPPO01900899"
+              "JPPO01900897"
             ],
-            "length": 249173
+            "length": 217960,
+            "title": "\u795e\u69d8\u3001\u4ecf\u69d8",
+            "video": false
           },
+          "title": "\u795e\u69d8\u3001\u4ecf\u69d8"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "c4f103eb-a1b3-466a-8b9d-f76ed462846a",
+          "length": 223600,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "1fd4f588-1f24-4634-bb69-4b095e705c67",
+            "isrcs": [
+              "JPPO01900898"
+            ],
+            "length": 223600,
+            "title": "Tokyo",
+            "video": false
+          },
+          "title": "TOKYO"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "\u3068",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            },
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "701f915e-8ed0-4520-82b0-2f25f7b2a149",
+                "name": "\u6d6e\u96f2",
+                "sort-name": "Ukigumo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u6d6e\u96f2"
+            }
+          ],
+          "id": "cb4cf3d3-f191-477e-b865-69bdb7264ecc",
           "length": 249173,
           "number": "8",
           "position": 8,
-          "id": "cb4cf3d3-f191-477e-b865-69bdb7264ecc",
-          "artist-credit": [
-            {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "\u3068",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "disambiguation": "",
-                "country": "JP",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
               }
-            },
-            {
-              "artist": {
-                "id": "701f915e-8ed0-4520-82b0-2f25f7b2a149",
-                "country": "JP",
-                "disambiguation": "",
-                "type": "Person",
-                "name": "\u6d6e\u96f2",
-                "sort-name": "Ukigumo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "name": "\u6d6e\u96f2",
-              "joinphrase": ""
-            }
-          ],
+            ],
+            "disambiguation": "",
+            "first-release-date": "2015-07-10",
+            "id": "92236c0d-c0ed-474b-aba5-8d2ab22b3233",
+            "isrcs": [
+              "JPPO01900899"
+            ],
+            "length": 249173,
+            "title": "\u9577\u304f\u77ed\u3044\u796d",
+            "video": false
+          },
           "title": "\u9577\u304f\u77ed\u3044\u796d"
         },
         {
-          "number": "9",
-          "length": 248640,
-          "position": 9,
-          "recording": {
-            "length": 248640,
-            "isrcs": [
-              "JPPO01500003"
-            ],
-            "video": false,
-            "disambiguation": "",
-            "title": "\u81f3\u4e0a\u306e\u4eba\u751f",
-            "id": "ed2e131d-cc85-4f7b-8cae-0320dc15984a",
-            "first-release-date": "2015-02-25",
-            "artist-credit": [
-              {
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "country": "JP",
-                  "disambiguation": ""
-                }
-              }
-            ]
-          },
           "artist-credit": [
             {
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo",
-                "disambiguation": "",
                 "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                 "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
                 "type": "Person",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
             }
           ],
           "id": "b02c4821-0ff3-4531-a61b-dc3538841e12",
+          "length": 248640,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2015-02-25",
+            "id": "ed2e131d-cc85-4f7b-8cae-0320dc15984a",
+            "isrcs": [
+              "JPPO01500003"
+            ],
+            "length": 248640,
+            "title": "\u81f3\u4e0a\u306e\u4eba\u751f",
+            "video": false
+          },
           "title": "\u81f3\u4e0a\u306e\u4eba\u751f"
         },
         {
-          "recording": {
-            "disambiguation": "",
-            "video": false,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e"
-                }
-              }
-            ],
-            "first-release-date": "2019-05-27",
-            "id": "0afa9676-8c2d-4935-929c-6a9e0b238a15",
-            "title": "\u6025\u304c\u3070\u56de\u308c",
-            "isrcs": [
-              "JPPO01900900"
-            ],
-            "length": 176026
-          },
-          "length": 176026,
-          "number": "10",
-          "position": 10,
-          "id": "1d8e75df-f8a3-4335-b23d-a77396acad94",
           "artist-credit": [
             {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "\u3068",
               "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                 "country": "JP",
                 "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
                 "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e"
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "\u3068",
+              "name": "\u690e\u540d\u6797\u6a8e"
             },
             {
               "artist": {
-                "id": "610f93f2-88d1-4529-8f73-bfcbb6ec9899",
-                "type": "Person",
-                "name": "\u30d2\u30a4\u30ba\u30df\u30de\u30b5\u30e6\u6a5f",
                 "country": null,
                 "disambiguation": "",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Hiizumi, Masayuki"
+                "id": "610f93f2-88d1-4529-8f73-bfcbb6ec9899",
+                "name": "\u30d2\u30a4\u30ba\u30df\u30de\u30b5\u30e6\u6a5f",
+                "sort-name": "Hiizumi, Masayuki",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "",
               "name": "\u30d2\u30a4\u30ba\u30df\u30de\u30b5\u30e6\u6a5f"
             }
           ],
+          "id": "1d8e75df-f8a3-4335-b23d-a77396acad94",
+          "length": 176026,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "0afa9676-8c2d-4935-929c-6a9e0b238a15",
+            "isrcs": [
+              "JPPO01900900"
+            ],
+            "length": 176026,
+            "title": "\u6025\u304c\u3070\u56de\u308c",
+            "video": false
+          },
           "title": "\u6025\u304c\u3070\u56de\u308c"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "e1d17e9f-ee08-4685-ba67-066f525eef60",
+          "length": 176933,
+          "number": "11",
+          "position": 11,
           "recording": {
-            "length": 176933,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "1d82d914-d60d-4d58-9329-df9d74cf6e1e",
             "isrcs": [
               "JPPO01900901"
             ],
-            "id": "1d82d914-d60d-4d58-9329-df9d74cf6e1e",
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo"
-                },
-                "joinphrase": "",
-                "name": "\u690e\u540d\u6797\u6a8e"
-              }
-            ],
+            "length": 176933,
             "title": "\u30b8\u30e6\u30fc\u30c0\u30e0",
-            "disambiguation": "",
             "video": false
           },
-          "position": 11,
-          "number": "11",
-          "length": 176933,
-          "title": "\u30b8\u30e6\u30fc\u30c0\u30e0",
-          "artist-credit": [
-            {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "country": "JP",
-                "disambiguation": "",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-              }
-            }
-          ],
-          "id": "e1d17e9f-ee08-4685-ba67-066f525eef60"
+          "title": "\u30b8\u30e6\u30fc\u30c0\u30e0"
         },
         {
-          "recording": {
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "artist": {
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "country": "JP",
-                  "disambiguation": "",
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ],
-            "id": "04bdcd96-31de-466a-a554-8096bdbd7665",
-            "title": "\u76ee\u629c\u304d\u901a\u308a",
-            "disambiguation": "",
-            "video": false,
-            "isrcs": [
-              "JPPO01900902"
-            ],
-            "length": 193280
-          },
-          "position": 12,
-          "length": 193280,
-          "number": "12",
-          "title": "\u76ee\u629c\u304d\u901a\u308a",
-          "id": "c640a4ed-6574-4929-bfb0-f3c93c51d432",
           "artist-credit": [
             {
               "artist": {
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
                 "country": "JP",
                 "disambiguation": "",
                 "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
                 "sort-name": "Sheena, Ringo",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "\u3068"
+              "joinphrase": "\u3068",
+              "name": "\u690e\u540d\u6797\u6a8e"
             },
             {
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Tortoise Matsumoto",
-                "id": "f5989e42-11b9-49d2-a752-7768ac2d4b3c",
-                "type": "Person",
-                "name": "\u30c8\u30fc\u30bf\u30b9\u677e\u672c",
+                "country": "JP",
                 "disambiguation": "",
-                "country": "JP"
+                "id": "f5989e42-11b9-49d2-a752-7768ac2d4b3c",
+                "name": "\u30c8\u30fc\u30bf\u30b9\u677e\u672c",
+                "sort-name": "Tortoise Matsumoto",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "\u30c8\u30fc\u30bf\u30b9\u677e\u672c",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "\u30c8\u30fc\u30bf\u30b9\u677e\u672c"
             }
-          ]
-        },
-        {
+          ],
+          "id": "c640a4ed-6574-4929-bfb0-f3c93c51d432",
+          "length": 193280,
+          "number": "12",
+          "position": 12,
           "recording": {
-            "length": 181266,
-            "isrcs": [
-              "JPPO01900903"
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "1b82aab5-431b-433c-ab15-b626b80b0e04",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
                   "country": "JP",
                   "disambiguation": "",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
                 "joinphrase": "",
                 "name": "\u690e\u540d\u6797\u6a8e"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "2019-05-27",
-            "title": "\u3042\u306e\u4e16\u306e\u9580"
+            "id": "04bdcd96-31de-466a-a554-8096bdbd7665",
+            "isrcs": [
+              "JPPO01900902"
+            ],
+            "length": 193280,
+            "title": "\u76ee\u629c\u304d\u901a\u308a",
+            "video": false
           },
-          "position": 13,
-          "number": "13",
-          "length": 181266,
-          "title": "\u3042\u306e\u4e16\u306e\u9580",
+          "title": "\u76ee\u629c\u304d\u901a\u308a"
+        },
+        {
           "artist-credit": [
             {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "disambiguation": "",
                 "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
                 "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e"
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
             }
           ],
-          "id": "a90ef753-a374-4f4c-8ba5-2ba264909f9c"
+          "id": "a90ef753-a374-4f4c-8ba5-2ba264909f9c",
+          "length": 181266,
+          "number": "13",
+          "position": 13,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "1b82aab5-431b-433c-ab15-b626b80b0e04",
+            "isrcs": [
+              "JPPO01900903"
+            ],
+            "length": 181266,
+            "title": "\u3042\u306e\u4e16\u306e\u9580",
+            "video": false
+          },
+          "title": "\u3042\u306e\u4e16\u306e\u9580"
         }
-      ],
-      "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794"
+      ]
     }
   ],
-  "asin": null,
-  "artist-credit": [
-    {
-      "joinphrase": "",
-      "name": "\u690e\u540d\u6797\u6a8e",
-      "artist": {
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "sort-name": "Sheena, Ringo",
-        "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-        "name": "\u690e\u540d\u6797\u6a8e",
-        "type": "Person",
-        "country": "JP",
-        "disambiguation": ""
-      }
-    }
-  ],
-  "id": "3ac4a81e-8106-4858-bce0-f7a78c6354b0",
+  "packaging": null,
+  "packaging-id": null,
   "quality": "normal",
-  "barcode": "0602577684647",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+        "iso-3166-1-codes": [
+          "JP"
+        ],
+        "name": "Japan",
+        "sort-name": "Japan",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2019-05-27"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "JP",
+          "disambiguation": "",
+          "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+          "name": "\u690e\u540d\u6797\u6a8e",
+          "sort-name": "Sheena, Ringo",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "",
+        "name": "\u690e\u540d\u6797\u6a8e"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2019-05-27",
+    "id": "397121b6-85c7-4b9a-970c-be7fdc40eb58",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "\u4e09\u6bd2\u53f2"
+  },
+  "status": "Official",
   "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "date": "2019-05-27"
+  "text-representation": {
+    "language": "jpn",
+    "script": "Jpan"
+  },
+  "title": "\u4e09\u6bd2\u53f2"
 }

--- a/scripts/eval_matching/corpus/eval_release_3c297f7a.json
+++ b/scripts/eval_matching/corpus/eval_release_3c297f7a.json
@@ -1,46 +1,95 @@
 {
-  "quality": "normal",
-  "id": "3c297f7a-39c5-4259-9387-0555cc8d6a26",
   "artist-credit": [
     {
       "artist": {
-        "sort-name": "Fleetwood Mac",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "disambiguation": "",
         "country": "GB",
+        "disambiguation": "",
+        "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
         "name": "Fleetwood Mac",
+        "sort-name": "Fleetwood Mac",
         "type": "Group",
-        "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
       "joinphrase": "",
       "name": "Fleetwood Mac"
     }
   ],
   "asin": null,
+  "barcode": "081227967789",
+  "country": "XE",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": false,
+    "count": 1,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2013-01-28",
+  "disambiguation": "35th anniversary edition",
+  "id": "3c297f7a-39c5-4259-9387-0555cc8d6a26",
+  "label-info": [
+    {
+      "catalog-number": "8122796778",
+      "label": {
+        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
+        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
+        "label-code": 392,
+        "name": "Warner Bros. Records",
+        "sort-name": "Warner Bros. Records",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    }
+  ],
   "media": [
     {
+      "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "442b9629-2bc3-31b3-ba83-f2adc32bfa05",
+      "position": 1,
+      "title": "",
       "track-count": 11,
+      "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
               "artist": {
-                "disambiguation": "",
                 "country": "GB",
-                "type": "Group",
-                "name": "Fleetwood Mac",
+                "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac"
-              }
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
           "id": "e7f87d7c-8bd1-46de-86f3-7f27c61a3ffd",
-          "title": "Second Hand News",
+          "length": 176306,
+          "number": "1",
+          "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "extra \u201cyeah yeah\u201d at end",
+            "first-release-date": "1977",
+            "id": "b25f351b-206f-4297-95bd-78459b704144",
             "isrcs": [
               "USWB10101367",
               "USWB10202616",
@@ -49,74 +98,50 @@
               "USWB19900177"
             ],
             "length": 173666,
-            "first-release-date": "1977",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac"
-                },
-                "name": "Fleetwood Mac",
-                "joinphrase": ""
-              }
-            ],
-            "id": "b25f351b-206f-4297-95bd-78459b704144",
             "title": "Second Hand News",
-            "disambiguation": "extra \u201cyeah yeah\u201d at end",
             "video": false
           },
-          "number": "1",
-          "length": 176306,
-          "position": 1
+          "title": "Second Hand News"
         },
         {
-          "id": "ec223f98-f9e3-4e05-91ce-6546c744af0f",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Fleetwood Mac",
               "artist": {
-                "name": "Fleetwood Mac",
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac"
-              }
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "title": "Dreams",
+          "id": "ec223f98-f9e3-4e05-91ce-6546c744af0f",
           "length": 257800,
           "number": "2",
           "position": 2,
           "recording": {
-            "disambiguation": "",
-            "video": false,
-            "id": "248cc9d1-97ea-493e-84d4-4c5ec718683b",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
                   "country": "GB",
-                  "disambiguation": ""
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Fleetwood Mac",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "1977-02-04",
-            "title": "Dreams",
-            "length": 257000,
+            "id": "248cc9d1-97ea-493e-84d4-4c5ec718683b",
             "isrcs": [
               "USRH11802580",
               "USWB10101368",
@@ -124,103 +149,104 @@
               "USWB10400046",
               "USWB11301111",
               "USWB19900178"
-            ]
-          }
+            ],
+            "length": 257000,
+            "title": "Dreams",
+            "video": false
+          },
+          "title": "Dreams"
         },
         {
-          "position": 3,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "7053c901-d904-4437-9eb7-a0ad2e539731",
           "length": 134400,
           "number": "3",
+          "position": 3,
           "recording": {
-            "title": "Never Going Back Again",
-            "id": "0b304971-9f84-485b-9f34-50f12004cf0d",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Fleetwood Mac",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-                }
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "first-release-date": "1977",
-            "video": false,
             "disambiguation": "",
-            "length": 134426,
+            "first-release-date": "1977",
+            "id": "0b304971-9f84-485b-9f34-50f12004cf0d",
             "isrcs": [
               "USWB10101369",
               "USWB10202610",
               "USWB10400047",
               "USWB11301112",
               "USWB19900179"
-            ]
+            ],
+            "length": 134426,
+            "title": "Never Going Back Again",
+            "video": false
           },
-          "title": "Never Going Back Again",
-          "id": "7053c901-d904-4437-9eb7-a0ad2e539731",
+          "title": "Never Going Back Again"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "name": "Fleetwood Mac",
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
                 "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
-          ]
-        },
-        {
-          "id": "113575a1-2e24-4331-8286-53a13d32c335",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac",
-                "type": "Group",
-                "name": "Fleetwood Mac",
-                "country": "GB",
-                "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-              },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
-            }
           ],
-          "title": "Don\u2019t Stop",
+          "id": "113575a1-2e24-4331-8286-53a13d32c335",
           "length": 193346,
           "number": "4",
           "position": 4,
           "recording": {
-            "first-release-date": "1977-02-04",
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "country": "GB",
                   "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "name": "Fleetwood Mac",
-                  "type": "Group"
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Fleetwood Mac",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "id": "1c0a78be-b883-4c5d-93f2-4f48405dbcb2",
-            "title": "Don\u2019t Stop",
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1977-02-04",
+            "id": "1c0a78be-b883-4c5d-93f2-4f48405dbcb2",
             "isrcs": [
               "USRH11802582",
               "USWB10101370",
@@ -229,31 +255,51 @@
               "USWB11301113",
               "USWB19900180"
             ],
-            "length": 192666
-          }
+            "length": 192666,
+            "title": "Don\u2019t Stop",
+            "video": false
+          },
+          "title": "Don\u2019t Stop"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "084d07a7-53e4-40e0-a3ed-215811c5bfe3",
+          "length": 223613,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "first-release-date": "1976-12-20",
             "artist-credit": [
               {
                 "artist": {
                   "country": "GB",
                   "disambiguation": "",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Fleetwood Mac",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "id": "66908b7f-050f-4e8d-82b0-a768a3d80c63",
-            "title": "Go Your Own Way",
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1976-12-20",
+            "id": "66908b7f-050f-4e8d-82b0-a768a3d80c63",
             "isrcs": [
               "USLIC0601867",
               "USRE11000837",
@@ -264,52 +310,51 @@
               "USWB11301114",
               "USWB19900181"
             ],
-            "length": 219373
+            "length": 219373,
+            "title": "Go Your Own Way",
+            "video": false
           },
-          "length": 223613,
-          "number": "5",
-          "position": 5,
-          "id": "084d07a7-53e4-40e0-a3ed-215811c5bfe3",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Fleetwood Mac",
-              "artist": {
-                "sort-name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "name": "Fleetwood Mac",
-                "disambiguation": "",
-                "country": "GB",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-              }
-            }
-          ],
           "title": "Go Your Own Way"
         },
         {
-          "id": "b4085655-d382-4e3a-8058-4ecdb00cd248",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Fleetwood Mac",
               "artist": {
-                "sort-name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type": "Group",
-                "name": "Fleetwood Mac",
+                "country": "GB",
                 "disambiguation": "",
-                "country": "GB"
-              }
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "title": "Songbird",
+          "id": "b4085655-d382-4e3a-8058-4ecdb00cd248",
           "length": 201573,
           "number": "6",
           "position": 6,
           "recording": {
-            "length": 200813,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "70b64435-e956-4141-9149-789b19ebcf9f",
             "isrcs": [
               "USWB10101378",
               "USWB10202615",
@@ -318,50 +363,51 @@
               "USWB11301115",
               "USWB19900182"
             ],
+            "length": 200813,
             "title": "Songbird",
-            "id": "70b64435-e956-4141-9149-789b19ebcf9f",
-            "first-release-date": "1977-02-04",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac"
-                },
-                "name": "Fleetwood Mac",
-                "joinphrase": ""
-              }
-            ],
-            "video": false,
-            "disambiguation": ""
-          }
+            "video": false
+          },
+          "title": "Songbird"
         },
         {
-          "title": "The Chain",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac",
-                "type": "Group",
-                "name": "Fleetwood Mac",
                 "country": "GB",
                 "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
           "id": "e1c6ffa2-51b9-44ed-a061-eb6b720c2a5c",
-          "position": 7,
-          "number": "7",
           "length": 270360,
+          "number": "7",
+          "position": 7,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "cd06c484-9319-4376-a104-504871e19756",
             "isrcs": [
               "USRH11802583",
               "USWB10101373",
@@ -372,33 +418,49 @@
             ],
             "length": 269400,
             "title": "The Chain",
-            "first-release-date": "1977-02-04",
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "name": "Fleetwood Mac",
-                  "type": "Group"
-                }
-              }
-            ],
-            "id": "cd06c484-9319-4376-a104-504871e19756",
-            "video": false,
-            "disambiguation": ""
-          }
+            "video": false
+          },
+          "title": "The Chain"
         },
         {
-          "number": "8",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "936933a6-cec1-45aa-a9e2-bdc31ea41733",
           "length": 213946,
+          "number": "8",
           "position": 8,
           "recording": {
-            "length": 213106,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "cce551a1-5a6c-494b-89fe-6dfac5e8aed1",
             "isrcs": [
               "USWB10101374",
               "USWB10202604",
@@ -406,47 +468,51 @@
               "USWB11301117",
               "USWB19900184"
             ],
+            "length": 213106,
             "title": "You Make Loving Fun",
-            "id": "cce551a1-5a6c-494b-89fe-6dfac5e8aed1",
+            "video": false
+          },
+          "title": "You Make Loving Fun"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "871ea783-c8f2-4320-8f36-ea20db13a706",
+          "length": 196586,
+          "number": "9",
+          "position": 9,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "name": "Fleetwood Mac",
-                  "type": "Group",
-                  "disambiguation": "",
-                  "country": "GB",
                   "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "1977-02-04",
-            "video": false,
-            "disambiguation": ""
-          },
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "name": "Fleetwood Mac",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": ""
-              },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
-            }
-          ],
-          "id": "936933a6-cec1-45aa-a9e2-bdc31ea41733",
-          "title": "You Make Loving Fun"
-        },
-        {
-          "recording": {
+            "id": "fc53705e-f3d6-4246-b0e3-23d1acc8f1d1",
             "isrcs": [
               "USWB10101375",
               "USWB10400055",
@@ -455,52 +521,49 @@
             ],
             "length": 195493,
             "title": "I Don\u2019t Want to Know",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "disambiguation": "",
-                  "country": "GB"
-                },
-                "name": "Fleetwood Mac",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1977-02-04",
-            "id": "fc53705e-f3d6-4246-b0e3-23d1acc8f1d1",
-            "video": false,
-            "disambiguation": ""
+            "video": false
           },
-          "position": 9,
-          "length": 196586,
-          "number": "9",
-          "title": "I Don\u2019t Want to Know",
-          "id": "871ea783-c8f2-4320-8f36-ea20db13a706",
+          "title": "I Don\u2019t Want to Know"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                 "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac"
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
-          ]
-        },
-        {
-          "position": 10,
-          "number": "10",
+          ],
+          "id": "ce1e88cc-6a63-4214-82d1-4285d69599d2",
           "length": 236120,
+          "number": "10",
+          "position": 10,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "0c9684a3-1109-44cb-ac8c-808168ae8715",
             "isrcs": [
               "USWB10101376",
               "USWB10400056",
@@ -508,87 +571,21 @@
               "USWB19900186"
             ],
             "length": 236226,
-            "disambiguation": "",
-            "video": false,
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
-                "artist": {
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "first-release-date": "1977-02-04",
-            "id": "0c9684a3-1109-44cb-ac8c-808168ae8715",
-            "title": "Oh Daddy"
+            "title": "Oh Daddy",
+            "video": false
           },
-          "title": "Oh Daddy",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "country": "GB",
-                "disambiguation": "",
-                "name": "Fleetwood Mac",
-                "type": "Group"
-              },
-              "name": "Fleetwood Mac",
-              "joinphrase": ""
-            }
-          ],
-          "id": "ce1e88cc-6a63-4214-82d1-4285d69599d2"
+          "title": "Oh Daddy"
         },
         {
-          "recording": {
-            "length": 302000,
-            "isrcs": [
-              "USWB10101377",
-              "USWB10400057",
-              "USWB11301120",
-              "USWB19900187"
-            ],
-            "title": "Gold Dust Woman",
-            "id": "6eda00db-318c-495b-96a1-494d249b04f5",
-            "first-release-date": "1977",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Fleetwood Mac",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "disambiguation": "",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-                }
-              }
-            ],
-            "video": false,
-            "disambiguation": "hard start, glass break, soft howling"
-          },
-          "number": "11",
-          "length": 295653,
-          "position": 11,
           "artist-credit": [
             {
               "artist": {
+                "country": "GB",
+                "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                 "name": "Fleetwood Mac",
-                "type": "Group",
-                "disambiguation": "",
-                "country": "GB",
                 "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
@@ -596,89 +593,92 @@
             }
           ],
           "id": "b4e183bb-83cc-4864-a96e-d50b9582656f",
+          "length": 295653,
+          "number": "11",
+          "position": 11,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "hard start, glass break, soft howling",
+            "first-release-date": "1977",
+            "id": "6eda00db-318c-495b-96a1-494d249b04f5",
+            "isrcs": [
+              "USWB10101377",
+              "USWB10400057",
+              "USWB11301120",
+              "USWB19900187"
+            ],
+            "length": 302000,
+            "title": "Gold Dust Woman",
+            "video": false
+          },
           "title": "Gold Dust Woman"
         }
-      ],
-      "id": "442b9629-2bc3-31b3-ba83-f2adc32bfa05",
-      "track-offset": 0,
-      "title": "",
-      "position": 1,
-      "format": "CD"
+      ]
     }
   ],
-  "disambiguation": "35th anniversary edition",
-  "date": "2013-01-28",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "barcode": "081227967789",
   "packaging": "Jewel Case",
-  "title": "Rumours",
-  "status": "Official",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "release-group": {
-    "disambiguation": "",
-    "title": "Rumours",
-    "secondary-types": [],
-    "id": "416bb5e5-c7d1-3977-8fd7-7c9daf6c2be6",
-    "artist-credit": [
-      {
-        "name": "Fleetwood Mac",
-        "joinphrase": "",
-        "artist": {
-          "sort-name": "Fleetwood Mac",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "disambiguation": "",
-          "country": "GB",
-          "type": "Group",
-          "name": "Fleetwood Mac",
-          "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-        }
-      }
-    ],
-    "first-release-date": "1977-02-04",
-    "secondary-type-ids": [],
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "primary-type": "Album"
-  },
-  "country": "XE",
-  "label-info": [
-    {
-      "label": {
-        "sort-name": "Warner Bros. Records",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
-        "label-code": 392,
-        "name": "Warner Bros. Records",
-        "type": "Imprint",
-        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across"
-      },
-      "catalog-number": "8122796778"
-    }
-  ],
-  "cover-art-archive": {
-    "darkened": false,
-    "count": 1,
-    "artwork": true,
-    "front": true,
-    "back": false
-  },
   "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
   "release-events": [
     {
-      "date": "2013-01-28",
       "area": {
-        "name": "Europe",
-        "type": null,
         "disambiguation": "",
+        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
         "iso-3166-1-codes": [
           "XE"
         ],
-        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+        "name": "Europe",
         "sort-name": "Europe",
+        "type": null,
         "type-id": null
-      }
+      },
+      "date": "2013-01-28"
     }
-  ]
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "",
+          "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+          "name": "Fleetwood Mac",
+          "sort-name": "Fleetwood Mac",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Fleetwood Mac"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1977-02-04",
+    "id": "416bb5e5-c7d1-3977-8fd7-7c9daf6c2be6",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Rumours"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Rumours"
 }

--- a/scripts/eval_matching/corpus/eval_release_4fdf1514.json
+++ b/scripts/eval_matching/corpus/eval_release_4fdf1514.json
@@ -1,745 +1,745 @@
 {
-  "release-group": {
-    "disambiguation": "",
-    "id": "397121b6-85c7-4b9a-970c-be7fdc40eb58",
-    "first-release-date": "2019-05-27",
-    "artist-credit": [
-      {
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "JP",
+        "disambiguation": "",
+        "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
         "name": "\u690e\u540d\u6797\u6a8e",
-        "joinphrase": "",
-        "artist": {
-          "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-          "country": "JP",
-          "disambiguation": "",
-          "name": "\u690e\u540d\u6797\u6a8e",
-          "type": "Person",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "sort-name": "Sheena, Ringo"
-        }
-      }
-    ],
-    "title": "\u4e09\u6bd2\u53f2",
-    "secondary-types": [],
-    "secondary-type-ids": [],
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "primary-type": "Album"
+        "sort-name": "Sheena, Ringo",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+      },
+      "joinphrase": "",
+      "name": "\u690e\u540d\u6797\u6a8e"
+    }
+  ],
+  "asin": "B07QF91KKC",
+  "barcode": "4988031329207",
+  "country": "JP",
+  "cover-art-archive": {
+    "artwork": false,
+    "back": false,
+    "count": 0,
+    "darkened": false,
+    "front": false
   },
-  "text-representation": {
-    "script": "Jpan",
-    "language": "jpn"
-  },
+  "date": "2019-05-27",
+  "disambiguation": "\u521d\u56de\u9650\u5b9a\u751f\u7523\u76e4",
+  "id": "4fdf1514-5876-4e62-bf1e-afd7cc873392",
   "label-info": [
     {
       "catalog-number": "UPCH-29327",
       "label": {
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "sort-name": "EMI Records",
-        "label-code": null,
+        "disambiguation": "a J-Pop division of Universal Music Japan, 2014\u2013present. Do not use for American/European music!",
         "id": "a20eafb7-8512-446d-b5d8-7f5d31032e64",
-        "type": "Original Production",
+        "label-code": null,
         "name": "EMI Records",
-        "disambiguation": "a J-Pop division of Universal Music Japan, 2014\u2013present. Do not use for American/European music!"
+        "sort-name": "EMI Records",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
-  "country": "JP",
-  "packaging": null,
-  "status": "Official",
-  "title": "\u4e09\u6bd2\u53f2",
-  "release-events": [
-    {
-      "area": {
-        "type-id": null,
-        "sort-name": "Japan",
-        "id": "2db42837-c832-3c27-b4a3-08198f75693c",
-        "disambiguation": "",
-        "iso-3166-1-codes": [
-          "JP"
-        ],
-        "type": null,
-        "name": "Japan"
-      },
-      "date": "2019-05-27"
-    }
-  ],
-  "cover-art-archive": {
-    "back": false,
-    "front": false,
-    "artwork": false,
-    "count": 0,
-    "darkened": false
-  },
-  "packaging-id": null,
-  "asin": "B07QF91KKC",
   "media": [
     {
-      "track-offset": 0,
-      "id": "361ab452-f9da-34f8-89c0-8b2197e145d2",
       "format": "CD",
-      "title": "",
-      "position": 1,
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "361ab452-f9da-34f8-89c0-8b2197e145d2",
+      "position": 1,
+      "title": "",
+      "track-count": 13,
+      "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
               "artist": {
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "disambiguation": "",
                 "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
                 "sort-name": "Sheena, Ringo",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
             }
           ],
           "id": "00d5455f-5b4f-4ce2-a16d-9d82625006bd",
-          "title": "\u9d8f\u3068\u86c7\u3068\u8c5a",
-          "number": "1",
           "length": 182666,
+          "number": "1",
           "position": 1,
           "recording": {
-            "length": 182666,
-            "isrcs": [
-              "JPPO01900893"
-            ],
-            "id": "e3363ad3-0cf1-419e-86fa-82aa7809b120",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "country": "JP",
-                  "disambiguation": ""
-                }
-              }
-            ],
-            "first-release-date": "2019-05-27",
-            "title": "\u9d8f\u3068\u86c7\u3068\u8c5a",
-            "disambiguation": "",
-            "video": false
-          }
-        },
-        {
-          "id": "8d59dc1d-ff8d-4eeb-a0b2-258df7ef03ba",
-          "artist-credit": [
-            {
-              "artist": {
-                "disambiguation": "",
-                "country": "JP",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": "",
-              "name": "\u690e\u540d\u6797\u6a8e"
-            }
-          ],
-          "title": "\u7363\u3086\u304f\u7d30\u9053",
-          "length": 220346,
-          "number": "2",
-          "position": 2,
-          "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "\u7363\u3086\u304f\u7d30\u9053",
-            "id": "419294a2-e332-4472-8d4b-7434046160fd",
-            "artist-credit": [
-              {
-                "joinphrase": "\u3068",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "artist": {
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "disambiguation": "",
-                  "country": "JP"
-                }
-              },
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Miyamoto, Hiroji",
-                  "name": "\u5bae\u672c\u6d69\u6b21",
-                  "type": "Person",
-                  "country": "JP",
-                  "disambiguation": "\u30a8\u30ec\u30d5\u30a1\u30f3\u30c8\u30ab\u30b7\u30de\u30b7",
-                  "id": "15f27586-9157-4f6e-b469-557a414308b7"
-                },
-                "name": "\u5bae\u672c\u6d69\u6b21",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2018-10-02",
-            "length": 220346,
-            "isrcs": [
-              "JPPO01804549"
-            ]
-          }
-        },
-        {
-          "position": 3,
-          "number": "3",
-          "length": 218346,
-          "recording": {
-            "isrcs": [
-              "JPPO01900894"
-            ],
-            "length": 218346,
-            "video": false,
-            "disambiguation": "",
-            "title": "\u30de\u30fb\u30b7\u30a7\u30ea",
-            "first-release-date": "2019-05-27",
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                   "country": "JP",
                   "disambiguation": "",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person"
-                },
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": ""
-              }
-            ],
-            "id": "07eca33e-af49-4ce8-9b65-f62431bc8f25"
-          },
-          "title": "\u30de\u30fb\u30b7\u30a7\u30ea",
-          "artist-credit": [
-            {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
-              "artist": {
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "country": "JP",
-                "disambiguation": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
-            }
-          ],
-          "id": "b3f05dcf-fc7b-483d-a7a5-ca37bd908919"
-        },
-        {
-          "artist-credit": [
-            {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
-              "artist": {
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "disambiguation": "",
-                "country": "JP",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo"
-              }
-            }
-          ],
-          "id": "b8164ce8-c85b-4ce5-bc2c-376b301cc4b3",
-          "title": "\u99c6\u3051\u843d\u3061\u8005",
-          "number": "4",
-          "length": 185093,
-          "position": 4,
-          "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "\u99c6\u3051\u843d\u3061\u8005",
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": "",
-                "artist": {
                   "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                   "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "country": "JP",
-                  "disambiguation": "",
                   "sort-name": "Sheena, Ringo",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ],
-            "id": "5e3a930e-965d-438e-b4f9-9da40f623bb4",
-            "isrcs": [
-              "JPPO01900895"
-            ],
-            "length": 185093
-          }
-        },
-        {
-          "position": 5,
-          "length": 140680,
-          "number": "5",
-          "recording": {
-            "isrcs": [
-              "JPPO01900896"
-            ],
-            "length": 140680,
-            "title": "\u3069\u3093\u5e95\u307e\u3067",
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "artist": {
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-                }
-              }
-            ],
-            "id": "5aab17cd-af63-481c-ab05-33a7a393b624",
-            "video": false,
-            "disambiguation": ""
-          },
-          "title": "\u3069\u3093\u5e95\u307e\u3067",
-          "id": "b06b4973-4f5f-41fc-9c89-b352a8260f01",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "country": "JP",
-                "disambiguation": "",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-              }
-            }
-          ]
-        },
-        {
-          "title": "\u795e\u69d8\u3001\u4ecf\u69d8",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "country": "JP",
-                "disambiguation": "",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-              },
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": ""
-            }
-          ],
-          "id": "42b9669e-ee9f-4b8e-aece-e77104f3d6ac",
-          "recording": {
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": "",
-                "artist": {
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo"
-                }
-              }
-            ],
-            "id": "63eba6a3-82b1-4952-9602-8a3accbb566b",
-            "title": "\u795e\u69d8\u3001\u4ecf\u69d8",
-            "disambiguation": "",
-            "video": false,
-            "isrcs": [
-              "JPPO01900897"
-            ],
-            "length": 217960
-          },
-          "position": 6,
-          "number": "6",
-          "length": 217960
-        },
-        {
-          "recording": {
-            "length": 223600,
-            "isrcs": [
-              "JPPO01900898"
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "1fd4f588-1f24-4634-bb69-4b095e705c67",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Sheena, Ringo"
-                },
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2019-05-27",
-            "title": "Tokyo"
-          },
-          "length": 223600,
-          "number": "7",
-          "position": 7,
-          "id": "9b5babc5-d8d5-49ac-9a86-806fb6a78a60",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "country": "JP",
-                "disambiguation": ""
-              },
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": ""
-            }
-          ],
-          "title": "TOKYO"
-        },
-        {
-          "artist-credit": [
-            {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
-              "artist": {
-                "country": "JP",
-                "disambiguation": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo"
-              }
-            }
-          ],
-          "id": "9355cbf9-ab24-45ce-b1fc-e2715b516f62",
-          "title": "\u9577\u304f\u77ed\u3044\u796d",
-          "number": "8",
-          "length": 249173,
-          "position": 8,
-          "recording": {
-            "disambiguation": "",
-            "video": false,
-            "id": "92236c0d-c0ed-474b-aba5-8d2ab22b3233",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "artist": {
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "country": "JP",
-                  "disambiguation": "",
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ],
-            "first-release-date": "2015-07-10",
-            "title": "\u9577\u304f\u77ed\u3044\u796d",
-            "length": 249173,
-            "isrcs": [
-              "JPPO01900899"
-            ]
-          }
-        },
-        {
-          "position": 9,
-          "length": 248640,
-          "number": "9",
-          "recording": {
-            "title": "\u81f3\u4e0a\u306e\u4eba\u751f",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e"
-                },
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2015-02-25",
-            "id": "ed2e131d-cc85-4f7b-8cae-0320dc15984a",
-            "video": false,
-            "disambiguation": "",
-            "isrcs": [
-              "JPPO01500003"
-            ],
-            "length": 248640
-          },
-          "title": "\u81f3\u4e0a\u306e\u4eba\u751f",
-          "id": "fc2b29c1-918d-47c1-8a87-f08ca64877c1",
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "country": "JP",
-                "disambiguation": "",
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": "",
-              "name": "\u690e\u540d\u6797\u6a8e"
-            }
-          ]
-        },
-        {
-          "id": "04542afb-48a2-4e8f-85ea-bdbaea2d343e",
-          "artist-credit": [
-            {
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "type": "Person",
-                "disambiguation": "",
-                "country": "JP",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-              }
-            }
-          ],
-          "title": "\u6025\u304c\u3070\u56de\u308c",
-          "recording": {
-            "isrcs": [
-              "JPPO01900900"
-            ],
-            "length": 176026,
-            "title": "\u6025\u304c\u3070\u56de\u308c",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "",
-                  "country": "JP",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
                 },
                 "joinphrase": "",
                 "name": "\u690e\u540d\u6797\u6a8e"
               }
             ],
-            "first-release-date": "2019-05-27",
-            "id": "0afa9676-8c2d-4935-929c-6a9e0b238a15",
-            "video": false,
-            "disambiguation": ""
-          },
-          "length": 176026,
-          "number": "10",
-          "position": 10
-        },
-        {
-          "title": "\u30b8\u30e6\u30fc\u30c0\u30e0",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "\u690e\u540d\u6797\u6a8e",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Sheena, Ringo",
-                "country": "JP",
-                "disambiguation": "",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87"
-              }
-            }
-          ],
-          "id": "5293d613-9f2d-45b5-b18a-040a6bb186f5",
-          "recording": {
-            "length": 176933,
-            "isrcs": [
-              "JPPO01900901"
-            ],
-            "id": "1d82d914-d60d-4d58-9329-df9d74cf6e1e",
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": "",
-                "artist": {
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
-                  "country": "JP",
-                  "disambiguation": "",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ],
-            "title": "\u30b8\u30e6\u30fc\u30c0\u30e0",
             "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "e3363ad3-0cf1-419e-86fa-82aa7809b120",
+            "isrcs": [
+              "JPPO01900893"
+            ],
+            "length": 182666,
+            "title": "\u9d8f\u3068\u86c7\u3068\u8c5a",
             "video": false
           },
-          "position": 11,
-          "number": "11",
-          "length": 176933
+          "title": "\u9d8f\u3068\u86c7\u3068\u8c5a"
         },
         {
-          "title": "\u76ee\u629c\u304d\u901a\u308a",
-          "id": "c1c0b3d4-c9b9-40e0-abde-072a33736a5c",
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Sheena, Ringo",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "country": "JP",
+                "disambiguation": "",
                 "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
                 "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
                 "type": "Person",
-                "country": "JP",
-                "disambiguation": ""
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "",
               "name": "\u690e\u540d\u6797\u6a8e"
             }
           ],
+          "id": "8d59dc1d-ff8d-4eeb-a0b2-258df7ef03ba",
+          "length": 220346,
+          "number": "2",
+          "position": 2,
           "recording": {
-            "id": "04bdcd96-31de-466a-a554-8096bdbd7665",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Sheena, Ringo",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                  "type": "Person",
-                  "name": "\u690e\u540d\u6797\u6a8e",
                   "country": "JP",
-                  "disambiguation": ""
-                },
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2019-05-27",
-            "title": "\u76ee\u629c\u304d\u901a\u308a",
-            "disambiguation": "",
-            "video": false,
-            "length": 193280,
-            "isrcs": [
-              "JPPO01900902"
-            ]
-          },
-          "position": 12,
-          "length": 193280,
-          "number": "12"
-        },
-        {
-          "recording": {
-            "length": 181266,
-            "isrcs": [
-              "JPPO01900903"
-            ],
-            "id": "1b82aab5-431b-433c-ab15-b626b80b0e04",
-            "first-release-date": "2019-05-27",
-            "artist-credit": [
-              {
-                "artist": {
                   "disambiguation": "",
-                  "country": "JP",
-                  "name": "\u690e\u540d\u6797\u6a8e",
-                  "type": "Person",
                   "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
                   "sort-name": "Sheena, Ringo",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "joinphrase": ""
+                "joinphrase": "\u3068",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              },
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "\u30a8\u30ec\u30d5\u30a1\u30f3\u30c8\u30ab\u30b7\u30de\u30b7",
+                  "id": "15f27586-9157-4f6e-b469-557a414308b7",
+                  "name": "\u5bae\u672c\u6d69\u6b21",
+                  "sort-name": "Miyamoto, Hiroji",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u5bae\u672c\u6d69\u6b21"
               }
             ],
-            "title": "\u3042\u306e\u4e16\u306e\u9580",
             "disambiguation": "",
+            "first-release-date": "2018-10-02",
+            "id": "419294a2-e332-4472-8d4b-7434046160fd",
+            "isrcs": [
+              "JPPO01804549"
+            ],
+            "length": 220346,
+            "title": "\u7363\u3086\u304f\u7d30\u9053",
             "video": false
           },
-          "number": "13",
-          "length": 181266,
-          "position": 13,
+          "title": "\u7363\u3086\u304f\u7d30\u9053"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "\u690e\u540d\u6797\u6a8e",
               "artist": {
-                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-                "type": "Person",
-                "name": "\u690e\u540d\u6797\u6a8e",
-                "disambiguation": "",
                 "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
                 "sort-name": "Sheena, Ringo",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "b3f05dcf-fc7b-483d-a7a5-ca37bd908919",
+          "length": 218346,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
               }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "07eca33e-af49-4ce8-9b65-f62431bc8f25",
+            "isrcs": [
+              "JPPO01900894"
+            ],
+            "length": 218346,
+            "title": "\u30de\u30fb\u30b7\u30a7\u30ea",
+            "video": false
+          },
+          "title": "\u30de\u30fb\u30b7\u30a7\u30ea"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "b8164ce8-c85b-4ce5-bc2c-376b301cc4b3",
+          "length": 185093,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "5e3a930e-965d-438e-b4f9-9da40f623bb4",
+            "isrcs": [
+              "JPPO01900895"
+            ],
+            "length": 185093,
+            "title": "\u99c6\u3051\u843d\u3061\u8005",
+            "video": false
+          },
+          "title": "\u99c6\u3051\u843d\u3061\u8005"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "b06b4973-4f5f-41fc-9c89-b352a8260f01",
+          "length": 140680,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "5aab17cd-af63-481c-ab05-33a7a393b624",
+            "isrcs": [
+              "JPPO01900896"
+            ],
+            "length": 140680,
+            "title": "\u3069\u3093\u5e95\u307e\u3067",
+            "video": false
+          },
+          "title": "\u3069\u3093\u5e95\u307e\u3067"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "42b9669e-ee9f-4b8e-aece-e77104f3d6ac",
+          "length": 217960,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "63eba6a3-82b1-4952-9602-8a3accbb566b",
+            "isrcs": [
+              "JPPO01900897"
+            ],
+            "length": 217960,
+            "title": "\u795e\u69d8\u3001\u4ecf\u69d8",
+            "video": false
+          },
+          "title": "\u795e\u69d8\u3001\u4ecf\u69d8"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "9b5babc5-d8d5-49ac-9a86-806fb6a78a60",
+          "length": 223600,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "1fd4f588-1f24-4634-bb69-4b095e705c67",
+            "isrcs": [
+              "JPPO01900898"
+            ],
+            "length": 223600,
+            "title": "Tokyo",
+            "video": false
+          },
+          "title": "TOKYO"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "9355cbf9-ab24-45ce-b1fc-e2715b516f62",
+          "length": 249173,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2015-07-10",
+            "id": "92236c0d-c0ed-474b-aba5-8d2ab22b3233",
+            "isrcs": [
+              "JPPO01900899"
+            ],
+            "length": 249173,
+            "title": "\u9577\u304f\u77ed\u3044\u796d",
+            "video": false
+          },
+          "title": "\u9577\u304f\u77ed\u3044\u796d"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "fc2b29c1-918d-47c1-8a87-f08ca64877c1",
+          "length": 248640,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2015-02-25",
+            "id": "ed2e131d-cc85-4f7b-8cae-0320dc15984a",
+            "isrcs": [
+              "JPPO01500003"
+            ],
+            "length": 248640,
+            "title": "\u81f3\u4e0a\u306e\u4eba\u751f",
+            "video": false
+          },
+          "title": "\u81f3\u4e0a\u306e\u4eba\u751f"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "04542afb-48a2-4e8f-85ea-bdbaea2d343e",
+          "length": 176026,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "0afa9676-8c2d-4935-929c-6a9e0b238a15",
+            "isrcs": [
+              "JPPO01900900"
+            ],
+            "length": 176026,
+            "title": "\u6025\u304c\u3070\u56de\u308c",
+            "video": false
+          },
+          "title": "\u6025\u304c\u3070\u56de\u308c"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "5293d613-9f2d-45b5-b18a-040a6bb186f5",
+          "length": 176933,
+          "number": "11",
+          "position": 11,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "1d82d914-d60d-4d58-9329-df9d74cf6e1e",
+            "isrcs": [
+              "JPPO01900901"
+            ],
+            "length": 176933,
+            "title": "\u30b8\u30e6\u30fc\u30c0\u30e0",
+            "video": false
+          },
+          "title": "\u30b8\u30e6\u30fc\u30c0\u30e0"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
+            }
+          ],
+          "id": "c1c0b3d4-c9b9-40e0-abde-072a33736a5c",
+          "length": 193280,
+          "number": "12",
+          "position": 12,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "04bdcd96-31de-466a-a554-8096bdbd7665",
+            "isrcs": [
+              "JPPO01900902"
+            ],
+            "length": 193280,
+            "title": "\u76ee\u629c\u304d\u901a\u308a",
+            "video": false
+          },
+          "title": "\u76ee\u629c\u304d\u901a\u308a"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "JP",
+                "disambiguation": "",
+                "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                "name": "\u690e\u540d\u6797\u6a8e",
+                "sort-name": "Sheena, Ringo",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "\u690e\u540d\u6797\u6a8e"
             }
           ],
           "id": "39d0f534-c521-4607-a68a-d48ea8567fe7",
+          "length": 181266,
+          "number": "13",
+          "position": 13,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "JP",
+                  "disambiguation": "",
+                  "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+                  "name": "\u690e\u540d\u6797\u6a8e",
+                  "sort-name": "Sheena, Ringo",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "\u690e\u540d\u6797\u6a8e"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2019-05-27",
+            "id": "1b82aab5-431b-433c-ab15-b626b80b0e04",
+            "isrcs": [
+              "JPPO01900903"
+            ],
+            "length": 181266,
+            "title": "\u3042\u306e\u4e16\u306e\u9580",
+            "video": false
+          },
           "title": "\u3042\u306e\u4e16\u306e\u9580"
         }
-      ],
-      "track-count": 13
+      ]
     }
   ],
-  "disambiguation": "\u521d\u56de\u9650\u5b9a\u751f\u7523\u76e4",
+  "packaging": null,
+  "packaging-id": null,
   "quality": "normal",
-  "artist-credit": [
+  "release-events": [
     {
-      "name": "\u690e\u540d\u6797\u6a8e",
-      "joinphrase": "",
-      "artist": {
-        "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
-        "name": "\u690e\u540d\u6797\u6a8e",
-        "type": "Person",
+      "area": {
         "disambiguation": "",
-        "country": "JP",
-        "sort-name": "Sheena, Ringo",
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-      }
+        "id": "2db42837-c832-3c27-b4a3-08198f75693c",
+        "iso-3166-1-codes": [
+          "JP"
+        ],
+        "name": "Japan",
+        "sort-name": "Japan",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2019-05-27"
     }
   ],
-  "id": "4fdf1514-5876-4e62-bf1e-afd7cc873392",
-  "barcode": "4988031329207",
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "JP",
+          "disambiguation": "",
+          "id": "9e414497-23b7-4ab7-9ec6-8ea9864c9e87",
+          "name": "\u690e\u540d\u6797\u6a8e",
+          "sort-name": "Sheena, Ringo",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "",
+        "name": "\u690e\u540d\u6797\u6a8e"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2019-05-27",
+    "id": "397121b6-85c7-4b9a-970c-be7fdc40eb58",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "\u4e09\u6bd2\u53f2"
+  },
+  "status": "Official",
   "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "date": "2019-05-27"
+  "text-representation": {
+    "language": "jpn",
+    "script": "Jpan"
+  },
+  "title": "\u4e09\u6bd2\u53f2"
 }

--- a/scripts/eval_matching/corpus/eval_release_5c62d977.json
+++ b/scripts/eval_matching/corpus/eval_release_5c62d977.json
@@ -1,802 +1,802 @@
 {
-  "release-events": [
+  "artist-credit": [
     {
-      "area": {
-        "sort-name": "United States",
-        "type": null,
-        "name": "United States",
-        "type-id": null,
-        "id": "489ce91b-6658-3307-9877-795b68554c98",
-        "iso-3166-1-codes": [
-          "US"
-        ],
-        "disambiguation": ""
+      "artist": {
+        "country": "SE",
+        "disambiguation": "Swedish pop group",
+        "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+        "name": "ABBA",
+        "sort-name": "ABBA",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
-      "date": ""
+      "joinphrase": "",
+      "name": "ABBA"
     }
   ],
-  "disambiguation": "silver faced",
-  "status": "Official",
+  "asin": null,
+  "barcode": "075678151323",
+  "country": "US",
   "cover-art-archive": {
+    "artwork": true,
     "back": true,
     "count": 4,
-    "artwork": true,
     "darkened": false,
     "front": false
   },
-  "title": "Greatest Hits",
-  "barcode": "075678151323",
+  "date": "",
+  "disambiguation": "silver faced",
+  "id": "5c62d977-f527-42c0-80db-c1a6ff17841e",
+  "label-info": [
+    {
+      "catalog-number": "19114-2",
+      "label": {
+        "disambiguation": "Warner Music imprint",
+        "id": "50c384a2-0b44-401b-b893-8181173339c7",
+        "label-code": 121,
+        "name": "Atlantic",
+        "sort-name": "Atlantic",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    }
+  ],
   "media": [
     {
+      "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "a2e02101-4b57-3026-82e0-96f5afd236f9",
       "position": 1,
       "title": "",
       "track-count": 14,
-      "format": "CD",
+      "track-offset": 0,
       "tracks": [
         {
-          "number": "1",
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "ABBA",
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "ABBA",
+                "country": "SE",
                 "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
+                "sort-name": "ABBA",
                 "type": "Group",
-                "country": "SE"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "ABBA",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "ABBA"
             }
           ],
+          "id": "56249bf6-22d5-4dad-89fb-651fa37694c4",
+          "length": 200333,
+          "number": "1",
+          "position": 1,
           "recording": {
             "artist-credit": [
               {
-                "name": "ABBA",
                 "artist": {
-                  "name": "ABBA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "sort-name": "ABBA",
                   "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
                   "type": "Group",
-                  "disambiguation": "Swedish pop group"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "ABBA"
               }
             ],
-            "first-release-date": "1975-04-21",
             "disambiguation": "album version",
-            "length": 202000,
+            "first-release-date": "1975-04-21",
             "id": "f2ada1c9-fa39-4d15-aa11-9bd798a885a9",
-            "title": "SOS",
             "isrcs": [
               "SEAYD7501040",
               "SEAYD7515070",
               "SEUV71000403",
               "USAT20612056"
             ],
+            "length": 202000,
+            "title": "SOS",
             "video": false
           },
-          "position": 1,
-          "title": "SOS",
-          "id": "56249bf6-22d5-4dad-89fb-651fa37694c4",
-          "length": 200333
+          "title": "SOS"
         },
         {
-          "number": "2",
           "artist-credit": [
             {
-              "name": "ABBA",
               "artist": {
-                "disambiguation": "Swedish pop group",
-                "type": "Group",
                 "country": "SE",
+                "disambiguation": "Swedish pop group",
                 "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
                 "sort-name": "ABBA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "ABBA"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "ABBA"
             }
           ],
-          "position": 2,
-          "title": "He Is Your Brother",
-          "length": 198333,
           "id": "ff5403c7-a4d1-44fd-81d8-887fdad3a2c3",
+          "length": 198333,
+          "number": "2",
+          "position": 2,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "disambiguation": "Swedish pop group",
-                  "type": "Group",
                   "country": "SE",
+                  "disambiguation": "Swedish pop group",
                   "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
                   "sort-name": "ABBA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "ABBA"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "ABBA"
               }
             ],
-            "first-release-date": "1972-11-01",
             "disambiguation": "",
-            "title": "He Is Your Brother",
-            "video": false,
+            "first-release-date": "1972-11-01",
+            "id": "37ceefad-4163-4932-9de3-c82e9876eff0",
             "isrcs": [
               "SEAYD7301090"
             ],
             "length": 199373,
-            "id": "37ceefad-4163-4932-9de3-c82e9876eff0"
-          }
+            "title": "He Is Your Brother",
+            "video": false
+          },
+          "title": "He Is Your Brother"
         },
         {
-          "number": "3",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "disambiguation": "Swedish pop group",
-                "type": "Group",
                 "country": "SE",
+                "disambiguation": "Swedish pop group",
                 "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
                 "sort-name": "ABBA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "ABBA"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "ABBA"
             }
           ],
+          "id": "be9e619e-f62b-41ed-8ad8-3e6db80b7610",
+          "length": 186333,
+          "number": "3",
+          "position": 3,
           "recording": {
-            "first-release-date": "1973-03-26",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "ABBA",
                 "artist": {
-                  "disambiguation": "Swedish pop group",
                   "country": "SE",
-                  "type": "Group",
+                  "disambiguation": "Swedish pop group",
                   "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "sort-name": "ABBA",
                   "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "ABBA"
               }
             ],
+            "disambiguation": "English version",
+            "first-release-date": "1973-03-26",
             "id": "692a0e1e-0b76-47f1-b3f9-f70c15451979",
-            "length": 185000,
-            "video": false,
             "isrcs": [
               "SEAYD7301010",
               "SEAYD7315160",
               "SEAYD7390001"
             ],
+            "length": 185000,
             "title": "Ring Ring",
-            "disambiguation": "English version"
+            "video": false
           },
-          "title": "Ring Ring",
-          "position": 3,
-          "length": 186333,
-          "id": "be9e619e-f62b-41ed-8ad8-3e6db80b7610"
+          "title": "Ring Ring"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "Swedish pop group",
                 "country": "SE",
-                "type": "Group",
+                "disambiguation": "Swedish pop group",
                 "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "sort-name": "ABBA",
                 "name": "ABBA",
+                "sort-name": "ABBA",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "ABBA",
-              "joinphrase": ""
-            }
-          ],
-          "number": "4",
-          "id": "5d086efa-8323-483f-998c-aff5fe4a0549",
-          "length": 192133,
-          "position": 4,
-          "title": "Another Town, Another Train",
-          "recording": {
-            "video": false,
-            "isrcs": [
-              "SEAYD7301020"
-            ],
-            "title": "Another Town, Another Train",
-            "id": "49fa64ab-c150-403f-a7c7-e6cd013dc006",
-            "length": 193066,
-            "disambiguation": "",
-            "first-release-date": "1973-03-26",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "ABBA",
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "sort-name": "ABBA",
-                  "type": "Group",
-                  "country": "SE",
-                  "disambiguation": "Swedish pop group"
-                },
-                "name": "ABBA"
-              }
-            ]
-          }
-        },
-        {
-          "number": "5",
-          "artist-credit": [
-            {
               "joinphrase": "",
-              "artist": {
-                "name": "ABBA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "sort-name": "ABBA",
-                "country": "SE",
-                "type": "Group",
-                "disambiguation": "Swedish pop group"
-              },
               "name": "ABBA"
             }
           ],
+          "id": "5d086efa-8323-483f-998c-aff5fe4a0549",
+          "length": 192133,
+          "number": "4",
+          "position": 4,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1973-03-26",
+            "id": "49fa64ab-c150-403f-a7c7-e6cd013dc006",
+            "isrcs": [
+              "SEAYD7301020"
+            ],
+            "length": 193066,
+            "title": "Another Town, Another Train",
+            "video": false
+          },
+          "title": "Another Town, Another Train"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "SE",
+                "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
+                "sort-name": "ABBA",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "ABBA"
+            }
+          ],
+          "id": "5d385878-7269-486d-9f38-df8846c0943a",
+          "length": 175000,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1974-03-04",
             "id": "41ddb95e-2c40-4098-a900-753b5e51ed56",
-            "length": 176773,
             "isrcs": [
               "SEA017400030",
               "SEAYD7415040",
               "SEAYD7423170",
               "SEAYD7490003"
             ],
-            "video": false,
+            "length": 176773,
             "title": "Honey, Honey",
-            "artist-credit": [
-              {
-                "name": "ABBA",
-                "artist": {
-                  "disambiguation": "Swedish pop group",
-                  "type": "Group",
-                  "country": "SE",
-                  "sort-name": "ABBA",
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "ABBA"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1974-03-04"
+            "video": false
           },
-          "title": "Honey Honey",
-          "position": 5,
-          "id": "5d385878-7269-486d-9f38-df8846c0943a",
-          "length": 175000
+          "title": "Honey Honey"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "SE",
+                "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
+                "sort-name": "ABBA",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "ABBA"
+            }
+          ],
+          "id": "3345c9cf-a4d9-4ff2-900e-1bfb6f652312",
+          "length": 186466,
+          "number": "6",
+          "position": 6,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
             "disambiguation": "",
-            "title": "So Long",
-            "video": false,
+            "first-release-date": "1974-11-18",
+            "id": "3eb4c364-5a4a-4a4b-9bf3-cf1100ff534f",
             "isrcs": [
               "SEA017500020",
               "SEAYD7490002",
               "SEAYD7501110"
             ],
             "length": 186426,
-            "id": "3eb4c364-5a4a-4a4b-9bf3-cf1100ff534f",
-            "artist-credit": [
-              {
-                "name": "ABBA",
-                "artist": {
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "sort-name": "ABBA",
-                  "name": "ABBA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "Swedish pop group",
-                  "country": "SE",
-                  "type": "Group"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1974-11-18"
+            "title": "So Long",
+            "video": false
           },
-          "length": 186466,
-          "id": "3345c9cf-a4d9-4ff2-900e-1bfb6f652312",
-          "position": 6,
-          "title": "So Long",
-          "artist-credit": [
-            {
-              "name": "ABBA",
-              "artist": {
-                "sort-name": "ABBA",
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "ABBA",
-                "disambiguation": "Swedish pop group",
-                "type": "Group",
-                "country": "SE"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "number": "6"
+          "title": "So Long"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "SE",
+                "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
+                "sort-name": "ABBA",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "ABBA"
+            }
+          ],
+          "id": "4c3df460-abdb-4966-b961-16103305aa44",
+          "length": 212000,
+          "number": "7",
+          "position": 7,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1975-04-21",
             "id": "5e0aa7e4-01cb-441c-9fc2-d89e890cb981",
-            "length": 213000,
             "isrcs": [
               "SEAYD7501010",
               "SEAYD7590001"
             ],
-            "video": false,
+            "length": 213000,
             "title": "Mamma Mia",
-            "disambiguation": "",
-            "first-release-date": "1975-04-21",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "ABBA",
-                "artist": {
-                  "country": "SE",
-                  "type": "Group",
-                  "disambiguation": "Swedish pop group",
-                  "name": "ABBA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "sort-name": "ABBA"
-                }
-              }
-            ]
+            "video": false
           },
-          "title": "Mamma Mia",
-          "position": 7,
-          "id": "4c3df460-abdb-4966-b961-16103305aa44",
-          "length": 212000,
-          "number": "7",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "ABBA",
-              "artist": {
-                "disambiguation": "Swedish pop group",
-                "type": "Group",
-                "country": "SE",
-                "sort-name": "ABBA",
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "ABBA"
-              }
-            }
-          ]
+          "title": "Mamma Mia"
         },
         {
           "artist-credit": [
             {
-              "name": "ABBA",
               "artist": {
-                "disambiguation": "Swedish pop group",
                 "country": "SE",
-                "type": "Group",
+                "disambiguation": "Swedish pop group",
                 "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "sort-name": "ABBA",
                 "name": "ABBA",
+                "sort-name": "ABBA",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "ABBA"
             }
           ],
+          "id": "bea6e013-0ba3-4652-a24a-34217b32992b",
+          "length": 197000,
           "number": "8",
+          "position": 8,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1975-04-21",
             "id": "945e970d-6658-4d3b-ab89-7332057e1638",
-            "length": 197226,
-            "video": false,
             "isrcs": [
               "SEA017500030",
               "SEAYD7501070",
               "SEAYD7590003"
             ],
+            "length": 197226,
             "title": "I Do, I Do, I Do, I Do, I Do",
-            "disambiguation": "",
-            "first-release-date": "1975-04-21",
-            "artist-credit": [
-              {
-                "name": "ABBA",
-                "artist": {
-                  "sort-name": "ABBA",
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "ABBA",
-                  "disambiguation": "Swedish pop group",
-                  "type": "Group",
-                  "country": "SE"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "video": false
           },
-          "length": 197000,
-          "id": "bea6e013-0ba3-4652-a24a-34217b32992b",
-          "title": "I Do, I Do, I Do, I Do, I Do",
-          "position": 8
+          "title": "I Do, I Do, I Do, I Do, I Do"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "SE",
+                "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
+                "sort-name": "ABBA",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "ABBA"
+            }
+          ],
+          "id": "59c49c9b-b3a9-4960-861d-0f3c7ec11e00",
+          "length": 163200,
+          "number": "9",
+          "position": 9,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1972-05",
+            "id": "5edf5416-9766-4ad7-9aa5-b8119f55da20",
             "isrcs": [
               "SEA017225010",
               "SEAYD7301040"
             ],
-            "title": "People Need Love",
-            "id": "5edf5416-9766-4ad7-9aa5-b8119f55da20",
             "length": 165640,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "ABBA",
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "name": "ABBA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "Swedish pop group",
-                  "country": "SE",
-                  "type": "Group"
-                },
-                "name": "ABBA"
-              }
-            ],
-            "first-release-date": "1972-05"
+            "title": "People Need Love",
+            "video": false
           },
-          "id": "59c49c9b-b3a9-4960-861d-0f3c7ec11e00",
-          "length": 163200,
-          "title": "People Need Love",
-          "position": 9,
+          "title": "People Need Love"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "ABBA",
+                "country": "SE",
+                "disambiguation": "Swedish pop group",
                 "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
                 "sort-name": "ABBA",
                 "type": "Group",
-                "country": "SE",
-                "disambiguation": "Swedish pop group"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "ABBA"
             }
           ],
-          "number": "9"
-        },
-        {
-          "position": 10,
-          "title": "Waterloo",
-          "length": 162000,
           "id": "dafd7b26-2bdb-44d9-aa8e-412315b5336a",
+          "length": 162000,
+          "number": "10",
+          "position": 10,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
+            "disambiguation": "English version",
+            "first-release-date": "1974-03-04",
             "id": "bfdcfb41-167c-4f5b-b163-bde83bbf69ac",
-            "length": 166000,
-            "video": false,
             "isrcs": [
               "SEA017400010",
               "SEAYD7415010",
               "SEAYD8603110"
             ],
+            "length": 166000,
             "title": "Waterloo",
-            "disambiguation": "English version",
-            "first-release-date": "1974-03-04",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "ABBA",
-                "artist": {
-                  "country": "SE",
-                  "type": "Group",
-                  "disambiguation": "Swedish pop group",
-                  "name": "ABBA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "ABBA",
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8"
-                }
-              }
-            ]
+            "video": false
           },
-          "number": "10",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "country": "SE",
-                "type": "Group",
-                "disambiguation": "Swedish pop group",
-                "name": "ABBA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "sort-name": "ABBA"
-              },
-              "name": "ABBA"
-            }
-          ]
+          "title": "Waterloo"
         },
         {
-          "recording": {
-            "artist-credit": [
-              {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "SE",
+                "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
                 "name": "ABBA",
-                "artist": {
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "sort-name": "ABBA",
-                  "name": "ABBA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "Swedish pop group",
-                  "country": "SE",
-                  "type": "Group"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1973-03-26",
-            "disambiguation": "",
-            "isrcs": [
-              "SEAYD7301060"
-            ],
-            "video": false,
-            "title": "Nina, Pretty Ballerina",
-            "id": "0942bd0c-c430-493c-bb80-8f366e5c99cd",
-            "length": 173000
-          },
-          "title": "Nina Pretty Ballerina",
-          "position": 11,
+                "sort-name": "ABBA",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "ABBA"
+            }
+          ],
           "id": "02b071a7-2b05-4c10-8d61-32381817d1a5",
           "length": 171466,
           "number": "11",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "ABBA",
-              "artist": {
-                "country": "SE",
-                "type": "Group",
-                "disambiguation": "Swedish pop group",
-                "name": "ABBA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "ABBA",
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8"
-              }
-            }
-          ]
-        },
-        {
+          "position": 11,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "ABBA",
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
                   "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
                   "sort-name": "ABBA",
                   "type": "Group",
-                  "country": "SE",
-                  "disambiguation": "Swedish pop group"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "ABBA",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "ABBA"
               }
             ],
-            "first-release-date": "1975-04-21",
             "disambiguation": "",
-            "title": "Bang\u2010a\u2010Boomerang",
+            "first-release-date": "1973-03-26",
+            "id": "0942bd0c-c430-493c-bb80-8f366e5c99cd",
+            "isrcs": [
+              "SEAYD7301060"
+            ],
+            "length": 173000,
+            "title": "Nina, Pretty Ballerina",
+            "video": false
+          },
+          "title": "Nina Pretty Ballerina"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "SE",
+                "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
+                "sort-name": "ABBA",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "ABBA"
+            }
+          ],
+          "id": "408fae48-f8ec-4870-b3d0-c788d1efe45b",
+          "length": 184400,
+          "number": "12",
+          "position": 12,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1975-04-21",
+            "id": "80ae37e0-667d-48ba-9121-492acb447610",
             "isrcs": [
               "SEAYD7501060"
             ],
-            "video": false,
             "length": 184880,
-            "id": "80ae37e0-667d-48ba-9121-492acb447610"
+            "title": "Bang\u2010a\u2010Boomerang",
+            "video": false
           },
-          "length": 184400,
-          "id": "408fae48-f8ec-4870-b3d0-c788d1efe45b",
-          "title": "Bang-a-Boomerang",
-          "position": 12,
+          "title": "Bang-a-Boomerang"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
                 "country": "SE",
-                "type": "Group",
                 "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
                 "name": "ABBA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "sort-name": "ABBA"
-              },
-              "name": "ABBA",
-              "joinphrase": ""
-            }
-          ],
-          "number": "12"
-        },
-        {
-          "number": "13",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "ABBA",
-              "artist": {
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
                 "sort-name": "ABBA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "ABBA",
-                "disambiguation": "Swedish pop group",
                 "type": "Group",
-                "country": "SE"
-              }
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "ABBA"
             }
           ],
+          "id": "c1317b62-32e2-467c-a6eb-72352a568a41",
+          "length": 193493,
+          "number": "13",
+          "position": 13,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type": "Group",
                   "country": "SE",
                   "disambiguation": "Swedish pop group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "ABBA",
                   "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "sort-name": "ABBA"
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "ABBA",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "ABBA"
               }
             ],
-            "first-release-date": "1974-03-04",
             "disambiguation": "",
-            "title": "Dance (While the Music Still Goes On)",
-            "video": false,
+            "first-release-date": "1974-03-04",
+            "id": "23662e92-e9c0-4300-8285-873f38a35010",
             "isrcs": [
               "SEAYD7401060"
             ],
             "length": 192933,
-            "id": "23662e92-e9c0-4300-8285-873f38a35010"
+            "title": "Dance (While the Music Still Goes On)",
+            "video": false
           },
-          "position": 13,
-          "title": "Dance (While the Music Still Goes On)",
-          "length": 193493,
-          "id": "c1317b62-32e2-467c-a6eb-72352a568a41"
+          "title": "Dance (While the Music Still Goes On)"
         },
         {
-          "length": 248840,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "SE",
+                "disambiguation": "Swedish pop group",
+                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                "name": "ABBA",
+                "sort-name": "ABBA",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "ABBA"
+            }
+          ],
           "id": "9cea40fe-0164-4db7-a272-2a5dff3a1e82",
+          "length": 248840,
+          "number": "14",
           "position": 14,
-          "title": "Fernando",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "SE",
+                  "disambiguation": "Swedish pop group",
+                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+                  "name": "ABBA",
+                  "sort-name": "ABBA",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "ABBA"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1976-03-16",
+            "id": "f9a74bed-c572-43da-8eb5-babc4aee8ffa",
             "isrcs": [
               "SEAYD7503010",
               "SEAYD7602070",
               "SEAYD7602071"
             ],
-            "video": false,
-            "title": "Fernando",
-            "id": "f9a74bed-c572-43da-8eb5-babc4aee8ffa",
             "length": 254000,
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "ABBA",
-                  "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "ABBA",
-                  "disambiguation": "Swedish pop group",
-                  "type": "Group",
-                  "country": "SE"
-                },
-                "name": "ABBA",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1976-03-16"
+            "title": "Fernando",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "ABBA",
-              "artist": {
-                "disambiguation": "Swedish pop group",
-                "type": "Group",
-                "country": "SE",
-                "sort-name": "ABBA",
-                "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "ABBA"
-              }
-            }
-          ],
-          "number": "14"
+          "title": "Fernando"
         }
-      ],
-      "track-offset": 0
+      ]
     }
   ],
-  "country": "US",
   "packaging": "Jewel Case",
   "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "asin": null,
-  "date": "",
-  "label-info": [
+  "quality": "normal",
+  "release-events": [
     {
-      "catalog-number": "19114-2",
-      "label": {
-        "label-code": 121,
-        "disambiguation": "Warner Music imprint",
-        "type": "Imprint",
-        "id": "50c384a2-0b44-401b-b893-8181173339c7",
-        "sort-name": "Atlantic",
-        "name": "Atlantic",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
-      }
+      "area": {
+        "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
+        "iso-3166-1-codes": [
+          "US"
+        ],
+        "name": "United States",
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
+      },
+      "date": ""
     }
   ],
-  "quality": "normal",
-  "id": "5c62d977-f527-42c0-80db-c1a6ff17841e",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "SE",
+          "disambiguation": "Swedish pop group",
+          "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
+          "name": "ABBA",
+          "sort-name": "ABBA",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "ABBA"
+      }
+    ],
     "disambiguation": "",
+    "first-release-date": "1975-11-17",
+    "id": "763dbe66-d5fb-332e-8b2d-599f8b272edc",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
     "secondary-type-ids": [
       "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
     ],
-    "id": "763dbe66-d5fb-332e-8b2d-599f8b272edc",
-    "primary-type": "Album",
-    "title": "Greatest Hits",
     "secondary-types": [
       "Compilation"
     ],
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "artist-credit": [
-      {
-        "joinphrase": "",
-        "name": "ABBA",
-        "artist": {
-          "country": "SE",
-          "type": "Group",
-          "disambiguation": "Swedish pop group",
-          "name": "ABBA",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-          "sort-name": "ABBA"
-        }
-      }
-    ],
-    "first-release-date": "1975-11-17"
+    "title": "Greatest Hits"
   },
-  "artist-credit": [
-    {
-      "joinphrase": "",
-      "name": "ABBA",
-      "artist": {
-        "id": "d87e52c5-bb8d-4da8-b941-9f4928627dc8",
-        "sort-name": "ABBA",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "name": "ABBA",
-        "disambiguation": "Swedish pop group",
-        "type": "Group",
-        "country": "SE"
-      }
-    }
-  ],
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  }
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Greatest Hits"
 }

--- a/scripts/eval_matching/corpus/eval_release_5c976ee2.json
+++ b/scripts/eval_matching/corpus/eval_release_5c976ee2.json
@@ -1,50 +1,87 @@
 {
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "GB",
+        "disambiguation": "",
+        "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+        "name": "Fleetwood Mac",
+        "sort-name": "Fleetwood Mac",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Fleetwood Mac"
+    }
+  ],
+  "asin": "B00AGKHEUI",
+  "barcode": "081227970949",
+  "country": "US",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": false,
+    "count": 19,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2013-01-29",
+  "disambiguation": "2013 deluxe edition",
+  "id": "5c976ee2-d4d4-4932-8f16-54f2b50f8ac5",
+  "label-info": [
+    {
+      "catalog-number": "R2-532752",
+      "label": null
+    }
+  ],
   "media": [
     {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "ffa5a7d5-b7b8-3341-a8c1-ed3fbb3c0edf",
       "position": 1,
       "title": "",
-      "id": "ffa5a7d5-b7b8-3341-a8c1-ed3fbb3c0edf",
-      "format": "CD",
+      "track-count": 12,
       "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
               "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
                 "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
-          "number": "1",
-          "length": 176306,
           "id": "9817b5ec-1202-4cab-b21c-0d561d52a52e",
+          "length": 176306,
+          "number": "1",
+          "position": 1,
           "recording": {
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
                 "artist": {
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "title": "Second Hand News",
-            "id": "b25f351b-206f-4297-95bd-78459b704144",
             "disambiguation": "extra \u201cyeah yeah\u201d at end",
+            "first-release-date": "1977",
+            "id": "b25f351b-206f-4297-95bd-78459b704144",
             "isrcs": [
               "USWB10101367",
               "USWB10202616",
@@ -52,19 +89,50 @@
               "USWB11301110",
               "USWB19900177"
             ],
-            "first-release-date": "1977",
-            "video": false,
-            "length": 173666
+            "length": 173666,
+            "title": "Second Hand News",
+            "video": false
           },
-          "title": "Second Hand News",
-          "position": 1
+          "title": "Second Hand News"
         },
         {
-          "title": "Dreams",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "0fdb7d8f-9f35-453e-b4ef-4b5cf8f68c77",
+          "length": 257800,
+          "number": "2",
           "position": 2,
           "recording": {
-            "title": "Dreams",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1977-02-04",
             "id": "248cc9d1-97ea-493e-84d4-4c5ec718683b",
             "isrcs": [
               "USRH11802580",
@@ -74,66 +142,50 @@
               "USWB11301111",
               "USWB19900178"
             ],
-            "first-release-date": "1977-02-04",
-            "video": false,
             "length": 257000,
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "artist": {
-                  "country": "GB",
-                  "type": "Group",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "title": "Dreams",
+            "video": false
           },
-          "id": "0fdb7d8f-9f35-453e-b4ef-4b5cf8f68c77",
-          "length": 257800,
-          "number": "2",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": ""
-              },
-              "joinphrase": "",
-              "name": "Fleetwood Mac"
-            }
-          ]
+          "title": "Dreams"
         },
         {
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
               "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
                 "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "number": "3",
-          "length": 134400,
           "id": "f52328dc-ed60-467d-b2ec-4149e86bc2fb",
+          "length": 134400,
+          "number": "3",
           "position": 3,
           "recording": {
-            "title": "Never Going Back Again",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977",
             "id": "0b304971-9f84-485b-9f34-50f12004cf0d",
             "isrcs": [
               "USWB10101369",
@@ -142,50 +194,51 @@
               "USWB11301112",
               "USWB19900179"
             ],
-            "disambiguation": "",
             "length": 134426,
-            "video": false,
-            "first-release-date": "1977",
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "country": "GB"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "title": "Never Going Back Again",
+            "video": false
           },
           "title": "Never Going Back Again"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "8e347ba0-69bb-4e73-b585-0f8e0a997b72",
           "length": 193346,
+          "number": "4",
           "position": 4,
           "recording": {
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
                 "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "title": "Don\u2019t Stop",
-            "id": "1c0a78be-b883-4c5d-93f2-4f48405dbcb2",
             "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "1c0a78be-b883-4c5d-93f2-4f48405dbcb2",
             "isrcs": [
               "USRH11802582",
               "USWB10101370",
@@ -194,66 +247,51 @@
               "USWB11301113",
               "USWB19900180"
             ],
-            "first-release-date": "1977-02-04",
-            "video": false,
-            "length": 192666
+            "length": 192666,
+            "title": "Don\u2019t Stop",
+            "video": false
           },
-          "title": "Don\u2019t Stop",
-          "id": "8e347ba0-69bb-4e73-b585-0f8e0a997b72",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "name": "Fleetwood Mac"
-            }
-          ],
-          "number": "4"
+          "title": "Don\u2019t Stop"
         },
         {
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
               "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
                 "country": "GB",
-                "type": "Group"
-              }
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "number": "5",
+          "id": "8803d469-1a0d-4244-9b62-3f328908d828",
           "length": 223613,
-          "title": "Go Your Own Way",
+          "number": "5",
+          "position": 5,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac",
                   "country": "GB",
-                  "type": "Group",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "disambiguation": "",
-                  "sort-name": "Fleetwood Mac"
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "id": "66908b7f-050f-4e8d-82b0-a768a3d80c63",
             "disambiguation": "",
+            "first-release-date": "1976-12-20",
+            "id": "66908b7f-050f-4e8d-82b0-a768a3d80c63",
             "isrcs": [
               "USLIC0601867",
               "USRE11000837",
@@ -264,52 +302,50 @@
               "USWB11301114",
               "USWB19900181"
             ],
-            "title": "Go Your Own Way",
             "length": 219373,
-            "first-release-date": "1976-12-20",
+            "title": "Go Your Own Way",
             "video": false
           },
-          "position": 5,
-          "id": "8803d469-1a0d-4244-9b62-3f328908d828"
+          "title": "Go Your Own Way"
         },
         {
-          "number": "6",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "type": "Group",
                 "country": "GB",
-                "sort-name": "Fleetwood Mac",
                 "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
           "id": "3294d126-b507-4439-86cc-0f6d719ef1fc",
+          "length": 200813,
+          "number": "6",
           "position": 6,
           "recording": {
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
                 "artist": {
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "sort-name": "Fleetwood Mac",
                   "country": "GB",
-                  "type": "Group",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "length": 200813,
+            "disambiguation": "",
             "first-release-date": "1977-02-04",
-            "video": false,
             "id": "70b64435-e956-4141-9149-789b19ebcf9f",
             "isrcs": [
               "USWB10101378",
@@ -319,17 +355,51 @@
               "USWB11301115",
               "USWB19900182"
             ],
-            "disambiguation": "",
-            "title": "Songbird"
+            "length": 200813,
+            "title": "Songbird",
+            "video": false
           },
-          "title": "Songbird",
-          "length": 200813
+          "title": "Songbird"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "5da1b8e0-7d29-4479-a5c0-a4312877c83f",
           "length": 270213,
+          "number": "7",
+          "position": 7,
           "recording": {
-            "id": "cd06c484-9319-4376-a104-504871e19756",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "cd06c484-9319-4376-a104-504871e19756",
             "isrcs": [
               "USRH11802583",
               "USWB10101373",
@@ -338,51 +408,49 @@
               "USWB11301116",
               "USWB19900183"
             ],
-            "title": "The Chain",
             "length": 269400,
-            "video": false,
-            "first-release-date": "1977-02-04",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "type": "Group",
-                  "country": "GB"
-                },
-                "name": "Fleetwood Mac"
-              }
-            ]
+            "title": "The Chain",
+            "video": false
           },
-          "position": 7,
-          "title": "The Chain",
-          "id": "5da1b8e0-7d29-4479-a5c0-a4312877c83f",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac"
-              }
-            }
-          ],
-          "number": "7"
+          "title": "The Chain"
         },
         {
-          "title": "You Make Loving Fun",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "7bc106d5-f4a5-478a-8c0e-f9b3620c0fb5",
+          "length": 216626,
+          "number": "8",
+          "position": 8,
           "recording": {
-            "length": 213106,
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1977-02-04",
             "id": "cce551a1-5a6c-494b-89fe-6dfac5e8aed1",
             "isrcs": [
@@ -392,154 +460,152 @@
               "USWB11301117",
               "USWB19900184"
             ],
-            "disambiguation": "",
+            "length": 213106,
             "title": "You Make Loving Fun",
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
-                "artist": {
-                  "type": "Group",
-                  "country": "GB",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac"
-                }
-              }
-            ]
+            "video": false
           },
-          "position": 8,
-          "id": "7bc106d5-f4a5-478a-8c0e-f9b3620c0fb5",
-          "length": 216626,
-          "number": "8",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group"
-              },
-              "joinphrase": ""
-            }
-          ]
+          "title": "You Make Loving Fun"
         },
         {
-          "number": "9",
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
               "artist": {
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                 "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
+          "id": "1b18589a-0f9e-4878-9650-4c7474c0af24",
+          "length": 196853,
+          "number": "9",
           "position": 9,
-          "title": "I Don\u2019t Want to Know",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977-02-04",
+            "id": "fc53705e-f3d6-4246-b0e3-23d1acc8f1d1",
             "isrcs": [
               "USWB10101375",
               "USWB10400055",
               "USWB11301118",
               "USWB19900185"
             ],
-            "id": "fc53705e-f3d6-4246-b0e3-23d1acc8f1d1",
-            "disambiguation": "",
-            "title": "I Don\u2019t Want to Know",
-            "video": false,
-            "first-release-date": "1977-02-04",
             "length": 195493,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "type": "Group",
-                  "country": "GB",
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Fleetwood Mac"
-              }
-            ]
+            "title": "I Don\u2019t Want to Know",
+            "video": false
           },
-          "id": "1b18589a-0f9e-4878-9650-4c7474c0af24",
-          "length": 196853
+          "title": "I Don\u2019t Want to Know"
         },
         {
-          "number": "10",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "sort-name": "Fleetwood Mac",
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type": "Group",
-                "country": "GB",
                 "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
+          "id": "0be61387-5db1-44f3-ae46-e54a1b661470",
+          "length": 236240,
+          "number": "10",
+          "position": 10,
           "recording": {
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
                 "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "first-release-date": "1977-02-04",
-            "video": false,
-            "length": 236226,
-            "title": "Oh Daddy",
             "disambiguation": "",
+            "first-release-date": "1977-02-04",
             "id": "0c9684a3-1109-44cb-ac8c-808168ae8715",
             "isrcs": [
               "USWB10101376",
               "USWB10400056",
               "USWB11301119",
               "USWB19900186"
-            ]
+            ],
+            "length": 236226,
+            "title": "Oh Daddy",
+            "video": false
           },
-          "position": 10,
-          "title": "Oh Daddy",
-          "id": "0be61387-5db1-44f3-ae46-e54a1b661470",
-          "length": 236240
+          "title": "Oh Daddy"
         },
         {
-          "length": 295626,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
           "id": "b1477367-90b7-44f5-9f04-e25cfaf948ef",
+          "length": 295626,
+          "number": "11",
+          "position": 11,
           "recording": {
-            "length": 302000,
-            "first-release-date": "1977",
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
             "disambiguation": "hard start, glass break, soft howling",
+            "first-release-date": "1977",
             "id": "6eda00db-318c-495b-96a1-494d249b04f5",
             "isrcs": [
               "USWB10101377",
@@ -547,1546 +613,1480 @@
               "USWB11301120",
               "USWB19900187"
             ],
+            "length": 302000,
             "title": "Gold Dust Woman",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group"
-                },
-                "name": "Fleetwood Mac"
-              }
-            ]
+            "video": false
           },
-          "title": "Gold Dust Woman",
-          "position": 11,
+          "title": "Gold Dust Woman"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Fleetwood Mac",
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type": "Group",
-                "country": "GB",
                 "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
-          "number": "11"
-        },
-        {
+          "id": "ea6efd4c-11da-49cb-bccc-9aa71ddc95c0",
+          "length": 288786,
           "number": "12",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
-              "artist": {
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
+          "position": 12,
           "recording": {
-            "first-release-date": "1997",
-            "video": false,
-            "length": 288786,
-            "id": "055423fb-f8e4-4d99-9e96-5bbfb061c1fe",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
             "disambiguation": "long version",
+            "first-release-date": "1997",
+            "id": "055423fb-f8e4-4d99-9e96-5bbfb061c1fe",
             "isrcs": [
               "USWB10101372",
               "USWB10400052",
               "USWB11301121"
             ],
+            "length": 288786,
             "title": "Silver Springs",
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
-                "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "country": "GB"
-                }
-              }
-            ]
+            "video": false
           },
-          "title": "Silver Springs",
-          "position": 12,
-          "id": "ea6efd4c-11da-49cb-bccc-9aa71ddc95c0",
-          "length": 288786
+          "title": "Silver Springs"
         }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "track-count": 12
+      ]
     },
     {
       "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "f73c672e-c709-337a-bc87-6edf53f7ea61",
+      "position": 2,
+      "title": "Live, 1977 \u201cRumours\u201d World Tour",
+      "track-count": 12,
       "track-offset": 0,
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "3ccbf02e-ddb8-43ed-b0c8-171c2e59ae53",
           "length": 48000,
-          "title": "Intro",
+          "number": "1",
           "position": 1,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "country": "GB",
                   "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
                   "type": "Group",
-                  "country": "GB"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "length": 48373,
-            "first-release-date": "2013-01-25",
-            "video": false,
             "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
             "id": "5c969fd7-4bc5-4cd1-b705-ab426121bb72",
             "isrcs": [
               "USRE11000845"
             ],
-            "title": "Intro"
+            "length": 48373,
+            "title": "Intro",
+            "video": false
           },
-          "id": "3ccbf02e-ddb8-43ed-b0c8-171c2e59ae53",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": ""
-              }
-            }
-          ],
-          "number": "1"
+          "title": "Intro"
         },
         {
-          "number": "2",
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "type": "Group",
                 "country": "GB",
-                "sort-name": "Fleetwood Mac",
                 "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "title": "Monday Morning",
+          "id": "a76f5da9-f931-4ada-9e0c-ec7e99c7f0ec",
+          "length": 158000,
+          "number": "2",
+          "position": 2,
           "recording": {
-            "length": 158893,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "live, 1977 Rumours World Tour",
             "first-release-date": "2013-01-25",
-            "video": false,
             "id": "ef365742-09ff-4b9f-8a45-95ed850cc3b0",
             "isrcs": [
               "USRE11000846"
             ],
-            "disambiguation": "live, 1977 Rumours World Tour",
+            "length": 158893,
             "title": "Monday Morning",
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
-                "artist": {
-                  "type": "Group",
-                  "country": "GB",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac"
-                }
-              }
-            ]
+            "video": false
           },
-          "position": 2,
-          "id": "a76f5da9-f931-4ada-9e0c-ec7e99c7f0ec",
-          "length": 158000
+          "title": "Monday Morning"
         },
         {
-          "length": 247000,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
           "id": "01057dac-f2dc-4cd3-8bd2-4df646a8a4f4",
+          "length": 247000,
+          "number": "3",
           "position": 3,
-          "title": "Dreams",
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Fleetwood Mac",
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "country": "GB",
                   "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
+            "disambiguation": "live, 1977 Rumours World Tour",
             "first-release-date": "2013-01-25",
-            "video": false,
-            "length": 247213,
-            "title": "Dreams",
             "id": "ed3bb905-8dff-4168-97fe-8219790c4c37",
             "isrcs": [
               "USRE11000847"
             ],
-            "disambiguation": "live, 1977 Rumours World Tour"
+            "length": 247213,
+            "title": "Dreams",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
-              "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group"
-              }
-            }
-          ],
-          "number": "3"
+          "title": "Dreams"
         },
         {
-          "length": 231000,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
           "id": "17fcdb8f-cf7f-4b27-95b6-bf031864f08c",
+          "length": 231000,
+          "number": "4",
           "position": 4,
           "recording": {
-            "length": 231653,
-            "first-release-date": "2013-01-25",
-            "video": false,
-            "title": "Don\u2019t Stop",
-            "id": "dcc9a547-0e4a-447c-99cb-ab62345a01d8",
-            "disambiguation": "live, 1977 Rumours World Tour",
-            "isrcs": [
-              "USRE11000848"
-            ],
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "type": "Group",
-                  "country": "GB"
-                },
-                "joinphrase": "",
-                "name": "Fleetwood Mac"
-              }
-            ]
-          },
-          "title": "Don\u2019t Stop",
-          "artist-credit": [
-            {
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Fleetwood Mac",
-                "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac"
-              },
-              "joinphrase": "",
-              "name": "Fleetwood Mac"
-            }
-          ],
-          "number": "4"
-        },
-        {
-          "number": "5",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac"
-              }
-            }
-          ],
-          "title": "The Chain",
-          "recording": {
-            "id": "128d15bc-d2ff-4b43-b063-c32091d043ca",
-            "disambiguation": "live, 1977 Rumours World Tour",
-            "isrcs": [
-              "USRE11000849"
-            ],
-            "title": "The Chain",
-            "length": 340533,
-            "first-release-date": "2013-01-25",
-            "video": false,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "sort-name": "Fleetwood Mac",
                   "country": "GB",
-                  "type": "Group"
-                },
-                "name": "Fleetwood Mac"
-              }
-            ]
-          },
-          "position": 5,
-          "id": "fe4b0d43-6e89-4621-bd47-6f19595bac3e",
-          "length": 340000
-        },
-        {
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": ""
-              },
-              "joinphrase": "",
-              "name": "Fleetwood Mac"
-            }
-          ],
-          "number": "6",
-          "length": 287000,
-          "id": "14dab676-6c32-4066-8936-9dea9d37e81b",
-          "title": "Oh Daddy",
-          "position": 6,
-          "recording": {
-            "length": 287866,
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "disambiguation": "live, 1977 Rumours World Tour",
-            "id": "15a6dd88-6284-41d5-8eb7-f9fc350d18a1",
-            "isrcs": [
-              "USRE11000850"
-            ],
-            "title": "Oh Daddy",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "disambiguation": "",
-                  "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
-            ]
-          }
+            ],
+            "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
+            "id": "dcc9a547-0e4a-447c-99cb-ab62345a01d8",
+            "isrcs": [
+              "USRE11000848"
+            ],
+            "length": 231653,
+            "title": "Don\u2019t Stop",
+            "video": false
+          },
+          "title": "Don\u2019t Stop"
         },
         {
-          "number": "7",
           "artist-credit": [
             {
               "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
                 "country": "GB",
-                "type": "Group"
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "fe4b0d43-6e89-4621-bd47-6f19595bac3e",
+          "length": 340000,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
+            "id": "128d15bc-d2ff-4b43-b063-c32091d043ca",
+            "isrcs": [
+              "USRE11000849"
+            ],
+            "length": 340533,
+            "title": "The Chain",
+            "video": false
+          },
+          "title": "The Chain"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "14dab676-6c32-4066-8936-9dea9d37e81b",
+          "length": 287000,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
+            "id": "15a6dd88-6284-41d5-8eb7-f9fc350d18a1",
+            "isrcs": [
+              "USRE11000850"
+            ],
+            "length": 287866,
+            "title": "Oh Daddy",
+            "video": false
+          },
+          "title": "Oh Daddy"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
           "id": "cf14ae79-c65c-402a-b09b-cd70453cf889",
+          "length": 475000,
+          "number": "7",
           "position": 7,
-          "title": "Rhiannon",
           "recording": {
-            "first-release-date": "2013-01-25",
-            "video": false,
-            "length": 475306,
-            "title": "Rhiannon",
-            "id": "f527b625-82b1-4b95-a43e-fbab598ba26e",
-            "disambiguation": "live, 1977 Rumours World Tour",
-            "isrcs": [
-              "USRE11000851"
-            ],
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
                 "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "country": "GB"
-                }
-              }
-            ]
-          },
-          "length": 475000
-        },
-        {
-          "id": "69e00a38-668f-41f6-b8c1-c4e0a8481f0d",
-          "recording": {
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "name": "Fleetwood Mac",
-                  "type": "Group",
-                  "country": "GB",
                   "sort-name": "Fleetwood Mac",
-                  "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "length": 139960,
+            "disambiguation": "live, 1977 Rumours World Tour",
             "first-release-date": "2013-01-25",
-            "video": false,
+            "id": "f527b625-82b1-4b95-a43e-fbab598ba26e",
+            "isrcs": [
+              "USRE11000851"
+            ],
+            "length": 475306,
+            "title": "Rhiannon",
+            "video": false
+          },
+          "title": "Rhiannon"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "69e00a38-668f-41f6-b8c1-c4e0a8481f0d",
+          "length": 139000,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
             "id": "a527daa4-43e4-4a64-8d31-55228cab20dd",
             "isrcs": [
               "USRE11000852"
             ],
-            "disambiguation": "live, 1977 Rumours World Tour",
-            "title": "Never Going Back Again"
+            "length": 139960,
+            "title": "Never Going Back Again",
+            "video": false
           },
-          "position": 8,
-          "title": "Never Going Back Again",
-          "length": 139000,
-          "number": "8",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Fleetwood Mac",
-                "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-              },
-              "name": "Fleetwood Mac"
-            }
-          ]
+          "title": "Never Going Back Again"
         },
         {
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "type": "Group",
                 "country": "GB",
-                "sort-name": "Fleetwood Mac",
                 "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-              }
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "number": "9",
-          "length": 423000,
           "id": "e8ba5982-87f3-40f0-8823-c20f50acdeb8",
+          "length": 423000,
+          "number": "9",
+          "position": 9,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "id": "03204c88-b56c-40aa-b0d5-eff471059d8c",
             "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
+            "id": "03204c88-b56c-40aa-b0d5-eff471059d8c",
             "isrcs": [
               "USRE11000853"
             ],
-            "title": "Gold Dust Woman",
             "length": 423053,
-            "video": false,
-            "first-release-date": "2013-01-25"
+            "title": "Gold Dust Woman",
+            "video": false
           },
-          "position": 9,
           "title": "Gold Dust Woman"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "11bd43ed-1fd0-4bb3-80f0-654ed8aa9f2c",
+          "length": 451000,
+          "number": "10",
           "position": 10,
-          "title": "World Turning",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
             "id": "af0ff4af-f7db-4d91-91f4-8edc50e2642d",
             "isrcs": [
               "USRE11000854"
             ],
-            "disambiguation": "live, 1977 Rumours World Tour",
-            "title": "World Turning",
             "length": 451493,
-            "first-release-date": "2013-01-25",
-            "video": false,
+            "title": "World Turning",
+            "video": false
+          },
+          "title": "World Turning"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "b3f2d3dc-9b01-43c8-a9e5-6fc85de580a1",
+          "length": 294000,
+          "number": "11",
+          "position": 11,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac",
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "sort-name": "Fleetwood Mac"
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
-            ]
-          },
-          "id": "11bd43ed-1fd0-4bb3-80f0-654ed8aa9f2c",
-          "length": 451000,
-          "number": "10",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Fleetwood Mac",
-                "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-              },
-              "name": "Fleetwood Mac"
-            }
-          ]
-        },
-        {
-          "id": "b3f2d3dc-9b01-43c8-a9e5-6fc85de580a1",
-          "position": 11,
-          "title": "Go Your Own Way",
-          "recording": {
-            "artist-credit": [
-              {
-                "name": "Fleetwood Mac",
-                "artist": {
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "type": "Group",
-                  "country": "GB",
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "joinphrase": ""
-              }
             ],
+            "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
+            "id": "2fe30d0c-5a66-4350-8825-1d3178854c9f",
             "isrcs": [
               "USRE11000855"
             ],
-            "id": "2fe30d0c-5a66-4350-8825-1d3178854c9f",
-            "disambiguation": "live, 1977 Rumours World Tour",
+            "length": 294466,
             "title": "Go Your Own Way",
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "length": 294466
+            "video": false
           },
-          "length": 294000,
-          "number": "11",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Fleetwood Mac",
-                "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac"
-              },
-              "joinphrase": ""
-            }
-          ]
+          "title": "Go Your Own Way"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
           "id": "181c158e-5bb8-4817-87ed-15725331add6",
+          "length": 240000,
+          "number": "12",
           "position": 12,
-          "title": "Songbird",
           "recording": {
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
                   "country": "GB",
-                  "sort-name": "Fleetwood Mac",
                   "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "length": 240440,
-            "title": "Songbird",
-            "id": "a125c00e-b643-42a4-b28d-336f944d2d99",
             "disambiguation": "live, 1977 Rumours World Tour",
+            "first-release-date": "2013-01-25",
+            "id": "a125c00e-b643-42a4-b28d-336f944d2d99",
             "isrcs": [
               "USRE11000856"
-            ]
+            ],
+            "length": 240440,
+            "title": "Songbird",
+            "video": false
           },
-          "length": 240000,
-          "number": "12",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "type": "Group",
-                "country": "GB",
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "name": "Fleetwood Mac"
-            }
-          ]
+          "title": "Songbird"
         }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "track-count": 12,
-      "position": 2,
-      "title": "Live, 1977 \u201cRumours\u201d World Tour",
-      "id": "f73c672e-c709-337a-bc87-6edf53f7ea61"
+      ]
     },
     {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "2a621e69-18c5-3436-ae9c-7d036b82f6ba",
       "position": 3,
       "title": "More from the Recording Sessions",
-      "id": "2a621e69-18c5-3436-ae9c-7d036b82f6ba",
-      "format": "CD",
+      "track-count": 16,
       "track-offset": 0,
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "tracks": [
         {
-          "number": "1",
           "artist-credit": [
             {
               "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
                 "country": "GB",
-                "type": "Group"
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
           "id": "9b33490d-bc89-418a-b66d-7ba6ab5cf4a9",
+          "length": 146000,
+          "number": "1",
           "position": 1,
-          "title": "Second Hand News (early take)",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
             "id": "4e3ecc28-b60c-4247-ad59-1839242d5d88",
             "isrcs": [
               "USWB11203111"
             ],
-            "title": "Second Hand News (early take)",
             "length": 146746,
-            "first-release-date": "2013-01-25",
-            "video": false,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Fleetwood Mac"
-              }
-            ]
+            "title": "Second Hand News (early take)",
+            "video": false
           },
-          "length": 146000
+          "title": "Second Hand News (early take)"
         },
         {
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
                 "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "number": "2",
+          "id": "badc457b-9821-4825-8209-27c78057cc32",
           "length": 335000,
+          "number": "2",
           "position": 2,
-          "title": "Dreams (take 2)",
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
                   "country": "GB",
-                  "sort-name": "Fleetwood Mac",
                   "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "first-release-date": "2013-01-25",
-            "video": false,
-            "length": 335133,
-            "title": "Dreams (take 2)",
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
             "id": "3020399a-74aa-473b-b508-33ab3119c0a2",
             "isrcs": [
               "USWB11203112"
-            ]
+            ],
+            "length": 335133,
+            "title": "Dreams (take 2)",
+            "video": false
           },
-          "id": "badc457b-9821-4825-8209-27c78057cc32"
+          "title": "Dreams (take 2)"
         },
         {
-          "length": 139000,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
           "id": "259e0ced-ebf3-4925-acce-2dff8a3d183f",
-          "title": "Never Going Back Again (acoustic duet)",
+          "length": 139000,
+          "number": "3",
+          "position": 3,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac",
-                  "type": "Group",
                   "country": "GB",
-                  "sort-name": "Fleetwood Mac",
                   "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "length": 139546,
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
             "id": "3028087a-e64a-4f6c-88c3-2b9fb271764b",
             "isrcs": [
               "USWB11203113"
             ],
-            "title": "Never Going Back Again (acoustic duet)"
+            "length": 139546,
+            "title": "Never Going Back Again (acoustic duet)",
+            "video": false
           },
-          "position": 3,
+          "title": "Never Going Back Again (acoustic duet)"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
                 "country": "GB",
-                "type": "Group",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "sort-name": "Fleetwood Mac"
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
-          "number": "3"
-        },
-        {
+          "id": "5e0fb6f8-c9c4-4a0b-b857-1496fdd6d064",
           "length": 244000,
-          "title": "Go Your Own Way (early take)",
+          "number": "4",
           "position": 4,
           "recording": {
-            "title": "Go Your Own Way (early take)",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
             "id": "121f3c05-ed8b-4ffa-bdff-876f76c9e5b3",
             "isrcs": [
               "USWB11203114"
             ],
             "length": 244573,
-            "first-release-date": "2013-01-25",
-            "video": false,
-            "artist-credit": [
-              {
-                "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "type": "Group",
-                  "country": "GB"
-                },
-                "joinphrase": "",
-                "name": "Fleetwood Mac"
-              }
-            ]
+            "title": "Go Your Own Way (early take)",
+            "video": false
           },
-          "id": "5e0fb6f8-c9c4-4a0b-b857-1496fdd6d064",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Fleetwood Mac",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "type": "Group",
-                "country": "GB"
-              },
-              "name": "Fleetwood Mac"
-            }
-          ],
-          "number": "4"
+          "title": "Go Your Own Way (early take)"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "sort-name": "Fleetwood Mac",
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type": "Group",
-                "country": "GB",
                 "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
-          "number": "5",
+          "id": "28919ef0-ab65-4a8f-9b3b-7305e7e5cc7f",
           "length": 273000,
+          "number": "5",
+          "position": 5,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "country": "GB",
                   "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
                   "type": "Group",
-                  "country": "GB"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "length": 273266,
-            "video": false,
+            "disambiguation": "",
             "first-release-date": "2013-01-25",
-            "title": "Songbird (demo)",
+            "id": "6d2d0efb-ef82-4e73-be11-6634fdefdce8",
             "isrcs": [
               "USWB11203115"
             ],
-            "id": "6d2d0efb-ef82-4e73-be11-6634fdefdce8",
-            "disambiguation": ""
+            "length": 273266,
+            "title": "Songbird (demo)",
+            "video": false
           },
-          "position": 5,
-          "title": "Songbird (demo)",
-          "id": "28919ef0-ab65-4a8f-9b3b-7305e7e5cc7f"
+          "title": "Songbird (demo)"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "type": "Group",
                 "country": "GB",
-                "sort-name": "Fleetwood Mac",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac"
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
-          "number": "6",
+          "id": "3a379b8a-15cf-4c25-8f0d-fcbc8128c4e6",
           "length": 263000,
+          "number": "6",
           "position": 6,
-          "title": "Songbird (instrumental, take 10)",
           "recording": {
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
                 "artist": {
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group",
                   "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "length": 263906,
-            "video": false,
+            "disambiguation": "",
             "first-release-date": "2013-01-25",
-            "title": "Songbird (instrumental, take 10)",
             "id": "b7f69feb-a832-4015-8c9c-c0633d5e80c9",
             "isrcs": [
               "USWB11203116"
             ],
-            "disambiguation": ""
+            "length": 263906,
+            "title": "Songbird (instrumental, take 10)",
+            "video": false
           },
-          "id": "3a379b8a-15cf-4c25-8f0d-fcbc8128c4e6"
+          "title": "Songbird (instrumental, take 10)"
         },
         {
-          "recording": {
-            "title": "I Don\u2019t Want to Know (early take)",
-            "isrcs": [
-              "USWB11203117"
-            ],
-            "id": "b82356f6-2dc5-4159-ad39-b666c3755058",
-            "disambiguation": "",
-            "length": 222173,
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Fleetwood Mac",
-                  "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "type": "Group",
-                  "country": "GB"
-                },
-                "name": "Fleetwood Mac"
-              }
-            ]
-          },
-          "title": "I Don\u2019t Want to Know (early take)",
-          "position": 7,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
           "id": "c72ff76a-d25a-45e1-9aae-0c675d015cb6",
           "length": 222000,
           "number": "7",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "artist": {
-                "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "joinphrase": ""
-            }
-          ]
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-01-25",
+            "id": "b82356f6-2dc5-4159-ad39-b666c3755058",
+            "isrcs": [
+              "USWB11203117"
+            ],
+            "length": 222173,
+            "title": "I Don\u2019t Want to Know (early take)",
+            "video": false
+          },
+          "title": "I Don\u2019t Want to Know (early take)"
         },
         {
-          "length": 314000,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
           "id": "76f46290-dcc5-4323-b576-1a8b8f175fc3",
+          "length": 314000,
+          "number": "8",
           "position": 8,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
                   "country": "GB",
-                  "type": "Group",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "length": 314026,
-            "first-release-date": "2013-01-25",
-            "video": false,
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
             "id": "fe5f6503-a9a4-49f8-8d95-d265efeaf914",
             "isrcs": [
               "USWB11203118"
             ],
-            "title": "Keep Me There (instrumental)"
+            "length": 314026,
+            "title": "Keep Me There (instrumental)",
+            "video": false
           },
-          "title": "Keep Me There (instrumental)",
+          "title": "Keep Me There (instrumental)"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
                 "country": "GB",
-                "type": "Group",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                 "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
                 "sort-name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
-          "number": "8"
-        },
-        {
           "id": "ba479e24-708c-48e1-a4aa-c8a5a98fe2ee",
-          "title": "The Chain (demo)",
+          "length": 329000,
+          "number": "9",
           "position": 9,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "id": "a24937ba-1f16-4aaa-b815-f3fc76591010",
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
+            "id": "a24937ba-1f16-4aaa-b815-f3fc76591010",
             "isrcs": [
               "USWB11203119"
             ],
+            "length": 329133,
             "title": "The Chain (demo)",
-            "first-release-date": "2013-01-25",
-            "video": false,
-            "length": 329133
+            "video": false
           },
-          "length": 329000,
-          "number": "9",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
-              "artist": {
-                "country": "GB",
-                "type": "Group",
-                "disambiguation": "",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "sort-name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac"
-              }
-            }
-          ]
+          "title": "The Chain (demo)"
         },
         {
           "artist-credit": [
             {
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
                 "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
-          "number": "10",
-          "length": 258000,
           "id": "bb0b2280-1ece-4091-b403-e7b2dbddf579",
+          "length": 258000,
+          "number": "10",
+          "position": 10,
           "recording": {
-            "length": 258920,
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "title": "Keep Me There (with vocal)",
-            "id": "db54cde3-8522-4562-9e66-b9ccdeafc581",
-            "disambiguation": "",
-            "isrcs": [
-              "USWB11203120"
-            ],
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac",
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "sort-name": "Fleetwood Mac"
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
-            ]
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-01-25",
+            "id": "db54cde3-8522-4562-9e66-b9ccdeafc581",
+            "isrcs": [
+              "USWB11203120"
+            ],
+            "length": 258920,
+            "title": "Keep Me There (with vocal)",
+            "video": false
           },
-          "position": 10,
           "title": "Keep Me There (with vocal)"
         },
         {
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
               "artist": {
-                "name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
                 "country": "GB",
-                "type": "Group"
-              }
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "number": "11",
+          "id": "7548cf3d-0b2b-4415-a98d-d64670f6d0be",
           "length": 325000,
+          "number": "11",
           "position": 11,
-          "title": "Gold Dust Woman (early take)",
           "recording": {
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac",
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "sort-name": "Fleetwood Mac"
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "title": "Gold Dust Woman (early take)",
+            "disambiguation": "",
+            "first-release-date": "2013-01-25",
+            "id": "dd4e90a3-b9a7-45d1-b946-5813581e500f",
             "isrcs": [
               "USWB11203121"
             ],
-            "id": "dd4e90a3-b9a7-45d1-b946-5813581e500f",
-            "disambiguation": "",
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "length": 325226
+            "length": 325226,
+            "title": "Gold Dust Woman (early take)",
+            "video": false
           },
-          "id": "7548cf3d-0b2b-4415-a98d-d64670f6d0be"
+          "title": "Gold Dust Woman (early take)"
         },
         {
-          "length": 228000,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
           "id": "bc2645cd-363c-4cf3-95ee-24841c939614",
-          "title": "Oh Daddy (early take)",
+          "length": 228000,
+          "number": "12",
           "position": 12,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
             "id": "636431af-26f4-4f65-b58f-010700fee6bf",
             "isrcs": [
               "USWB11203122"
             ],
-            "title": "Oh Daddy (early take)",
             "length": 228413,
-            "video": false,
-            "first-release-date": "2013-01-25",
+            "title": "Oh Daddy (early take)",
+            "video": false
+          },
+          "title": "Oh Daddy (early take)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "686d130b-a833-4f98-8a05-322f224578fd",
+          "length": 331000,
+          "number": "13",
+          "position": 13,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
                   "sort-name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
-            ]
-          },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "country": "GB",
-                "type": "Group",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac"
-              },
-              "name": "Fleetwood Mac"
-            }
-          ],
-          "number": "12"
-        },
-        {
-          "length": 331000,
-          "id": "686d130b-a833-4f98-8a05-322f224578fd",
-          "position": 13,
-          "recording": {
-            "title": "Silver Springs (early take)",
+            ],
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
             "id": "7966eb16-08ab-47ce-903b-d603a58763de",
             "isrcs": [
               "USWB11203123"
             ],
-            "first-release-date": "2013-01-25",
-            "video": false,
             "length": 331720,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Fleetwood Mac"
-              }
-            ]
+            "title": "Silver Springs (early take)",
+            "video": false
           },
-          "title": "Silver Springs (early take)",
-          "artist-credit": [
-            {
-              "name": "Fleetwood Mac",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac"
-              }
-            }
-          ],
-          "number": "13"
+          "title": "Silver Springs (early take)"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
+            }
+          ],
+          "id": "a63b72ab-aedc-4a0a-ab06-0514a41df191",
           "length": 267000,
+          "number": "14",
+          "position": 14,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-01-25",
+            "id": "dcd3dd6d-2fef-405e-9dad-dd1afd755ed7",
             "isrcs": [
               "USWB11203124"
             ],
-            "id": "dcd3dd6d-2fef-405e-9dad-dd1afd755ed7",
-            "disambiguation": "",
-            "title": "Planets of the Universe (demo)",
-            "first-release-date": "2013-01-25",
-            "video": false,
             "length": 267946,
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "sort-name": "Fleetwood Mac",
-                  "country": "GB",
-                  "type": "Group",
-                  "name": "Fleetwood Mac",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "joinphrase": "",
-                "name": "Fleetwood Mac"
-              }
-            ]
+            "title": "Planets of the Universe (demo)",
+            "video": false
           },
-          "title": "Planets of the Universe (demo)",
-          "position": 14,
-          "id": "a63b72ab-aedc-4a0a-ab06-0514a41df191",
+          "title": "Planets of the Universe (demo)"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
                 "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Fleetwood Mac"
             }
           ],
-          "number": "14"
-        },
-        {
+          "id": "9727f58d-ae9a-4f3a-ac6e-b2cf8f6db30e",
+          "length": 63000,
           "number": "15",
-          "artist-credit": [
-            {
-              "artist": {
-                "country": "GB",
-                "type": "Group",
-                "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "disambiguation": "",
-                "sort-name": "Fleetwood Mac",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Fleetwood Mac"
-              },
-              "joinphrase": "",
-              "name": "Fleetwood Mac"
-            }
-          ],
           "position": 15,
-          "title": "Doesn\u2019t Anything Last (acoustic duet)",
           "recording": {
             "artist-credit": [
               {
-                "name": "Fleetwood Mac",
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Fleetwood Mac",
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "",
                   "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "sort-name": "Fleetwood Mac"
-                }
+                  "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Fleetwood Mac"
               }
             ],
-            "length": 63146,
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "title": "Doesn\u2019t Anything Last (acoustic duet)",
-            "id": "de91a419-9ff7-4678-b94b-db4e14f7f738",
             "disambiguation": "",
+            "first-release-date": "2013-01-25",
+            "id": "de91a419-9ff7-4678-b94b-db4e14f7f738",
             "isrcs": [
               "USWB11203125"
-            ]
+            ],
+            "length": 63146,
+            "title": "Doesn\u2019t Anything Last (acoustic duet)",
+            "video": false
           },
-          "id": "9727f58d-ae9a-4f3a-ac6e-b2cf8f6db30e",
-          "length": 63000
+          "title": "Doesn\u2019t Anything Last (acoustic duet)"
         },
         {
           "artist-credit": [
             {
-              "name": "Fleetwood Mac",
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
                 "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                "sort-name": "Fleetwood Mac",
-                "country": "GB",
-                "type": "Group",
                 "name": "Fleetwood Mac",
+                "sort-name": "Fleetwood Mac",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Fleetwood Mac"
             }
           ],
-          "number": "16",
+          "id": "f4876e66-a4b8-4153-b383-e69157d2261a",
           "length": 156000,
+          "number": "16",
           "position": 16,
-          "title": "Never Going Back Again (instrumental)",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Fleetwood Mac",
-                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
-                  "disambiguation": "",
-                  "type": "Group",
                   "country": "GB",
+                  "disambiguation": "",
+                  "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
                   "name": "Fleetwood Mac",
+                  "sort-name": "Fleetwood Mac",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Fleetwood Mac"
               }
             ],
-            "title": "Never Going Back Again (instrumental)",
+            "disambiguation": "",
+            "first-release-date": "2013-01-25",
             "id": "a4cd0f2a-95ba-49bb-ae37-5bfbc6434ed8",
             "isrcs": [
               "USWB11203126"
             ],
-            "disambiguation": "",
-            "video": false,
-            "first-release-date": "2013-01-25",
-            "length": 156893
+            "length": 156893,
+            "title": "Never Going Back Again (instrumental)",
+            "video": false
           },
-          "id": "f4876e66-a4b8-4153-b383-e69157d2261a"
+          "title": "Never Going Back Again (instrumental)"
         }
-      ],
-      "track-count": 16
+      ]
     }
   ],
-  "title": "Rumours",
+  "packaging": "Gatefold Cover",
+  "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+  "quality": "normal",
   "release-events": [
     {
       "area": {
-        "type-id": null,
-        "name": "United States",
-        "type": null,
-        "id": "489ce91b-6658-3307-9877-795b68554c98",
         "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
         "iso-3166-1-codes": [
           "US"
         ],
-        "sort-name": "United States"
+        "name": "United States",
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
       },
       "date": "2013-01-29"
     }
   ],
-  "id": "5c976ee2-d4d4-4932-8f16-54f2b50f8ac5",
-  "disambiguation": "2013 deluxe edition",
-  "label-info": [
-    {
-      "catalog-number": "R2-532752",
-      "label": null
-    }
-  ],
-  "date": "2013-01-29",
   "release-group": {
-    "id": "416bb5e5-c7d1-3977-8fd7-7c9daf6c2be6",
-    "disambiguation": "",
-    "title": "Rumours",
-    "first-release-date": "1977-02-04",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "secondary-types": [],
-    "secondary-type-ids": [],
-    "primary-type": "Album",
     "artist-credit": [
       {
         "artist": {
-          "name": "Fleetwood Mac",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "sort-name": "Fleetwood Mac",
+          "country": "GB",
           "disambiguation": "",
           "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a",
+          "name": "Fleetwood Mac",
+          "sort-name": "Fleetwood Mac",
           "type": "Group",
-          "country": "GB"
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
         },
         "joinphrase": "",
         "name": "Fleetwood Mac"
       }
-    ]
+    ],
+    "disambiguation": "",
+    "first-release-date": "1977-02-04",
+    "id": "416bb5e5-c7d1-3977-8fd7-7c9daf6c2be6",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Rumours"
   },
-  "asin": "B00AGKHEUI",
-  "artist-credit": [
-    {
-      "name": "Fleetwood Mac",
-      "joinphrase": "",
-      "artist": {
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "name": "Fleetwood Mac",
-        "type": "Group",
-        "country": "GB",
-        "sort-name": "Fleetwood Mac",
-        "disambiguation": "",
-        "id": "bd13909f-1c29-4c27-a874-d4aaf27c5b1a"
-      }
-    }
-  ],
   "status": "Official",
-  "barcode": "081227970949",
-  "packaging": "Gatefold Cover",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "country": "US",
   "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
-  "cover-art-archive": {
-    "darkened": false,
-    "back": false,
-    "front": true,
-    "count": 19,
-    "artwork": true
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
   },
-  "quality": "normal"
+  "title": "Rumours"
 }

--- a/scripts/eval_matching/corpus/eval_release_6a76904c.json
+++ b/scripts/eval_matching/corpus/eval_release_6a76904c.json
@@ -1,311 +1,311 @@
 {
-  "release-group": {
-    "artist-credit": [
-      {
-        "name": "Godspeed You Black Emperor!",
-        "artist": {
-          "disambiguation": "",
-          "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-          "sort-name": "Godspeed You! Black Emperor",
-          "country": "CA",
-          "type": "Group",
-          "name": "Godspeed You! Black Emperor",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-        },
-        "joinphrase": ""
-      }
-    ],
-    "secondary-types": [],
-    "primary-type": "Album",
-    "secondary-type-ids": [],
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "first-release-date": "2000-10-09",
-    "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!",
-    "id": "3822abb6-ca53-3ae1-a4ec-7718cb321e9b",
-    "disambiguation": ""
-  },
-  "asin": "B00004ZD69",
   "artist-credit": [
     {
       "artist": {
-        "sort-name": "Godspeed You! Black Emperor",
-        "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-        "disambiguation": "",
-        "type": "Group",
         "country": "CA",
+        "disambiguation": "",
+        "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
         "name": "Godspeed You! Black Emperor",
+        "sort-name": "Godspeed You! Black Emperor",
+        "type": "Group",
         "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
       "joinphrase": "",
       "name": "Godspeed You Black Emperor!"
     }
   ],
-  "status": "Official",
-  "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!",
-  "media": [
-    {
-      "id": "b5d710e7-201c-3b7b-8f46-98e745a85ac0",
-      "title": "",
-      "position": 1,
-      "format": "CD",
-      "track-count": 2,
-      "tracks": [
-        {
-          "length": 1352413,
-          "title": "Storm",
-          "position": 1,
-          "recording": {
-            "length": 1352413,
-            "video": false,
-            "first-release-date": "2000-10-09",
-            "title": "Storm",
-            "isrcs": [
-              "USI4R0401862"
-            ],
-            "id": "519e6d2f-c762-48b1-8798-8f0299e11cc7",
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Godspeed You! Black Emperor",
-                  "type": "Group",
-                  "country": "CA",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "disambiguation": ""
-                },
-                "name": "Godspeed You Black Emperor!"
-              }
-            ]
-          },
-          "id": "4644a541-68ba-3b66-91d8-f9f569ebc4b0",
-          "artist-credit": [
-            {
-              "name": "Godspeed You Black Emperor!",
-              "artist": {
-                "type": "Group",
-                "country": "CA",
-                "sort-name": "Godspeed You! Black Emperor",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "disambiguation": "",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Godspeed You! Black Emperor"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "number": "1"
-        },
-        {
-          "title": "Static",
-          "position": 2,
-          "recording": {
-            "id": "30d53b2b-dbd5-4975-bbdf-48986b4bd089",
-            "isrcs": [
-              "USI4R0401863"
-            ],
-            "disambiguation": "",
-            "title": "Static",
-            "length": 1355946,
-            "video": false,
-            "first-release-date": "2000-10-09",
-            "artist-credit": [
-              {
-                "name": "Godspeed You Black Emperor!",
-                "joinphrase": "",
-                "artist": {
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "country": "CA",
-                  "type": "Group",
-                  "name": "Godspeed You! Black Emperor",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ]
-          },
-          "id": "d74fbc43-33dc-3bc6-9229-b3057275aee9",
-          "length": 1355946,
-          "number": "2",
-          "artist-credit": [
-            {
-              "name": "Godspeed You Black Emperor!",
-              "joinphrase": "",
-              "artist": {
-                "type": "Group",
-                "country": "CA",
-                "sort-name": "Godspeed You! Black Emperor",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "disambiguation": "",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Godspeed You! Black Emperor"
-              }
-            }
-          ]
-        }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "track-offset": 0
-    },
-    {
-      "format": "CD",
-      "tracks": [
-        {
-          "id": "218cef98-2bf5-38f5-8122-e3281ae4e7eb",
-          "title": "Sleep",
-          "recording": {
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Godspeed You! Black Emperor",
-                  "country": "CA",
-                  "type": "Group",
-                  "disambiguation": "",
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "sort-name": "Godspeed You! Black Emperor"
-                },
-                "joinphrase": "",
-                "name": "Godspeed You Black Emperor!"
-              }
-            ],
-            "length": 1397746,
-            "video": false,
-            "first-release-date": "2000-10-09",
-            "disambiguation": "",
-            "id": "b8f1c93d-4273-4428-96cb-c38c6fb0d867",
-            "isrcs": [
-              "USI4R0401864"
-            ],
-            "title": "Sleep"
-          },
-          "position": 1,
-          "length": 1397746,
-          "number": "1",
-          "artist-credit": [
-            {
-              "name": "Godspeed You Black Emperor!",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Godspeed You! Black Emperor",
-                "country": "CA",
-                "type": "Group",
-                "disambiguation": "",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "sort-name": "Godspeed You! Black Emperor"
-              }
-            }
-          ]
-        },
-        {
-          "number": "2",
-          "artist-credit": [
-            {
-              "name": "Godspeed You Black Emperor!",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Godspeed You! Black Emperor",
-                "country": "CA",
-                "type": "Group",
-                "disambiguation": "",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "sort-name": "Godspeed You! Black Emperor"
-              }
-            }
-          ],
-          "id": "7c2a2f12-66c6-3a48-bc38-b6486cb136ac",
-          "title": "Antennas to Heaven",
-          "recording": {
-            "artist-credit": [
-              {
-                "name": "Godspeed You Black Emperor!",
-                "joinphrase": "",
-                "artist": {
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "country": "CA",
-                  "type": "Group",
-                  "name": "Godspeed You! Black Emperor",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "length": 1137586,
-            "video": false,
-            "first-release-date": "2000-10-09",
-            "isrcs": [
-              "USI4R0401865"
-            ],
-            "id": "5fb00c2b-5bc9-420a-882a-cc024d137a08",
-            "disambiguation": "",
-            "title": "Antennas to Heaven"
-          },
-          "position": 2,
-          "length": 1137586
-        }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "track-count": 2,
-      "track-offset": 0,
-      "id": "7c04c3c6-74bf-34b3-90d6-be53f1907cc6",
-      "title": "",
-      "position": 2
-    }
-  ],
-  "release-events": [
-    {
-      "date": "2000-10-09",
-      "area": {
-        "type-id": null,
-        "name": "United States",
-        "type": null,
-        "iso-3166-1-codes": [
-          "US"
-        ],
-        "sort-name": "United States",
-        "disambiguation": "",
-        "id": "489ce91b-6658-3307-9877-795b68554c98"
-      }
-    }
-  ],
-  "id": "6a76904c-0caf-34e1-8cc2-7d95e86a3824",
+  "asin": "B00004ZD69",
+  "barcode": "796441804320",
+  "country": "US",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 11,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2000-10-09",
   "disambiguation": "",
+  "id": "6a76904c-0caf-34e1-8cc2-7d95e86a3824",
   "label-info": [
     {
       "catalog-number": "KRANK 043",
       "label": {
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "name": "kranky",
-        "label-code": null,
-        "type": "Original Production",
         "disambiguation": "",
         "id": "4536e738-6350-4cae-af70-79d56d106c45",
-        "sort-name": "kranky"
+        "label-code": null,
+        "name": "kranky",
+        "sort-name": "kranky",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
-  "date": "2000-10-09",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "country": "US",
-  "cover-art-archive": {
-    "count": 11,
-    "front": true,
-    "back": true,
-    "darkened": false,
-    "artwork": true
-  },
+  "media": [
+    {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "b5d710e7-201c-3b7b-8f46-98e745a85ac0",
+      "position": 1,
+      "title": "",
+      "track-count": 2,
+      "track-offset": 0,
+      "tracks": [
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "4644a541-68ba-3b66-91d8-f9f569ebc4b0",
+          "length": 1352413,
+          "number": "1",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "519e6d2f-c762-48b1-8798-8f0299e11cc7",
+            "isrcs": [
+              "USI4R0401862"
+            ],
+            "length": 1352413,
+            "title": "Storm",
+            "video": false
+          },
+          "title": "Storm"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "d74fbc43-33dc-3bc6-9229-b3057275aee9",
+          "length": 1355946,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "30d53b2b-dbd5-4975-bbdf-48986b4bd089",
+            "isrcs": [
+              "USI4R0401863"
+            ],
+            "length": 1355946,
+            "title": "Static",
+            "video": false
+          },
+          "title": "Static"
+        }
+      ]
+    },
+    {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "7c04c3c6-74bf-34b3-90d6-be53f1907cc6",
+      "position": 2,
+      "title": "",
+      "track-count": 2,
+      "track-offset": 0,
+      "tracks": [
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "218cef98-2bf5-38f5-8122-e3281ae4e7eb",
+          "length": 1397746,
+          "number": "1",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "b8f1c93d-4273-4428-96cb-c38c6fb0d867",
+            "isrcs": [
+              "USI4R0401864"
+            ],
+            "length": 1397746,
+            "title": "Sleep",
+            "video": false
+          },
+          "title": "Sleep"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "7c2a2f12-66c6-3a48-bc38-b6486cb136ac",
+          "length": 1137586,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "5fb00c2b-5bc9-420a-882a-cc024d137a08",
+            "isrcs": [
+              "USI4R0401865"
+            ],
+            "length": 1137586,
+            "title": "Antennas to Heaven",
+            "video": false
+          },
+          "title": "Antennas to Heaven"
+        }
+      ]
+    }
+  ],
+  "packaging": "Gatefold Cover",
   "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
   "quality": "normal",
-  "barcode": "796441804320",
-  "packaging": "Gatefold Cover",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
+        "iso-3166-1-codes": [
+          "US"
+        ],
+        "name": "United States",
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2000-10-09"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "CA",
+          "disambiguation": "",
+          "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+          "name": "Godspeed You! Black Emperor",
+          "sort-name": "Godspeed You! Black Emperor",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Godspeed You Black Emperor!"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2000-10-09",
+    "id": "3822abb6-ca53-3ae1-a4ec-7718cb321e9b",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "text-representation": {
     "language": "eng",
     "script": "Latn"
-  }
+  },
+  "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!"
 }

--- a/scripts/eval_matching/corpus/eval_release_748e3e26.json
+++ b/scripts/eval_matching/corpus/eval_release_748e3e26.json
@@ -2,310 +2,310 @@
   "artist-credit": [
     {
       "artist": {
-        "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-        "sort-name": "Godspeed You! Black Emperor",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "disambiguation": "",
         "country": "CA",
+        "disambiguation": "",
+        "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
         "name": "Godspeed You! Black Emperor",
-        "type": "Group"
+        "sort-name": "Godspeed You! Black Emperor",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
       "joinphrase": "",
       "name": "Godspeed You Black Emperor!"
     }
   ],
+  "asin": null,
+  "barcode": "666561001216",
+  "country": "CA",
+  "cover-art-archive": {
+    "artwork": false,
+    "back": false,
+    "count": 0,
+    "darkened": false,
+    "front": false
+  },
   "date": "2018",
+  "disambiguation": "",
+  "id": "748e3e26-1b4a-4ba9-a2f8-f8bf72ca532d",
+  "label-info": [
+    {
+      "catalog-number": "cst012",
+      "label": {
+        "disambiguation": "Montreal record label",
+        "id": "3496ee09-46bf-4bfd-92f1-38593e24d987",
+        "label-code": null,
+        "name": "Constellation",
+        "sort-name": "Constellation",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
+      }
+    }
+  ],
+  "media": [
+    {
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+      "id": "f4ebbf2c-8f46-3e25-98e1-e61de42afe40",
+      "position": 1,
+      "title": "",
+      "track-count": 2,
+      "track-offset": 0,
+      "tracks": [
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "b60b2be1-bcd6-4750-9773-f9367fc39e24",
+          "length": 1319000,
+          "number": "A",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "519e6d2f-c762-48b1-8798-8f0299e11cc7",
+            "isrcs": [
+              "USI4R0401862"
+            ],
+            "length": 1352413,
+            "title": "Storm",
+            "video": false
+          },
+          "title": "Storm (Lift Yr. Skinny Fists, Like Antennas to Heaven\u2026 / Gathering Storm / Il Pleut \u00c0 Mourir [+Clatters Like Worry] / \u201cWelcome to Barco AM/PM\u2026\u201d [L.A.X.; 5/14/00] / Cancer Towers On Holy Road Hi\u2010Way)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "764bc9e9-9343-4aea-a4ee-1ff0898ac82d",
+          "length": 1267000,
+          "number": "B",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "30d53b2b-dbd5-4975-bbdf-48986b4bd089",
+            "isrcs": [
+              "USI4R0401863"
+            ],
+            "length": 1355946,
+            "title": "Static",
+            "video": false
+          },
+          "title": "Static (Terrible Canyons of Static / Atomic Clock. / Chart #3 / World Police and Friendly Fire / [\u2026+The Buildings They Are Sleeping Now])"
+        }
+      ]
+    },
+    {
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+      "id": "d6d8e20a-4695-3490-8368-19cc897265d4",
+      "position": 2,
+      "title": "",
+      "track-count": 2,
+      "track-offset": 0,
+      "tracks": [
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "c1e1b4bd-f9ee-4e0c-8281-4ab28ee81073",
+          "length": 1272000,
+          "number": "C",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "b8f1c93d-4273-4428-96cb-c38c6fb0d867",
+            "isrcs": [
+              "USI4R0401864"
+            ],
+            "length": 1397746,
+            "title": "Sleep",
+            "video": false
+          },
+          "title": "Sleep (Murray Ostril: \u201c\u2026They Don\u2019t Sleep Anymore On the Beach\u2026\u201d / Monheim / Broken Windows, Locks of Love Pt. III. / 3rd Part)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "e43c8b20-2ed0-466c-a034-b1ee2e89dcda",
+          "length": 1137000,
+          "number": "D",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "5fb00c2b-5bc9-420a-882a-cc024d137a08",
+            "isrcs": [
+              "USI4R0401865"
+            ],
+            "length": 1137586,
+            "title": "Antennas to Heaven",
+            "video": false
+          },
+          "title": "Antennas to Heaven\u2026 (Moya Sings \u201cBaby\u2010O\u201d\u2026 / Edgyswingsetacid / [Glockenspiel Duet Recorded On A Campsite In Rhinebeck, N.Y.] / \u201cAttention\u2026Mon Ami\u2026Fa\u2010Lala\u2010Lala\u2010La\u2010La\u2026\u201d [55\u2010St.Laurent] / She Dreamt She Was A Bulldozer, She Dreamt She Was Alone In An Empty Field / Deathkamp Drone / [Antennas to Heaven\u2026]"
+        }
+      ]
+    }
+  ],
+  "packaging": "Gatefold Cover",
+  "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
+        "iso-3166-1-codes": [
+          "CA"
+        ],
+        "name": "Canada",
+        "sort-name": "Canada",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2018"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "CA",
+          "disambiguation": "",
+          "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+          "name": "Godspeed You! Black Emperor",
+          "sort-name": "Godspeed You! Black Emperor",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Godspeed You Black Emperor!"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2000-10-09",
+    "id": "3822abb6-ca53-3ae1-a4ec-7718cb321e9b",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "text-representation": {
     "language": "eng",
     "script": "Latn"
   },
-  "label-info": [
-    {
-      "label": {
-        "sort-name": "Constellation",
-        "id": "3496ee09-46bf-4bfd-92f1-38593e24d987",
-        "type": "Original Production",
-        "name": "Constellation",
-        "disambiguation": "Montreal record label",
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "label-code": null
-      },
-      "catalog-number": "cst012"
-    }
-  ],
-  "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
-  "barcode": "666561001216",
-  "disambiguation": "",
-  "country": "CA",
-  "release-events": [
-    {
-      "date": "2018",
-      "area": {
-        "name": "Canada",
-        "disambiguation": "",
-        "type": null,
-        "iso-3166-1-codes": [
-          "CA"
-        ],
-        "type-id": null,
-        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
-        "sort-name": "Canada"
-      }
-    }
-  ],
-  "release-group": {
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "first-release-date": "2000-10-09",
-    "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!",
-    "id": "3822abb6-ca53-3ae1-a4ec-7718cb321e9b",
-    "secondary-types": [],
-    "disambiguation": "",
-    "artist-credit": [
-      {
-        "joinphrase": "",
-        "name": "Godspeed You Black Emperor!",
-        "artist": {
-          "sort-name": "Godspeed You! Black Emperor",
-          "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-          "type": "Group",
-          "disambiguation": "",
-          "country": "CA",
-          "name": "Godspeed You! Black Emperor",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-        }
-      }
-    ],
-    "secondary-type-ids": [],
-    "primary-type": "Album"
-  },
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "packaging": "Gatefold Cover",
-  "id": "748e3e26-1b4a-4ba9-a2f8-f8bf72ca532d",
-  "title": "Lift Your Skinny Fists Like Antennas To Heaven",
-  "asin": null,
-  "status": "Official",
-  "media": [
-    {
-      "position": 1,
-      "track-offset": 0,
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
-      "title": "",
-      "tracks": [
-        {
-          "number": "A",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "CA",
-                "disambiguation": "",
-                "name": "Godspeed You! Black Emperor",
-                "sort-name": "Godspeed You! Black Emperor",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4"
-              },
-              "name": "Godspeed You Black Emperor!",
-              "joinphrase": ""
-            }
-          ],
-          "title": "Storm (Lift Yr. Skinny Fists, Like Antennas to Heaven\u2026 / Gathering Storm / Il Pleut \u00c0 Mourir [+Clatters Like Worry] / \u201cWelcome to Barco AM/PM\u2026\u201d [L.A.X.; 5/14/00] / Cancer Towers On Holy Road Hi\u2010Way)",
-          "length": 1319000,
-          "recording": {
-            "isrcs": [
-              "USI4R0401862"
-            ],
-            "title": "Storm",
-            "length": 1352413,
-            "first-release-date": "2000-10-09",
-            "artist-credit": [
-              {
-                "name": "Godspeed You Black Emperor!",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "type": "Group",
-                  "disambiguation": "",
-                  "country": "CA",
-                  "name": "Godspeed You! Black Emperor",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "519e6d2f-c762-48b1-8798-8f0299e11cc7"
-          },
-          "id": "b60b2be1-bcd6-4750-9773-f9367fc39e24",
-          "position": 1
-        },
-        {
-          "id": "764bc9e9-9343-4aea-a4ee-1ff0898ac82d",
-          "position": 2,
-          "recording": {
-            "first-release-date": "2000-10-09",
-            "length": 1355946,
-            "title": "Static",
-            "isrcs": [
-              "USI4R0401863"
-            ],
-            "id": "30d53b2b-dbd5-4975-bbdf-48986b4bd089",
-            "video": false,
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "name": "Godspeed You Black Emperor!",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "disambiguation": "",
-                  "country": "CA",
-                  "name": "Godspeed You! Black Emperor"
-                }
-              }
-            ]
-          },
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Godspeed You! Black Emperor",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "disambiguation": "",
-                "country": "CA",
-                "name": "Godspeed You! Black Emperor"
-              },
-              "joinphrase": "",
-              "name": "Godspeed You Black Emperor!"
-            }
-          ],
-          "length": 1267000,
-          "title": "Static (Terrible Canyons of Static / Atomic Clock. / Chart #3 / World Police and Friendly Fire / [\u2026+The Buildings They Are Sleeping Now])",
-          "number": "B"
-        }
-      ],
-      "format": "12\" Vinyl",
-      "id": "f4ebbf2c-8f46-3e25-98e1-e61de42afe40",
-      "track-count": 2
-    },
-    {
-      "id": "d6d8e20a-4695-3490-8368-19cc897265d4",
-      "tracks": [
-        {
-          "length": 1272000,
-          "title": "Sleep (Murray Ostril: \u201c\u2026They Don\u2019t Sleep Anymore On the Beach\u2026\u201d / Monheim / Broken Windows, Locks of Love Pt. III. / 3rd Part)",
-          "artist-credit": [
-            {
-              "name": "Godspeed You Black Emperor!",
-              "joinphrase": "",
-              "artist": {
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "sort-name": "Godspeed You! Black Emperor",
-                "country": "CA",
-                "name": "Godspeed You! Black Emperor",
-                "disambiguation": "",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "number": "C",
-          "position": 1,
-          "id": "c1e1b4bd-f9ee-4e0c-8281-4ab28ee81073",
-          "recording": {
-            "first-release-date": "2000-10-09",
-            "title": "Sleep",
-            "length": 1397746,
-            "isrcs": [
-              "USI4R0401864"
-            ],
-            "id": "b8f1c93d-4273-4428-96cb-c38c6fb0d867",
-            "video": false,
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Godspeed You Black Emperor!",
-                "artist": {
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "country": "CA",
-                  "disambiguation": "",
-                  "name": "Godspeed You! Black Emperor",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "length": 1137000,
-          "title": "Antennas to Heaven\u2026 (Moya Sings \u201cBaby\u2010O\u201d\u2026 / Edgyswingsetacid / [Glockenspiel Duet Recorded On A Campsite In Rhinebeck, N.Y.] / \u201cAttention\u2026Mon Ami\u2026Fa\u2010Lala\u2010Lala\u2010La\u2010La\u2026\u201d [55\u2010St.Laurent] / She Dreamt She Was A Bulldozer, She Dreamt She Was Alone In An Empty Field / Deathkamp Drone / [Antennas to Heaven\u2026]",
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "sort-name": "Godspeed You! Black Emperor",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "CA",
-                "name": "Godspeed You! Black Emperor",
-                "disambiguation": "",
-                "type": "Group"
-              },
-              "joinphrase": "",
-              "name": "Godspeed You Black Emperor!"
-            }
-          ],
-          "number": "D",
-          "position": 2,
-          "id": "e43c8b20-2ed0-466c-a034-b1ee2e89dcda",
-          "recording": {
-            "artist-credit": [
-              {
-                "name": "Godspeed You Black Emperor!",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Godspeed You! Black Emperor",
-                  "country": "CA",
-                  "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4"
-                }
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "5fb00c2b-5bc9-420a-882a-cc024d137a08",
-            "title": "Antennas to Heaven",
-            "length": 1137586,
-            "isrcs": [
-              "USI4R0401865"
-            ],
-            "first-release-date": "2000-10-09"
-          }
-        }
-      ],
-      "format": "12\" Vinyl",
-      "track-count": 2,
-      "position": 2,
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
-      "title": "",
-      "track-offset": 0
-    }
-  ],
-  "cover-art-archive": {
-    "count": 0,
-    "artwork": false,
-    "back": false,
-    "front": false,
-    "darkened": false
-  },
-  "quality": "normal"
+  "title": "Lift Your Skinny Fists Like Antennas To Heaven"
 }

--- a/scripts/eval_matching/corpus/eval_release_7c07f9a1.json
+++ b/scripts/eval_matching/corpus/eval_release_7c07f9a1.json
@@ -1,1862 +1,1862 @@
 {
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "asin": "B00HAA8URS",
-  "title": "BEYONC\u00c9",
-  "packaging": "Jewel Case",
   "artist-credit": [
     {
-      "name": "Beyonc\u00e9",
       "artist": {
-        "sort-name": "Beyonc\u00e9",
-        "disambiguation": "",
         "country": "US",
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+        "disambiguation": "",
         "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
         "name": "Beyonc\u00e9",
-        "type": "Person"
+        "sort-name": "Beyonc\u00e9",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
       },
-      "joinphrase": ""
+      "joinphrase": "",
+      "name": "Beyonc\u00e9"
     }
   ],
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "asin": "B00HAA8URS",
   "barcode": "888430325128",
+  "country": "US",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 5,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2013-12-20",
+  "disambiguation": "explicit",
+  "id": "7c07f9a1-381f-4c00-8d17-2acc537597f8",
+  "label-info": [
+    {
+      "catalog-number": "88843032512",
+      "label": {
+        "disambiguation": "owned by Sony Music Entertainment, worldwide except JP; formerly owned by CBS between 1938\u20131990 within US/CA/MX",
+        "id": "011d1192-6f65-45bd-85c4-0400dd45693e",
+        "label-code": 162,
+        "name": "Columbia",
+        "sort-name": "Columbia",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    },
+    {
+      "catalog-number": "88843032512",
+      "label": {
+        "disambiguation": "",
+        "id": "31eb6796-abba-4a02-b650-a556aa65f9ae",
+        "label-code": null,
+        "name": "Parkwood Entertainment",
+        "sort-name": "Parkwood Entertainment",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
+      }
+    }
+  ],
   "media": [
     {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "5c792d15-bb3a-3a5d-b8b6-6568c06deaf6",
       "position": 1,
       "title": "AUDIO",
-      "format": "CD",
+      "track-count": 14,
       "track-offset": 0,
       "tracks": [
         {
-          "position": 1,
-          "title": "Pretty Hurts",
-          "number": "1",
-          "length": 257659,
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "disambiguation": "",
-                "sort-name": "Beyonc\u00e9",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                 "name": "Beyonc\u00e9",
-                "type": "Person"
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Beyonc\u00e9"
             }
           ],
           "id": "d6249a01-209a-4840-b5e4-fdf2b8e934ad",
+          "length": 257659,
+          "number": "1",
+          "position": 1,
           "recording": {
-            "length": 257653,
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
                 "artist": {
-                  "sort-name": "Beyonc\u00e9",
+                  "country": "US",
                   "disambiguation": "",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
                   "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
-                }
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
               }
             ],
-            "title": "Pretty Hurts",
             "disambiguation": "",
             "first-release-date": "2013-12-13",
             "id": "c036f796-95e4-474f-998e-8bd7955636bf",
-            "video": false,
             "isrcs": [
               "USSM11307798"
-            ]
-          }
+            ],
+            "length": 257653,
+            "title": "Pretty Hurts",
+            "video": false
+          },
+          "title": "Pretty Hurts"
         },
         {
-          "position": 2,
-          "title": "Haunted",
-          "number": "2",
-          "length": 369033,
           "artist-credit": [
             {
-              "name": "Beyonc\u00e9",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                 "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
                 "type": "Person",
-                "disambiguation": "",
-                "sort-name": "Beyonc\u00e9"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
             }
           ],
           "id": "2e6e4ec5-63ad-4785-b9e7-ba75dd7a27d4",
+          "length": 369033,
+          "number": "2",
+          "position": 2,
           "recording": {
             "artist-credit": [
               {
-                "name": "Beyonc\u00e9",
                 "artist": {
                   "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
+                  "disambiguation": "",
                   "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
                   "sort-name": "Beyonc\u00e9",
-                  "disambiguation": ""
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
               }
             ],
-            "length": 369033,
             "disambiguation": "explicit",
-            "title": "Haunted",
             "first-release-date": "2013-12-13",
+            "id": "8a545575-898b-45d0-98f3-8f0f1929fa8f",
             "isrcs": [
               "USSM11307799"
             ],
-            "video": false,
-            "id": "8a545575-898b-45d0-98f3-8f0f1929fa8f"
-          }
+            "length": 369033,
+            "title": "Haunted",
+            "video": false
+          },
+          "title": "Haunted"
         },
         {
-          "recording": {
-            "isrcs": [
-              "USSM11307800"
-            ],
-            "video": false,
-            "id": "82418990-d1c2-4556-a826-9bccf5e9cd03",
-            "first-release-date": "2013-12-13",
-            "disambiguation": "explicit",
-            "title": "Drunk in Love",
-            "artist-credit": [
-              {
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
-                },
-                "joinphrase": " featuring "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "name": "JAY\u2010Z",
-                  "type": "Person"
-                },
-                "name": "JAY Z"
-              }
-            ],
-            "length": 323486
-          },
-          "id": "b9a2b54c-03c5-4a0d-8f20-3fec77b31b16",
           "artist-credit": [
             {
-              "joinphrase": " featuring ",
               "artist": {
                 "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
                 "disambiguation": "",
-                "sort-name": "Beyonc\u00e9"
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " featuring ",
               "name": "Beyonc\u00e9"
             },
             {
               "artist": {
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
-                "name": "JAY\u2010Z",
                 "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
                 "sort-name": "JAY\u2010Z",
-                "disambiguation": "US rapper"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "JAY Z",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "JAY Z"
             }
           ],
+          "id": "b9a2b54c-03c5-4a0d-8f20-3fec77b31b16",
           "length": 323486,
           "number": "3",
-          "title": "Drunk in Love",
-          "position": 3
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "JAY Z"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2013-12-13",
+            "id": "82418990-d1c2-4556-a826-9bccf5e9cd03",
+            "isrcs": [
+              "USSM11307800"
+            ],
+            "length": 323486,
+            "title": "Drunk in Love",
+            "video": false
+          },
+          "title": "Drunk in Love"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": "",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                 "name": "Beyonc\u00e9",
-                "type": "Person"
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Beyonc\u00e9"
             }
           ],
+          "id": "ebcd62c1-eace-420d-86b9-178511e87694",
           "length": 309727,
           "number": "4",
           "position": 4,
-          "title": "Blow",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2013-12-13",
             "id": "2c502dbd-abe9-4cdb-a950-2083a19623e7",
-            "video": false,
             "isrcs": [
               "USSM11307801"
             ],
             "length": 309720,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person"
-                }
-              }
-            ],
             "title": "Blow",
-            "disambiguation": ""
+            "video": false
           },
-          "id": "ebcd62c1-eace-420d-86b9-178511e87694"
+          "title": "Blow"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
           "id": "774951e6-5c90-4dab-98f5-1a6ce959fd6c",
+          "length": 228687,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "length": 228687,
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
                 "artist": {
-                  "sort-name": "Beyonc\u00e9",
+                  "country": "US",
                   "disambiguation": "",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
                   "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
-                }
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
               }
             ],
-            "title": "No Angel",
             "disambiguation": "",
             "first-release-date": "2013-12-13",
             "id": "ee446a97-635b-499d-ad35-bd729337cc83",
             "isrcs": [
               "USSM11307802"
             ],
+            "length": 228687,
+            "title": "No Angel",
             "video": false
           },
-          "length": 228687,
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "disambiguation": "",
-                "sort-name": "Beyonc\u00e9"
-              },
-              "name": "Beyonc\u00e9",
-              "joinphrase": ""
-            }
-          ],
-          "position": 5,
-          "title": "No Angel",
-          "number": "5"
+          "title": "No Angel"
         },
         {
-          "length": 319466,
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": "",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
                 "type": "Person",
-                "name": "Beyonc\u00e9"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Beyonc\u00e9",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
             }
           ],
-          "title": "Partition",
-          "position": 6,
-          "number": "6",
           "id": "2bb9cf5a-ac34-4f91-8cba-bfc6135bd7d8",
+          "length": 319466,
+          "number": "6",
+          "position": 6,
           "recording": {
-            "first-release-date": "2013-12-13",
-            "isrcs": [
-              "USSM11307803"
-            ],
-            "video": false,
-            "id": "db5082ae-a55d-4b91-9e22-130101a5becb",
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
                   "sort-name": "Beyonc\u00e9",
-                  "disambiguation": ""
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Beyonc\u00e9",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
               }
             ],
-            "length": 319466,
             "disambiguation": "explicit",
-            "title": "Partition"
-          }
+            "first-release-date": "2013-12-13",
+            "id": "db5082ae-a55d-4b91-9e22-130101a5becb",
+            "isrcs": [
+              "USSM11307803"
+            ],
+            "length": 319466,
+            "title": "Partition",
+            "video": false
+          },
+          "title": "Partition"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
           "id": "933df9cc-fae0-4b15-a1fb-821031e34be3",
+          "length": 184008,
+          "number": "7",
+          "position": 7,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
             "id": "a8601c16-b111-42d3-b041-eaaea31f2191",
             "isrcs": [
               "USSM11307804"
             ],
-            "video": false,
-            "first-release-date": "2013-12-13",
-            "title": "Jealous",
-            "disambiguation": "",
             "length": 184008,
-            "artist-credit": [
-              {
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": ""
-                },
-                "joinphrase": ""
-              }
-            ]
+            "title": "Jealous",
+            "video": false
           },
-          "length": 184008,
+          "title": "Jealous"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
                 "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
                 "disambiguation": "",
-                "sort-name": "Beyonc\u00e9"
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Beyonc\u00e9"
             }
           ],
-          "title": "Jealous",
-          "position": 7,
-          "number": "7"
-        },
-        {
-          "title": "Rocket",
-          "position": 8,
-          "number": "8",
-          "length": 391909,
-          "artist-credit": [
-            {
-              "name": "Beyonc\u00e9",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "name": "Beyonc\u00e9",
-                "type": "Person",
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
-              },
-              "joinphrase": ""
-            }
-          ],
           "id": "2fc9c6c9-8159-4c91-bffa-b7d51d131c6d",
+          "length": 391909,
+          "number": "8",
+          "position": 8,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "explicit",
             "first-release-date": "2013-12-13",
+            "id": "45288395-e9a0-43e9-a783-a4627bd33740",
             "isrcs": [
               "USSM11307805"
             ],
-            "video": false,
-            "id": "45288395-e9a0-43e9-a783-a4627bd33740",
-            "artist-credit": [
-              {
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
-                },
-                "joinphrase": ""
-              }
-            ],
             "length": 391907,
-            "disambiguation": "explicit",
-            "title": "Rocket"
-          }
+            "title": "Rocket",
+            "video": false
+          },
+          "title": "Rocket"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " featuring ",
+              "name": "Beyonc\u00e9"
+            },
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "Canadian rapper",
+                "id": "9fff2f8a-21e6-47de-a2b8-7f449929d43f",
+                "name": "Drake",
+                "sort-name": "Drake",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Drake"
+            }
+          ],
           "id": "9f71df43-b987-462a-80a7-d032a8ddab00",
+          "length": 378609,
+          "number": "9",
+          "position": 9,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
+              },
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "Canadian rapper",
+                  "id": "9fff2f8a-21e6-47de-a2b8-7f449929d43f",
+                  "name": "Drake",
+                  "sort-name": "Drake",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Drake"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2013-12-13",
             "id": "09a438dd-fd68-4cf4-b4e6-9cf51fc23e8f",
             "isrcs": [
               "USSM11307806"
             ],
-            "video": false,
-            "first-release-date": "2013-12-13",
-            "title": "Mine",
-            "disambiguation": "explicit",
             "length": 378600,
-            "artist-credit": [
-              {
-                "joinphrase": " featuring ",
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": ""
-                }
-              },
-              {
-                "name": "Drake",
-                "artist": {
-                  "id": "9fff2f8a-21e6-47de-a2b8-7f449929d43f",
-                  "name": "Drake",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "CA",
-                  "disambiguation": "Canadian rapper",
-                  "sort-name": "Drake"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "title": "Mine",
+            "video": false
           },
-          "title": "Mine",
-          "position": 9,
-          "number": "9",
-          "length": 378609,
+          "title": "Mine"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": " featuring ",
               "artist": {
-                "disambiguation": "",
-                "sort-name": "Beyonc\u00e9",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
                 "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
+          "id": "cc07cae1-57f2-4a1b-a5a1-617a6b960b77",
+          "length": 215947,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
+            "id": "d6aba709-74bd-43ae-b01c-3169c3668acd",
+            "isrcs": [
+              "USSM11307807"
+            ],
+            "length": 215947,
+            "title": "XO",
+            "video": false
+          },
+          "title": "XO"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " featuring ",
               "name": "Beyonc\u00e9"
             },
             {
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "CA",
-                "id": "9fff2f8a-21e6-47de-a2b8-7f449929d43f",
-                "type": "Person",
-                "name": "Drake",
-                "sort-name": "Drake",
-                "disambiguation": "Canadian rapper"
-              },
-              "name": "Drake",
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "position": 10,
-          "title": "XO",
-          "number": "10",
-          "length": 215947,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Beyonc\u00e9",
-              "artist": {
+                "country": "NG",
                 "disambiguation": "",
-                "sort-name": "Beyonc\u00e9",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
+                "id": "012fd9c9-1e34-4dc2-a8b8-da1136786771",
+                "name": "Chimamanda Ngozi Adichie",
+                "sort-name": "Adichie, Chimamanda Ngozi",
                 "type": "Person",
-                "name": "Beyonc\u00e9",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8"
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Chimamanda Ngozi Adichie"
             }
           ],
-          "id": "cc07cae1-57f2-4a1b-a5a1-617a6b960b77",
-          "recording": {
-            "isrcs": [
-              "USSM11307807"
-            ],
-            "video": false,
-            "id": "d6aba709-74bd-43ae-b01c-3169c3668acd",
-            "first-release-date": "2013-12-13",
-            "disambiguation": "",
-            "title": "XO",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": ""
-                }
-              }
-            ],
-            "length": 215947
-          }
-        },
-        {
           "id": "d67e0fb9-1884-4f74-8cda-d0ab44a02e17",
+          "length": 250951,
+          "number": "11",
+          "position": 11,
           "recording": {
             "artist-credit": [
               {
-                "name": "Beyonc\u00e9",
                 "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8"
-                },
-                "joinphrase": " featuring "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Adichie, Chimamanda Ngozi",
                   "disambiguation": "",
-                  "name": "Chimamanda Ngozi Adichie",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
                   "type": "Person",
-                  "id": "012fd9c9-1e34-4dc2-a8b8-da1136786771",
-                  "country": "NG",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
+              },
+              {
+                "artist": {
+                  "country": "NG",
+                  "disambiguation": "",
+                  "id": "012fd9c9-1e34-4dc2-a8b8-da1136786771",
+                  "name": "Chimamanda Ngozi Adichie",
+                  "sort-name": "Adichie, Chimamanda Ngozi",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
                 "name": "Chimamanda Ngozi Adichie"
               }
             ],
-            "length": 250951,
             "disambiguation": "explicit",
-            "title": "***Flawless",
             "first-release-date": "2013-12-13",
+            "id": "22d404f8-3229-41d3-bbd8-fd0661332fb9",
             "isrcs": [
               "USSM11307808"
             ],
-            "video": false,
-            "id": "22d404f8-3229-41d3-bbd8-fd0661332fb9"
+            "length": 250951,
+            "title": "***Flawless",
+            "video": false
           },
-          "length": 250951,
-          "artist-credit": [
-            {
-              "artist": {
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
-              },
-              "name": "Beyonc\u00e9",
-              "joinphrase": " featuring "
-            },
-            {
-              "name": "Chimamanda Ngozi Adichie",
-              "artist": {
-                "disambiguation": "",
-                "sort-name": "Adichie, Chimamanda Ngozi",
-                "country": "NG",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "012fd9c9-1e34-4dc2-a8b8-da1136786771",
-                "type": "Person",
-                "name": "Chimamanda Ngozi Adichie"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "title": "***Flawless",
-          "position": 11,
-          "number": "11"
+          "title": "***Flawless"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": " featuring ",
-              "name": "Beyonc\u00e9",
               "artist": {
-                "name": "Beyonc\u00e9",
-                "type": "Person",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                 "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "disambiguation": "",
-                "sort-name": "Beyonc\u00e9"
-              }
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " featuring ",
+              "name": "Beyonc\u00e9"
             },
             {
               "artist": {
-                "sort-name": "Ocean, Frank",
-                "disambiguation": "",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "",
+                "id": "e520459c-dff4-491d-a6e4-c97be35e0044",
                 "name": "Frank Ocean",
+                "sort-name": "Ocean, Frank",
                 "type": "Person",
-                "id": "e520459c-dff4-491d-a6e4-c97be35e0044"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Frank Ocean",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Frank Ocean"
             }
           ],
+          "id": "abbad310-6de4-4e36-a47e-8b0b7d2afa36",
           "length": 276569,
           "number": "12",
           "position": 12,
-          "title": "Superpower",
           "recording": {
-            "disambiguation": "",
-            "title": "Superpower",
             "artist-credit": [
               {
                 "artist": {
                   "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
                   "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Beyonc\u00e9",
-                "joinphrase": " featuring "
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
               },
               {
                 "artist": {
-                  "name": "Frank Ocean",
-                  "type": "Person",
-                  "id": "e520459c-dff4-491d-a6e4-c97be35e0044",
                   "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "disambiguation": "",
+                  "id": "e520459c-dff4-491d-a6e4-c97be35e0044",
+                  "name": "Frank Ocean",
                   "sort-name": "Ocean, Frank",
-                  "disambiguation": ""
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Frank Ocean",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Frank Ocean"
               }
             ],
-            "length": 276560,
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
+            "id": "bd3140b8-09f4-4348-bd26-333e4cbc3d79",
             "isrcs": [
               "USSM11307809"
             ],
-            "video": false,
-            "id": "bd3140b8-09f4-4348-bd26-333e4cbc3d79",
-            "first-release-date": "2013-12-13"
+            "length": 276560,
+            "title": "Superpower",
+            "video": false
           },
-          "id": "abbad310-6de4-4e36-a47e-8b0b7d2afa36"
+          "title": "Superpower"
         },
         {
-          "number": "13",
-          "title": "Heaven",
-          "position": 13,
           "artist-credit": [
             {
               "artist": {
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
                 "disambiguation": "",
-                "sort-name": "Beyonc\u00e9"
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Beyonc\u00e9",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
             }
           ],
+          "id": "0b369d80-f620-4338-b2f9-14e318cf54bf",
           "length": 230881,
+          "number": "13",
+          "position": 13,
           "recording": {
-            "isrcs": [
-              "USSM11307810"
-            ],
-            "video": false,
-            "id": "176ac145-619b-4f00-a726-558dc126e396",
-            "first-release-date": "2013-12-13",
-            "disambiguation": "",
-            "title": "Heaven",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
+                  "country": "US",
                   "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
                   "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                   "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
                   "type": "Person",
-                  "country": "US",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Beyonc\u00e9"
               }
             ],
-            "length": 230881
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
+            "id": "176ac145-619b-4f00-a726-558dc126e396",
+            "isrcs": [
+              "USSM11307810"
+            ],
+            "length": 230881,
+            "title": "Heaven",
+            "video": false
           },
-          "id": "0b369d80-f620-4338-b2f9-14e318cf54bf"
+          "title": "Heaven"
         },
         {
-          "number": "14",
-          "position": 14,
-          "title": "Blue",
           "artist-credit": [
             {
-              "joinphrase": " featuring ",
-              "name": "Beyonc\u00e9",
               "artist": {
-                "sort-name": "Beyonc\u00e9",
+                "country": "US",
                 "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
                 "name": "Beyonc\u00e9",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
-              }
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " featuring ",
+              "name": "Beyonc\u00e9"
             },
             {
               "artist": {
+                "country": "US",
                 "disambiguation": "Beyonc\u00e9 & Jay-Z\u2019s daughter",
-                "sort-name": "Carter, Blue Ivy",
-                "name": "Blue Ivy Carter",
-                "type": "Person",
                 "id": "159ed9dd-c41a-4552-9197-296eae04c6d7",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
+                "name": "Blue Ivy Carter",
+                "sort-name": "Carter, Blue Ivy",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Blue Ivy",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Blue Ivy"
             }
           ],
+          "id": "5814565b-b08d-4cde-bbdc-d6cb1c03d757",
           "length": 266920,
+          "number": "14",
+          "position": 14,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "Beyonc\u00e9 & Jay-Z\u2019s daughter",
+                  "id": "159ed9dd-c41a-4552-9197-296eae04c6d7",
+                  "name": "Blue Ivy Carter",
+                  "sort-name": "Carter, Blue Ivy",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Blue Ivy"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2013-12-13",
             "id": "94673629-547d-4e20-90e5-87ed5c699e81",
             "isrcs": [
               "USSM11307811"
             ],
-            "video": false,
             "length": 266920,
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
-                },
-                "name": "Beyonc\u00e9",
-                "joinphrase": " featuring "
-              },
-              {
-                "name": "Blue Ivy",
-                "artist": {
-                  "disambiguation": "Beyonc\u00e9 & Jay-Z\u2019s daughter",
-                  "sort-name": "Carter, Blue Ivy",
-                  "id": "159ed9dd-c41a-4552-9197-296eae04c6d7",
-                  "type": "Person",
-                  "name": "Blue Ivy Carter",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": ""
-              }
-            ],
             "title": "Blue",
-            "disambiguation": ""
+            "video": false
           },
-          "id": "5814565b-b08d-4cde-bbdc-d6cb1c03d757"
+          "title": "Blue"
         }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "id": "5c792d15-bb3a-3a5d-b8b6-6568c06deaf6",
-      "track-count": 14
+      ]
     },
     {
-      "position": 2,
       "format": "DVD-Video",
+      "format-id": "bb71fd58-ff93-32b4-a201-4ad1b2a80e5f",
+      "id": "853b7204-f1c4-35c4-803d-e128c651abfe",
+      "position": 2,
       "title": "VISUAL",
+      "track-count": 18,
       "track-offset": 0,
       "tracks": [
         {
-          "length": 425000,
           "artist-credit": [
             {
-              "name": "Beyonc\u00e9",
               "artist": {
+                "country": "US",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                 "name": "Beyonc\u00e9",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
                 "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
             }
           ],
-          "position": 1,
-          "title": "Pretty Hurts",
-          "number": "1",
           "id": "dba99248-1261-4e69-998c-c98197061268",
+          "length": 425000,
+          "number": "1",
+          "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2013-12-13",
             "id": "f8e24a0e-8d2a-4b08-acbe-696c9a17056f",
-            "video": true,
             "isrcs": [
               "USSM21302425"
             ],
             "length": 424809,
-            "artist-credit": [
-              {
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
-                },
-                "joinphrase": ""
-              }
-            ],
             "title": "Pretty Hurts",
-            "disambiguation": ""
-          }
+            "video": true
+          },
+          "title": "Pretty Hurts"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
           "id": "e619643e-8d84-489f-b0ac-2040add30b41",
+          "length": 152000,
+          "number": "2",
+          "position": 2,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "explicit",
             "first-release-date": "2013-12-13",
             "id": "c8e87dc3-05cf-48bb-b40f-97c32d8cb0ad",
             "isrcs": [
               "USSM21302426"
             ],
-            "video": true,
             "length": 151818,
+            "title": "Ghost",
+            "video": true
+          },
+          "title": "Ghost"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
+          "id": "96cfe0e6-a83d-40a3-b69d-05abca2bbb0d",
+          "length": 321000,
+          "number": "3",
+          "position": 3,
+          "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
                   "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "disambiguation": "",
                   "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                   "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
                   "type": "Person",
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Beyonc\u00e9"
               }
             ],
-            "title": "Ghost",
-            "disambiguation": "explicit"
-          },
-          "position": 2,
-          "title": "Ghost",
-          "number": "2",
-          "length": 152000,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
-              },
-              "name": "Beyonc\u00e9"
-            }
-          ]
-        },
-        {
-          "id": "96cfe0e6-a83d-40a3-b69d-05abca2bbb0d",
-          "recording": {
             "disambiguation": "",
-            "title": "Haunted",
-            "artist-credit": [
-              {
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 321000,
+            "first-release-date": "2013-12-13",
+            "id": "158fe696-8515-4732-9729-0b65f4e4a445",
             "isrcs": [
               "USSM21302427"
             ],
-            "video": true,
-            "id": "158fe696-8515-4732-9729-0b65f4e4a445",
-            "first-release-date": "2013-12-13"
+            "length": 321000,
+            "title": "Haunted",
+            "video": true
           },
-          "length": 321000,
-          "artist-credit": [
-            {
-              "name": "Beyonc\u00e9",
-              "artist": {
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "name": "Beyonc\u00e9",
-                "type": "Person",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
-              },
-              "joinphrase": ""
-            }
-          ],
-          "title": "Haunted",
-          "position": 3,
-          "number": "3"
+          "title": "Haunted"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
+          "id": "24e986ab-2f0d-4e69-a195-defae2f5014a",
+          "length": 381000,
+          "number": "4",
+          "position": 4,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "JAY Z"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2013-12-13",
+            "id": "afafdd5f-a07b-4566-b9b6-13eae651e66c",
             "isrcs": [
               "USSM21302428"
             ],
-            "video": true,
-            "id": "afafdd5f-a07b-4566-b9b6-13eae651e66c",
-            "first-release-date": "2013-12-13",
-            "disambiguation": "explicit",
+            "length": 381000,
             "title": "Drunk in Love",
-            "artist-credit": [
-              {
-                "joinphrase": " featuring ",
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": "",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8"
-                }
-              },
-              {
-                "name": "JAY Z",
-                "artist": {
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "disambiguation": "US rapper"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 381000
+            "video": true
           },
-          "id": "24e986ab-2f0d-4e69-a195-defae2f5014a",
-          "number": "4",
-          "position": 4,
-          "title": "Drunk in Love",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": "",
-                "name": "Beyonc\u00e9",
-                "type": "Person",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
-              },
-              "name": "Beyonc\u00e9",
-              "joinphrase": ""
-            }
-          ],
-          "length": 381000
+          "title": "Drunk in Love"
         },
         {
-          "position": 5,
-          "title": "Blow",
-          "number": "5",
-          "length": 326000,
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
                 "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
                 "name": "Beyonc\u00e9",
                 "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Beyonc\u00e9"
             }
           ],
           "id": "33b9a7c3-ade3-4503-a7af-2aba91a6eb2d",
+          "length": 326000,
+          "number": "5",
+          "position": 5,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2013-12-13",
-            "video": true,
+            "id": "7e37367b-7c05-4209-95fd-bf993e4e7567",
             "isrcs": [
               "USSM21302429"
             ],
-            "id": "7e37367b-7c05-4209-95fd-bf993e4e7567",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": "",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8"
-                }
-              }
-            ],
             "length": 325706,
-            "disambiguation": "",
-            "title": "Blow"
-          }
+            "title": "Blow",
+            "video": true
+          },
+          "title": "Blow"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
           "id": "4b37d796-52d4-4fdd-abd5-92cb2ab70cb1",
+          "length": 233000,
+          "number": "6",
+          "position": 6,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
             "id": "a4c318b8-991b-4ff4-96dd-107c7bdfdce2",
             "isrcs": [
               "USSM21302430"
             ],
-            "video": true,
-            "first-release-date": "2013-12-13",
-            "title": "No Angel",
-            "disambiguation": "",
             "length": 233000,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
-                }
-              }
-            ]
+            "title": "No Angel",
+            "video": true
           },
-          "length": 233000,
+          "title": "No Angel"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Beyonc\u00e9",
               "artist": {
-                "sort-name": "Beyonc\u00e9",
+                "country": "US",
                 "disambiguation": "",
-                "name": "Beyonc\u00e9",
-                "type": "Person",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
-              }
-            }
-          ],
-          "title": "No Angel",
-          "position": 6,
-          "number": "6"
-        },
-        {
-          "position": 7,
-          "title": "Yonc\u00e9",
-          "number": "7",
-          "length": 123000,
-          "artist-credit": [
-            {
-              "name": "Beyonc\u00e9",
-              "artist": {
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
                 "name": "Beyonc\u00e9",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
-            }
-          ],
-          "id": "c453356e-83d4-449e-95fd-3463ea39d5e1",
-          "recording": {
-            "isrcs": [
-              "USSM21302431"
-            ],
-            "video": true,
-            "id": "1fe10699-5b39-40d6-915a-0663a6c959c8",
-            "first-release-date": "2013-12-13",
-            "disambiguation": "",
-            "title": "Yonc\u00e9",
-            "artist-credit": [
-              {
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 122793
-          }
-        },
-        {
-          "recording": {
-            "id": "c80a3cde-a26a-409a-841b-33df099df0d8",
-            "video": true,
-            "isrcs": [
-              "USSM21302432"
-            ],
-            "first-release-date": "2013-12-13",
-            "title": "Partition",
-            "disambiguation": "explicit",
-            "length": 229000,
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person"
-                },
-                "name": "Beyonc\u00e9",
-                "joinphrase": ""
-              }
-            ]
-          },
-          "id": "7b859e1b-433e-485b-b79b-e4b3f0edaa6e",
-          "artist-credit": [
-            {
               "joinphrase": "",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
-              },
               "name": "Beyonc\u00e9"
             }
           ],
+          "id": "c453356e-83d4-449e-95fd-3463ea39d5e1",
+          "length": 123000,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
+            "id": "1fe10699-5b39-40d6-915a-0663a6c959c8",
+            "isrcs": [
+              "USSM21302431"
+            ],
+            "length": 122793,
+            "title": "Yonc\u00e9",
+            "video": true
+          },
+          "title": "Yonc\u00e9"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
+          "id": "7b859e1b-433e-485b-b79b-e4b3f0edaa6e",
           "length": 229000,
           "number": "8",
           "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2013-12-13",
+            "id": "c80a3cde-a26a-409a-841b-33df099df0d8",
+            "isrcs": [
+              "USSM21302432"
+            ],
+            "length": 229000,
+            "title": "Partition",
+            "video": true
+          },
           "title": "Partition"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
+          "id": "69cded20-a036-4590-a45a-3d95319498f3",
+          "length": 206000,
+          "number": "9",
+          "position": 9,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2013-12-13",
+            "id": "c5646d63-21e9-41fc-839d-114493fb2457",
             "isrcs": [
               "USSM21302433"
             ],
-            "video": true,
-            "id": "c5646d63-21e9-41fc-839d-114493fb2457",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US"
-                }
-              }
-            ],
             "length": 206000,
-            "disambiguation": "",
-            "title": "Jealous"
+            "title": "Jealous",
+            "video": true
           },
-          "id": "69cded20-a036-4590-a45a-3d95319498f3",
-          "number": "9",
-          "position": 9,
-          "title": "Jealous",
-          "artist-credit": [
-            {
-              "name": "Beyonc\u00e9",
-              "artist": {
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "disambiguation": "",
-                "sort-name": "Beyonc\u00e9"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "length": 206000
+          "title": "Jealous"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
+          "id": "3cf6d716-f79c-4a2c-a544-147bd105e8e7",
+          "length": 271000,
+          "number": "10",
+          "position": 10,
           "recording": {
-            "disambiguation": "explicit",
-            "title": "Rocket",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
+                  "disambiguation": "",
                   "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
                   "sort-name": "Beyonc\u00e9",
-                  "disambiguation": ""
-                }
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
               }
             ],
-            "length": 270000,
+            "disambiguation": "explicit",
+            "first-release-date": "2013-12-13",
+            "id": "9e386d1f-ae72-4ac0-9e79-0dff581531cc",
             "isrcs": [
               "USSM21302434"
             ],
-            "video": true,
-            "id": "9e386d1f-ae72-4ac0-9e79-0dff581531cc",
-            "first-release-date": "2013-12-13"
+            "length": 270000,
+            "title": "Rocket",
+            "video": true
           },
-          "id": "3cf6d716-f79c-4a2c-a544-147bd105e8e7",
+          "title": "Rocket"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
                 "name": "Beyonc\u00e9",
                 "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Beyonc\u00e9",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
             }
           ],
-          "length": 271000,
-          "number": "10",
-          "title": "Rocket",
-          "position": 10
-        },
-        {
           "id": "6c36c2e6-af38-4e1d-bc72-fc71049474c2",
+          "length": 299000,
+          "number": "11",
+          "position": 11,
           "recording": {
-            "title": "Mine",
-            "disambiguation": "explicit",
-            "length": 299000,
             "artist-credit": [
               {
                 "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
                   "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "disambiguation": "",
                   "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                   "name": "Beyonc\u00e9",
-                  "type": "Person"
-                },
-                "name": "Beyonc\u00e9",
-                "joinphrase": " featuring "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "Canadian rapper",
-                  "sort-name": "Drake",
-                  "name": "Drake",
+                  "sort-name": "Beyonc\u00e9",
                   "type": "Person",
-                  "id": "9fff2f8a-21e6-47de-a2b8-7f449929d43f",
-                  "country": "CA",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
+              },
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "Canadian rapper",
+                  "id": "9fff2f8a-21e6-47de-a2b8-7f449929d43f",
+                  "name": "Drake",
+                  "sort-name": "Drake",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
                 "name": "Drake"
               }
             ],
+            "disambiguation": "explicit",
+            "first-release-date": "2013-12-13",
             "id": "a1ac846d-bb44-49f2-b497-98d1ec27bce9",
             "isrcs": [
               "USSM21302435"
             ],
-            "video": true,
-            "first-release-date": "2013-12-13"
+            "length": 299000,
+            "title": "Mine",
+            "video": true
           },
-          "length": 299000,
+          "title": "Mine"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
                 "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Beyonc\u00e9"
             }
           ],
-          "position": 11,
-          "title": "Mine",
-          "number": "11"
-        },
-        {
           "id": "088fbff7-cb81-489a-b9d5-9774afec6009",
+          "length": 216000,
+          "number": "12",
+          "position": 12,
           "recording": {
-            "disambiguation": "",
-            "title": "XO",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": "",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                   "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Beyonc\u00e9"
               }
             ],
-            "length": 215966,
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
+            "id": "f1545cec-ec89-47de-bf51-9e4bbfa30e9b",
             "isrcs": [
               "USSM21302436"
             ],
-            "video": true,
-            "id": "f1545cec-ec89-47de-bf51-9e4bbfa30e9b",
-            "first-release-date": "2013-12-13"
+            "length": 215966,
+            "title": "XO",
+            "video": true
           },
-          "length": 216000,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Beyonc\u00e9",
-              "artist": {
-                "disambiguation": "",
-                "sort-name": "Beyonc\u00e9",
-                "name": "Beyonc\u00e9",
-                "type": "Person",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
-            }
-          ],
-          "title": "XO",
-          "position": 12,
-          "number": "12"
+          "title": "XO"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
           "id": "dd3f7da0-4366-48b2-9cf1-02bbbb71c1fa",
+          "length": 252000,
+          "number": "13",
+          "position": 13,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
                   "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Beyonc\u00e9",
-                "joinphrase": " featuring "
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "NG",
-                  "type": "Person",
-                  "name": "Chimamanda Ngozi Adichie",
+                  "disambiguation": "",
                   "id": "012fd9c9-1e34-4dc2-a8b8-da1136786771",
+                  "name": "Chimamanda Ngozi Adichie",
                   "sort-name": "Adichie, Chimamanda Ngozi",
-                  "disambiguation": ""
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Chimamanda Ngozi Adichie"
               }
             ],
-            "length": 252000,
             "disambiguation": "explicit",
-            "title": "***Flawless",
             "first-release-date": "2013-12-13",
-            "video": true,
+            "id": "547967f0-f99d-448b-93cb-710fcba631a7",
             "isrcs": [
               "USSM21302437"
             ],
-            "id": "547967f0-f99d-448b-93cb-710fcba631a7"
+            "length": 252000,
+            "title": "***Flawless",
+            "video": true
           },
-          "length": 252000,
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": "",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "US"
-              },
-              "name": "Beyonc\u00e9",
-              "joinphrase": ""
-            }
-          ],
-          "position": 13,
-          "title": "***Flawless",
-          "number": "13"
+          "title": "***Flawless"
         },
         {
-          "number": "14",
-          "position": 14,
-          "title": "Superpower",
           "artist-credit": [
             {
-              "name": "Beyonc\u00e9",
               "artist": {
-                "disambiguation": "",
-                "sort-name": "Beyonc\u00e9",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
                 "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
             }
           ],
+          "id": "1e911ba3-49d8-4402-9dc1-a1fbee59b72d",
           "length": 324000,
+          "number": "14",
+          "position": 14,
           "recording": {
-            "length": 324448,
             "artist-credit": [
               {
-                "name": "Beyonc\u00e9",
                 "artist": {
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": "",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
+                  "disambiguation": "",
                   "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
                   "type": "Person",
-                  "name": "Beyonc\u00e9"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "joinphrase": " featuring "
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
               },
               {
-                "joinphrase": "",
-                "name": "Frank Ocean",
                 "artist": {
-                  "sort-name": "Ocean, Frank",
-                  "disambiguation": "",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
+                  "disambiguation": "",
                   "id": "e520459c-dff4-491d-a6e4-c97be35e0044",
                   "name": "Frank Ocean",
-                  "type": "Person"
-                }
+                  "sort-name": "Ocean, Frank",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Frank Ocean"
               }
             ],
-            "title": "Superpower",
             "disambiguation": "",
             "first-release-date": "2013-12-13",
             "id": "60166819-82f2-4018-90ca-598ff6680ad3",
-            "video": true,
             "isrcs": [
               "USSM21302438"
-            ]
+            ],
+            "length": 324448,
+            "title": "Superpower",
+            "video": true
           },
-          "id": "1e911ba3-49d8-4402-9dc1-a1fbee59b72d"
+          "title": "Superpower"
         },
         {
           "artist-credit": [
             {
-              "name": "Beyonc\u00e9",
               "artist": {
+                "country": "US",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                 "name": "Beyonc\u00e9",
-                "type": "Person",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
             }
           ],
+          "id": "716abf8a-054d-4cfe-9b0c-5efadc455cd8",
           "length": 235000,
           "number": "15",
           "position": 15,
-          "title": "Heaven",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
             "id": "915b8d4b-924e-473f-b0d7-85ba0edf64d3",
             "isrcs": [
               "USSM21302439"
             ],
-            "video": true,
-            "first-release-date": "2013-12-13",
-            "title": "Heaven",
-            "disambiguation": "",
             "length": 235000,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Beyonc\u00e9",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ]
+            "title": "Heaven",
+            "video": true
           },
-          "id": "716abf8a-054d-4cfe-9b0c-5efadc455cd8"
+          "title": "Heaven"
         },
         {
-          "id": "ccd64da1-353e-4ec3-ba89-7654790df50e",
-          "recording": {
-            "isrcs": [
-              "USSM21302440"
-            ],
-            "video": true,
-            "id": "71c61b56-12ea-4c91-aec9-871a1a527bf8",
-            "first-release-date": "2013-12-13",
-            "disambiguation": "",
-            "title": "Blue",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": "",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                  "name": "Beyonc\u00e9",
-                  "type": "Person"
-                },
-                "name": "Beyonc\u00e9",
-                "joinphrase": " featuring "
-              },
-              {
-                "artist": {
-                  "id": "159ed9dd-c41a-4552-9197-296eae04c6d7",
-                  "type": "Person",
-                  "name": "Blue Ivy Carter",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "US",
-                  "sort-name": "Carter, Blue Ivy",
-                  "disambiguation": "Beyonc\u00e9 & Jay-Z\u2019s daughter"
-                },
-                "name": "Blue Ivy",
-                "joinphrase": ""
-              }
-            ],
-            "length": 275000
-          },
-          "length": 275000,
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
-                "name": "Beyonc\u00e9",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "US",
                 "disambiguation": "",
-                "sort-name": "Beyonc\u00e9"
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Beyonc\u00e9"
             }
           ],
-          "title": "Blue",
+          "id": "ccd64da1-353e-4ec3-ba89-7654790df50e",
+          "length": 275000,
+          "number": "16",
           "position": 16,
-          "number": "16"
-        },
-        {
-          "id": "85105138-cb87-4248-ba88-7289cc6beacf",
           "recording": {
-            "title": "Credits",
-            "disambiguation": "",
-            "length": 154000,
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Beyonc\u00e9",
-                  "disambiguation": "",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "US",
-                  "type": "Person",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                   "name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8"
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Beyonc\u00e9",
-                "joinphrase": ""
+                "joinphrase": " featuring ",
+                "name": "Beyonc\u00e9"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "Beyonc\u00e9 & Jay-Z\u2019s daughter",
+                  "id": "159ed9dd-c41a-4552-9197-296eae04c6d7",
+                  "name": "Blue Ivy Carter",
+                  "sort-name": "Carter, Blue Ivy",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Blue Ivy"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
+            "id": "71c61b56-12ea-4c91-aec9-871a1a527bf8",
+            "isrcs": [
+              "USSM21302440"
+            ],
+            "length": 275000,
+            "title": "Blue",
+            "video": true
+          },
+          "title": "Blue"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                "name": "Beyonc\u00e9",
+                "sort-name": "Beyonc\u00e9",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
+            }
+          ],
+          "id": "85105138-cb87-4248-ba88-7289cc6beacf",
+          "length": 154000,
+          "number": "17",
+          "position": 17,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2013-12-13",
             "id": "4fcdff65-e8b9-4538-b3f6-15f9623b15f7",
             "isrcs": [
               "USSM21302460"
             ],
-            "video": true,
-            "first-release-date": "2013-12-13"
+            "length": 154000,
+            "title": "Credits",
+            "video": true
           },
-          "length": 154000,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Beyonc\u00e9",
-              "artist": {
-                "sort-name": "Beyonc\u00e9",
-                "disambiguation": "",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "Beyonc\u00e9",
-                "id": "859d0860-d480-4efd-970c-c05d5f1776b8"
-              }
-            }
-          ],
-          "title": "Credits",
-          "position": 17,
-          "number": "17"
+          "title": "Credits"
         },
         {
-          "number": "18",
-          "title": "Grown Woman",
-          "position": 18,
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Beyonc\u00e9",
               "artist": {
+                "country": "US",
+                "disambiguation": "",
                 "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                 "name": "Beyonc\u00e9",
-                "type": "Person",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "sort-name": "Beyonc\u00e9",
-                "disambiguation": ""
-              }
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Beyonc\u00e9"
             }
           ],
+          "id": "f43f52a3-0260-429a-bba5-3a44af3d2d0f",
           "length": 264000,
+          "number": "18",
+          "position": 18,
           "recording": {
-            "first-release-date": "2013-12-13",
-            "isrcs": [
-              "USSM21302441"
-            ],
-            "video": true,
-            "id": "f9549acb-c874-4ea2-9dde-55b8e500db5e",
             "artist-credit": [
               {
                 "artist": {
                   "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Beyonc\u00e9",
-                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
                   "disambiguation": "",
-                  "sort-name": "Beyonc\u00e9"
+                  "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
+                  "name": "Beyonc\u00e9",
+                  "sort-name": "Beyonc\u00e9",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Beyonc\u00e9",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Beyonc\u00e9"
               }
             ],
-            "length": 264000,
             "disambiguation": "",
-            "title": "Grown Woman"
+            "first-release-date": "2013-12-13",
+            "id": "f9549acb-c874-4ea2-9dde-55b8e500db5e",
+            "isrcs": [
+              "USSM21302441"
+            ],
+            "length": 264000,
+            "title": "Grown Woman",
+            "video": true
           },
-          "id": "f43f52a3-0260-429a-bba5-3a44af3d2d0f"
+          "title": "Grown Woman"
         }
-      ],
-      "format-id": "bb71fd58-ff93-32b4-a201-4ad1b2a80e5f",
-      "id": "853b7204-f1c4-35c4-803d-e128c651abfe",
-      "track-count": 18
+      ]
     }
   ],
-  "cover-art-archive": {
-    "back": true,
-    "darkened": false,
-    "count": 5,
-    "artwork": true,
-    "front": true
-  },
+  "packaging": "Jewel Case",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
   "release-events": [
     {
       "area": {
+        "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
         "iso-3166-1-codes": [
           "US"
         ],
-        "sort-name": "United States",
-        "disambiguation": "",
-        "type-id": null,
-        "id": "489ce91b-6658-3307-9877-795b68554c98",
         "name": "United States",
-        "type": null
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
       },
       "date": "2013-12-20"
     }
   ],
-  "country": "US",
-  "date": "2013-12-20",
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "disambiguation": "explicit",
-  "quality": "normal",
-  "status": "Official",
   "release-group": {
-    "id": "8596171e-23b2-4bdd-8f1c-11960df0ecbe",
-    "secondary-types": [],
-    "primary-type": "Album",
-    "first-release-date": "2013-12-13",
-    "disambiguation": "",
-    "title": "BEYONC\u00c9",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
     "artist-credit": [
       {
         "artist": {
-          "disambiguation": "",
-          "sort-name": "Beyonc\u00e9",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
           "country": "US",
+          "disambiguation": "",
           "id": "859d0860-d480-4efd-970c-c05d5f1776b8",
           "name": "Beyonc\u00e9",
-          "type": "Person"
+          "sort-name": "Beyonc\u00e9",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
         },
-        "name": "Beyonc\u00e9",
-        "joinphrase": ""
+        "joinphrase": "",
+        "name": "Beyonc\u00e9"
       }
     ],
-    "secondary-type-ids": []
+    "disambiguation": "",
+    "first-release-date": "2013-12-13",
+    "id": "8596171e-23b2-4bdd-8f1c-11960df0ecbe",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "BEYONC\u00c9"
   },
-  "label-info": [
-    {
-      "label": {
-        "type": "Imprint",
-        "label-code": 162,
-        "name": "Columbia",
-        "id": "011d1192-6f65-45bd-85c4-0400dd45693e",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "disambiguation": "owned by Sony Music Entertainment, worldwide except JP; formerly owned by CBS between 1938\u20131990 within US/CA/MX",
-        "sort-name": "Columbia"
-      },
-      "catalog-number": "88843032512"
-    },
-    {
-      "catalog-number": "88843032512",
-      "label": {
-        "disambiguation": "",
-        "sort-name": "Parkwood Entertainment",
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "name": "Parkwood Entertainment",
-        "type": "Original Production",
-        "label-code": null,
-        "id": "31eb6796-abba-4a02-b650-a556aa65f9ae"
-      }
-    }
-  ],
-  "id": "7c07f9a1-381f-4c00-8d17-2acc537597f8"
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "BEYONC\u00c9"
 }

--- a/scripts/eval_matching/corpus/eval_release_8e061dc4.json
+++ b/scripts/eval_matching/corpus/eval_release_8e061dc4.json
@@ -1,684 +1,684 @@
 {
-  "quality": "normal",
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "cover-art-archive": {
-    "artwork": true,
-    "count": 1,
-    "back": false,
-    "darkened": false,
-    "front": true
-  },
-  "country": "US",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "text-representation": {
-    "language": "eng",
-    "script": "Latn"
-  },
-  "packaging": "Jewel Case",
-  "barcode": "0720642442524",
-  "status": "Official",
   "artist-credit": [
     {
-      "name": "Nirvana",
       "artist": {
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "name": "Nirvana",
         "country": "US",
-        "type": "Group",
-        "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
         "disambiguation": "1980s\u20131990s US grunge band",
-        "sort-name": "Nirvana"
+        "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+        "name": "Nirvana",
+        "sort-name": "Nirvana",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
-      "joinphrase": ""
+      "joinphrase": "",
+      "name": "Nirvana"
     }
   ],
   "asin": "B000003TA4",
-  "release-group": {
-    "id": "1b022e01-4da6-387b-8658-8678046e4cef",
-    "disambiguation": "",
-    "title": "Nevermind",
-    "first-release-date": "1991-09-24",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "secondary-type-ids": [],
-    "primary-type": "Album",
-    "secondary-types": [],
-    "artist-credit": [
-      {
-        "artist": {
-          "name": "Nirvana",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "disambiguation": "1980s\u20131990s US grunge band",
-          "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-          "sort-name": "Nirvana",
-          "country": "US",
-          "type": "Group"
-        },
-        "joinphrase": "",
-        "name": "Nirvana"
-      }
-    ]
+  "barcode": "0720642442524",
+  "country": "US",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": false,
+    "count": 1,
+    "darkened": false,
+    "front": true
   },
   "date": "1991-09-24",
-  "label-info": [
-    {
-      "label": {
-        "label-code": 7266,
-        "name": "Geffen Records",
-        "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678",
-        "sort-name": "Geffen Records",
-        "disambiguation": "",
-        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
-        "type": "Production"
-      },
-      "catalog-number": "GED24425"
-    }
-  ],
   "disambiguation": "",
   "id": "8e061dc4-790e-4587-ba53-011e7852f88d",
-  "release-events": [
+  "label-info": [
     {
-      "date": "1991-09-24",
-      "area": {
-        "type": null,
-        "sort-name": "United States",
-        "iso-3166-1-codes": [
-          "US"
-        ],
+      "catalog-number": "GED24425",
+      "label": {
         "disambiguation": "",
-        "id": "489ce91b-6658-3307-9877-795b68554c98",
-        "type-id": null,
-        "name": "United States"
+        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
+        "label-code": 7266,
+        "name": "Geffen Records",
+        "sort-name": "Geffen Records",
+        "type": "Production",
+        "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678"
       }
     }
   ],
-  "title": "Nevermind",
   "media": [
     {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "c3e97a4e-ac8a-3ccf-aa52-000dedf9a34e",
-      "title": "",
       "position": 1,
+      "title": "",
+      "track-count": 12,
+      "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
-              "name": "Nirvana",
               "artist": {
                 "country": "US",
-                "type": "Group",
                 "disambiguation": "1980s\u20131990s US grunge band",
                 "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
                 "sort-name": "Nirvana",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Nirvana"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
-          "number": "1",
-          "length": 301133,
           "id": "b51442aa-f5a4-31a3-8f2b-ab02640c2e89",
-          "title": "Smells Like Teen Spirit",
+          "length": 301133,
+          "number": "1",
+          "position": 1,
           "recording": {
-            "title": "Smells Like Teen Spirit",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1991-09-10",
             "id": "5fb524f1-8cc8-4c04-a921-e34c0a911ea7",
             "isrcs": [
               "USGF19942501"
             ],
-            "first-release-date": "1991-09-10",
-            "video": false,
             "length": 301133,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "type": "Group",
-                  "country": "US",
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Nirvana"
-              }
-            ]
+            "title": "Smells Like Teen Spirit",
+            "video": false
           },
-          "position": 1
+          "title": "Smells Like Teen Spirit"
         },
         {
-          "number": "2",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Nirvana",
                 "country": "US",
-                "type": "Group",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana"
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Nirvana"
             }
           ],
           "id": "5e55fa04-d664-3653-a1c9-0b660b08f846",
-          "title": "In Bloom",
+          "length": 254933,
+          "number": "2",
           "position": 2,
           "recording": {
             "artist-credit": [
               {
-                "name": "Nirvana",
                 "artist": {
+                  "country": "US",
                   "disambiguation": "1980s\u20131990s US grunge band",
                   "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "country": "US",
-                  "type": "Group",
                   "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
-            "video": false,
-            "first-release-date": "1991-09-24",
-            "length": 254973,
             "disambiguation": "Nevermind version",
+            "first-release-date": "1991-09-24",
             "id": "593e9317-a327-4a31-b796-416c62dcf49d",
             "isrcs": [
               "USGF19942502"
             ],
-            "title": "In Bloom"
+            "length": 254973,
+            "title": "In Bloom",
+            "video": false
           },
-          "length": 254933
+          "title": "In Bloom"
         },
         {
-          "number": "3",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Nirvana",
                 "country": "US",
-                "type": "Group",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana"
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Nirvana"
             }
           ],
+          "id": "8cbcbc84-3236-39a7-9510-4835d3653836",
+          "length": 219066,
+          "number": "3",
           "position": 3,
           "recording": {
-            "title": "Come as You Are",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
             "disambiguation": "original studio mix",
+            "first-release-date": "1991-09-24",
             "id": "70ac6733-068f-4613-b06b-bea17cfbcc30",
             "isrcs": [
               "USGF19942503"
             ],
             "length": 219026,
-            "first-release-date": "1991-09-24",
-            "video": false,
-            "artist-credit": [
-              {
-                "name": "Nirvana",
-                "artist": {
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type": "Group",
-                  "country": "US",
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "title": "Come as You Are",
+            "video": false
           },
-          "title": "Come as You Are",
-          "id": "8cbcbc84-3236-39a7-9510-4835d3653836",
-          "length": 219066
+          "title": "Come as You Are"
         },
         {
-          "length": 183760,
-          "id": "794e0eb3-6670-3c06-a0cd-fa83de9d8b36",
-          "position": 4,
-          "title": "Breed",
-          "recording": {
-            "disambiguation": "",
-            "id": "0cf9f95f-70e7-4f2e-8075-5d8ba38dd4a3",
-            "isrcs": [
-              "USGF19942504"
-            ],
-            "title": "Breed",
-            "video": false,
-            "first-release-date": "1991-09-24",
-            "length": 183840,
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Nirvana",
-                  "country": "US",
-                  "type": "Group",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "sort-name": "Nirvana"
-                },
-                "joinphrase": "",
-                "name": "Nirvana"
-              }
-            ]
-          },
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "type": "Group",
                 "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Nirvana"
             }
           ],
-          "number": "4"
+          "id": "794e0eb3-6670-3c06-a0cd-fa83de9d8b36",
+          "length": 183760,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1991-09-24",
+            "id": "0cf9f95f-70e7-4f2e-8075-5d8ba38dd4a3",
+            "isrcs": [
+              "USGF19942504"
+            ],
+            "length": 183840,
+            "title": "Breed",
+            "video": false
+          },
+          "title": "Breed"
         },
         {
-          "number": "5",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "name": "Nirvana",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Nirvana",
+                "country": "US",
                 "disambiguation": "1980s\u20131990s US grunge band",
                 "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
                 "type": "Group",
-                "country": "US"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Nirvana"
             }
           ],
           "id": "f27b5223-2100-3dfb-849c-4cd88d776ca2",
+          "length": 257000,
+          "number": "5",
+          "position": 5,
           "recording": {
             "artist-credit": [
               {
-                "name": "Nirvana",
-                "joinphrase": "",
                 "artist": {
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "country": "US",
                   "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
                   "type": "Group",
-                  "country": "US"
-                }
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
-            "length": 257000,
-            "video": false,
+            "disambiguation": "",
             "first-release-date": "1991-09-24",
-            "title": "Lithium",
+            "id": "3fac712c-4196-4865-8c1a-94231a7da309",
             "isrcs": [
               "USGF19942505"
             ],
-            "id": "3fac712c-4196-4865-8c1a-94231a7da309",
-            "disambiguation": ""
+            "length": 257000,
+            "title": "Lithium",
+            "video": false
           },
-          "title": "Lithium",
-          "position": 5,
-          "length": 257000
+          "title": "Lithium"
         },
         {
-          "number": "6",
           "artist-credit": [
             {
-              "name": "Nirvana",
-              "joinphrase": "",
               "artist": {
-                "name": "Nirvana",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana",
                 "country": "US",
-                "type": "Group"
-              }
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
           "id": "28c77747-09b7-3fd0-9663-a381d59e191f",
-          "title": "Polly",
+          "length": 177000,
+          "number": "6",
           "position": 6,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
+                  "country": "US",
                   "disambiguation": "1980s\u20131990s US grunge band",
                   "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "country": "US",
-                  "type": "Group",
                   "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Nirvana"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "1991-09-24",
-            "video": false,
-            "length": 177000,
-            "title": "Polly",
+            "id": "d088ed9e-1921-4568-ae75-fba8b15ed206",
             "isrcs": [
               "USGF19942506"
             ],
-            "id": "d088ed9e-1921-4568-ae75-fba8b15ed206",
-            "disambiguation": ""
+            "length": 177000,
+            "title": "Polly",
+            "video": false
           },
-          "length": 177000
+          "title": "Polly"
         },
         {
-          "number": "7",
           "artist-credit": [
             {
-              "name": "Nirvana",
               "artist": {
-                "type": "Group",
                 "country": "US",
-                "sort-name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Nirvana"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "title": "Territorial Pissings",
-          "position": 7,
-          "recording": {
-            "id": "dbaa10b1-d46a-4960-8b50-4e2d80c8113c",
-            "isrcs": [
-              "USGF19942507"
-            ],
-            "disambiguation": "",
-            "title": "Territorial Pissings",
-            "video": false,
-            "first-release-date": "1991-09-24",
-            "length": 143000,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type": "Group",
-                  "country": "US"
-                },
-                "name": "Nirvana"
-              }
-            ]
-          },
-          "id": "7e5dd15b-57ec-3ba8-a92a-c8a512f59eaa",
-          "length": 143133
-        },
-        {
-          "length": 223866,
-          "id": "82a81dc4-2065-383a-bdb6-ca64ed668de7",
-          "title": "Drain You",
-          "position": 8,
-          "recording": {
-            "artist-credit": [
-              {
-                "name": "Nirvana",
-                "joinphrase": "",
-                "artist": {
-                  "type": "Group",
-                  "country": "US",
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Nirvana"
-                }
-              }
-            ],
-            "id": "11cc49bd-f531-4cdd-9b59-e1f59b06c1d7",
-            "disambiguation": "",
-            "isrcs": [
-              "USGF19942508"
-            ],
-            "title": "Drain You",
-            "length": 223880,
-            "video": false,
-            "first-release-date": "1991-09-10"
-          },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Nirvana",
-                "type": "Group",
-                "country": "US",
-                "sort-name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "disambiguation": "1980s\u20131990s US grunge band"
-              },
-              "name": "Nirvana"
-            }
-          ],
-          "number": "8"
-        },
-        {
-          "id": "1ae79dcd-eead-3563-8eb7-aae03a919063",
-          "position": 9,
-          "title": "Lounge Act",
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "country": "US",
-                  "type": "Group"
-                },
-                "name": "Nirvana"
-              }
-            ],
-            "id": "aef0677b-93b4-4c66-be74-10120d0e6f5a",
-            "isrcs": [
-              "USGF19942509"
-            ],
-            "disambiguation": "",
-            "title": "Lounge Act",
-            "first-release-date": "1991-09-24",
-            "video": false,
-            "length": 156800
-          },
-          "length": 156773,
-          "number": "9",
-          "artist-credit": [
-            {
-              "artist": {
-                "name": "Nirvana",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana",
-                "country": "US",
-                "type": "Group"
-              },
-              "joinphrase": "",
-              "name": "Nirvana"
-            }
-          ]
-        },
-        {
-          "recording": {
-            "artist-credit": [
-              {
-                "name": "Nirvana",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "type": "Group",
-                  "country": "US",
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "title": "Stay Away",
-            "id": "8bf26383-8b9b-4252-9cb3-0efa4d3f47f1",
-            "isrcs": [
-              "USGF19942510"
-            ],
-            "disambiguation": "",
-            "length": 212466,
-            "video": false,
-            "first-release-date": "1991-09-24"
-          },
-          "position": 10,
-          "title": "Stay Away",
-          "id": "e6726ebf-b261-3325-bd23-522482ae89e5",
-          "length": 212466,
-          "number": "10",
-          "artist-credit": [
-            {
-              "name": "Nirvana",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Nirvana",
-                "type": "Group",
-                "country": "US",
-                "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-              }
-            }
-          ]
-        },
-        {
-          "number": "11",
-          "artist-credit": [
-            {
-              "artist": {
                 "disambiguation": "1980s\u20131990s US grunge band",
                 "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana",
-                "country": "US",
-                "type": "Group",
                 "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Nirvana"
             }
           ],
-          "title": "On a Plain",
-          "position": 11,
+          "id": "7e5dd15b-57ec-3ba8-a92a-c8a512f59eaa",
+          "length": 143133,
+          "number": "7",
+          "position": 7,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Nirvana",
-                  "type": "Group",
                   "country": "US",
-                  "sort-name": "Nirvana",
+                  "disambiguation": "1980s\u20131990s US grunge band",
                   "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "disambiguation": "1980s\u20131990s US grunge band"
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Nirvana"
               }
             ],
-            "first-release-date": "1991-09-24",
-            "video": false,
-            "length": 196373,
-            "id": "ea61d42b-9a76-47fd-bcf7-df911640c309",
             "disambiguation": "",
+            "first-release-date": "1991-09-24",
+            "id": "dbaa10b1-d46a-4960-8b50-4e2d80c8113c",
             "isrcs": [
-              "USGF19942511"
+              "USGF19942507"
             ],
-            "title": "On a Plain"
+            "length": 143000,
+            "title": "Territorial Pissings",
+            "video": false
           },
-          "id": "4b688a9c-0080-3cb8-9d4a-2c0cf6ee7131",
-          "length": 196400
+          "title": "Territorial Pissings"
         },
         {
           "artist-credit": [
             {
-              "name": "Nirvana",
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Nirvana",
-                "type": "Group",
                 "country": "US",
-                "sort-name": "Nirvana",
                 "disambiguation": "1980s\u20131990s US grunge band",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-              }
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
-          "number": "12",
-          "length": 1235066,
+          "id": "82a81dc4-2065-383a-bdb6-ca64ed668de7",
+          "length": 223866,
+          "number": "8",
+          "position": 8,
           "recording": {
-            "length": 1235066,
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1991-09-10",
+            "id": "11cc49bd-f531-4cdd-9b59-e1f59b06c1d7",
+            "isrcs": [
+              "USGF19942508"
+            ],
+            "length": 223880,
+            "title": "Drain You",
+            "video": false
+          },
+          "title": "Drain You"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "1ae79dcd-eead-3563-8eb7-aae03a919063",
+          "length": 156773,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1991-09-24",
+            "id": "aef0677b-93b4-4c66-be74-10120d0e6f5a",
+            "isrcs": [
+              "USGF19942509"
+            ],
+            "length": 156800,
+            "title": "Lounge Act",
+            "video": false
+          },
+          "title": "Lounge Act"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "e6726ebf-b261-3325-bd23-522482ae89e5",
+          "length": 212466,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1991-09-24",
+            "id": "8bf26383-8b9b-4252-9cb3-0efa4d3f47f1",
+            "isrcs": [
+              "USGF19942510"
+            ],
+            "length": 212466,
+            "title": "Stay Away",
+            "video": false
+          },
+          "title": "Stay Away"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "4b688a9c-0080-3cb8-9d4a-2c0cf6ee7131",
+          "length": 196400,
+          "number": "11",
+          "position": 11,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1991-09-24",
+            "id": "ea61d42b-9a76-47fd-bcf7-df911640c309",
+            "isrcs": [
+              "USGF19942511"
+            ],
+            "length": 196373,
+            "title": "On a Plain",
+            "video": false
+          },
+          "title": "On a Plain"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "f1f333d1-d3f3-3037-a815-aae8591606e2",
+          "length": 1235066,
+          "number": "12",
+          "position": 12,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1991-09-24",
             "id": "d506a8b2-4ba9-49b9-941f-40d1295ebd29",
             "isrcs": [
               "USUM71113875"
             ],
-            "disambiguation": "",
+            "length": 1235066,
             "title": "Something in the Way / Endless, Nameless",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type": "Group",
-                  "country": "US",
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Nirvana"
-                },
-                "joinphrase": "",
-                "name": "Nirvana"
-              }
-            ]
+            "video": false
           },
-          "position": 12,
-          "title": "Something in the Way / Endless, Nameless",
-          "id": "f1f333d1-d3f3-3037-a815-aae8591606e2"
+          "title": "Something in the Way / Endless, Nameless"
         }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "track-count": 12,
-      "track-offset": 0,
-      "format": "CD"
+      ]
     }
-  ]
+  ],
+  "packaging": "Jewel Case",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
+        "iso-3166-1-codes": [
+          "US"
+        ],
+        "name": "United States",
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
+      },
+      "date": "1991-09-24"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "1980s\u20131990s US grunge band",
+          "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+          "name": "Nirvana",
+          "sort-name": "Nirvana",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Nirvana"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1991-09-24",
+    "id": "1b022e01-4da6-387b-8658-8678046e4cef",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Nevermind"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Nevermind"
 }

--- a/scripts/eval_matching/corpus/eval_release_9764a202.json
+++ b/scripts/eval_matching/corpus/eval_release_9764a202.json
@@ -1,115 +1,138 @@
 {
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "barcode": "081227999247",
-  "label-info": [
-    {
-      "label": {
-        "name": "Rhino",
-        "disambiguation": "reissue label",
-        "type": "Imprint",
-        "label-code": 2982,
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "id": "c4f2cf49-b57c-4cc1-8061-f54400704ac4",
-        "sort-name": "Rhino"
-      },
-      "catalog-number": "8122-79992-4"
-    }
-  ],
   "artist-credit": [
     {
       "artist": {
-        "name": "Black Sabbath",
         "country": "GB",
         "disambiguation": "English heavy metal band",
-        "type": "Group",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
         "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-        "sort-name": "Black Sabbath"
+        "name": "Black Sabbath",
+        "sort-name": "Black Sabbath",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
-      "name": "Black Sabbath",
-      "joinphrase": ""
+      "joinphrase": "",
+      "name": "Black Sabbath"
     }
   ],
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
+  "asin": "B000NA77YO",
+  "barcode": "081227999247",
+  "country": "DE",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 6,
+    "darkened": false,
+    "front": true
   },
   "date": "2007-03-30",
+  "disambiguation": "",
+  "id": "9764a202-87e6-4bd1-9cf9-147a5d089f77",
+  "label-info": [
+    {
+      "catalog-number": "8122-79992-4",
+      "label": {
+        "disambiguation": "reissue label",
+        "id": "c4f2cf49-b57c-4cc1-8061-f54400704ac4",
+        "label-code": 2982,
+        "name": "Rhino",
+        "sort-name": "Rhino",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    }
+  ],
   "media": [
     {
-      "position": 1,
+      "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "title": "",
-      "track-offset": 0,
       "id": "59807c60-1295-3cf3-b707-9d598d975cef",
+      "position": 1,
+      "title": "",
+      "track-count": 16,
+      "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
               "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Black Sabbath",
                 "country": "GB",
                 "disambiguation": "English heavy metal band",
-                "type": "Group"
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Black Sabbath",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Black Sabbath"
             }
           ],
-          "title": "Neon Knights",
+          "id": "d60fa285-8544-317f-972b-1916ba9a70c9",
           "length": 232293,
           "number": "1",
           "position": 1,
-          "id": "d60fa285-8544-317f-972b-1916ba9a70c9",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1980-04-25",
-            "length": 232293,
-            "title": "Neon Knights",
+            "id": "0e8c9144-bd63-4cd6-9ed8-2d39690c0f87",
             "isrcs": [
               "GBUM70900395",
               "USRH12003566",
               "USWB10700217",
               "USWB10800510"
             ],
-            "video": false,
-            "id": "0e8c9144-bd63-4cd6-9ed8-2d39690c0f87",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "disambiguation": "English heavy metal band",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": ""
-          }
+            "length": 232293,
+            "title": "Neon Knights",
+            "video": false
+          },
+          "title": "Neon Knights"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
           "id": "af2ac9de-d440-323b-95cd-ac956e144cbf",
+          "length": 264493,
+          "number": "2",
           "position": 2,
           "recording": {
-            "video": false,
-            "id": "4325e6d2-8231-4ceb-ba22-3ff8bb5f5fa0",
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
                   "country": "GB",
-                  "name": "Black Sabbath",
                   "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
                   "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Black Sabbath"
@@ -117,427 +140,332 @@
             ],
             "disambiguation": "",
             "first-release-date": "1980-04-25",
-            "length": 264493,
-            "title": "Lady Evil",
+            "id": "4325e6d2-8231-4ceb-ba22-3ff8bb5f5fa0",
             "isrcs": [
               "GBUM70900393",
               "USRH12003568",
               "USWB10700218",
               "USWB10800512"
-            ]
+            ],
+            "length": 264493,
+            "title": "Lady Evil",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Black Sabbath",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "GB",
-                "name": "Black Sabbath",
-                "disambiguation": "English heavy metal band",
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-              }
-            }
-          ],
-          "length": 264493,
-          "title": "Lady Evil",
-          "number": "2"
+          "title": "Lady Evil"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "a3faf4b2-ccbb-38bb-96c9-a1104110422a",
+          "length": 418973,
+          "number": "3",
+          "position": 3,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Black Sabbath",
                 "artist": {
-                  "type": "Group",
-                  "disambiguation": "English heavy metal band",
                   "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                   "name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
               }
             ],
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1980-04-25",
             "id": "9ea011c9-d2ba-4e2a-adee-5ad2331f57e9",
-            "length": 417240,
-            "title": "Heaven and Hell",
             "isrcs": [
               "GBUM70900392",
               "USRH12003569",
               "USWB10700219",
               "USWB10800513"
             ],
-            "first-release-date": "1980-04-25"
+            "length": 417240,
+            "title": "Heaven and Hell",
+            "video": false
           },
-          "id": "a3faf4b2-ccbb-38bb-96c9-a1104110422a",
-          "position": 3,
-          "number": "3",
-          "title": "Heaven and Hell",
-          "length": 418973,
+          "title": "Heaven and Hell"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                 "name": "Black Sabbath",
                 "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Black Sabbath",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Black Sabbath"
             }
-          ]
-        },
-        {
-          "position": 4,
+          ],
           "id": "017559b5-68d5-3cf4-9753-3bedd4cc44fb",
+          "length": 284866,
+          "number": "4",
+          "position": 4,
           "recording": {
             "artist-credit": [
               {
-                "name": "Black Sabbath",
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type": "Group",
-                  "disambiguation": "English heavy metal band",
                   "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                   "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
               }
             ],
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1980-04-25",
             "id": "cbe61838-9184-4b59-bbde-862ca30682c5",
-            "title": "Die Young",
-            "length": 284866,
             "isrcs": [
               "GBUM70900391",
               "USRH12003571",
               "USWB10700220",
               "USWB10800515"
             ],
-            "first-release-date": "1980-04-25"
+            "length": 284866,
+            "title": "Die Young",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "artist": {
-                "country": "GB",
-                "name": "Black Sabbath",
-                "disambiguation": "English heavy metal band",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath"
-              },
-              "name": "Black Sabbath",
-              "joinphrase": ""
-            }
-          ],
-          "length": 284866,
-          "title": "Die Young",
-          "number": "4"
+          "title": "Die Young"
         },
         {
-          "title": "Lonely Is the Word",
-          "length": 351106,
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Black Sabbath",
               "artist": {
                 "country": "GB",
-                "name": "Black Sabbath",
                 "disambiguation": "English heavy metal band",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath"
-              }
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
             }
           ],
-          "number": "5",
           "id": "4fed0a54-6818-3f09-ad69-353991223291",
+          "length": 351106,
+          "number": "5",
           "position": 5,
           "recording": {
-            "length": 350000,
-            "title": "Lonely Is the Word",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1980-04-25",
+            "id": "fdcfcf7e-97ee-4262-8995-d439acc23cd8",
             "isrcs": [
               "GBUM70900394",
               "USRH12003573",
               "USWB10700221",
               "USWB10800517"
             ],
-            "first-release-date": "1980-04-25",
+            "length": 350000,
+            "title": "Lonely Is the Word",
+            "video": false
+          },
+          "title": "Lonely Is the Word"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "246d6d49-bd0e-3913-96b0-a12170fe1daf",
+          "length": 195986,
+          "number": "6",
+          "position": 6,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath",
                   "country": "GB",
                   "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                   "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
                   "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "fdcfcf7e-97ee-4262-8995-d439acc23cd8"
-          }
-        },
-        {
-          "number": "6",
-          "title": "The Mob Rules",
-          "length": 195986,
-          "artist-credit": [
-            {
-              "name": "Black Sabbath",
-              "joinphrase": "",
-              "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "country": "GB",
-                "disambiguation": "English heavy metal band",
-                "name": "Black Sabbath",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "recording": {
-            "video": false,
-            "id": "9e2f0f8f-fc91-438e-9f1b-4a9dc3319d4e",
-            "artist-credit": [
-              {
                 "joinphrase": "",
-                "name": "Black Sabbath",
-                "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type": "Group",
-                  "disambiguation": "English heavy metal band",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                "name": "Black Sabbath"
               }
             ],
             "disambiguation": "",
             "first-release-date": "1981-11-04",
-            "length": 195346,
-            "title": "The Mob Rules",
+            "id": "9e2f0f8f-fc91-438e-9f1b-4a9dc3319d4e",
             "isrcs": [
               "GBUM70900389",
               "USRH12003578",
               "USWB10000515",
               "USWB10700222"
-            ]
+            ],
+            "length": 195346,
+            "title": "The Mob Rules",
+            "video": false
           },
-          "position": 6,
-          "id": "246d6d49-bd0e-3913-96b0-a12170fe1daf"
+          "title": "The Mob Rules"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "3b27dad5-b6a3-3450-82b9-fe71d3281f3b",
+          "length": 222360,
+          "number": "7",
+          "position": 7,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1981-11-04",
-            "length": 222360,
-            "title": "Turn Up the Night",
+            "id": "2249f42f-b4a9-4fac-b1bd-0d1edcd9c886",
             "isrcs": [
               "GBUM70900381",
               "USRH12003574",
               "USWB10700223"
             ],
-            "video": false,
-            "id": "2249f42f-b4a9-4fac-b1bd-0d1edcd9c886",
-            "artist-credit": [
-              {
-                "name": "Black Sabbath",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type": "Group",
-                  "disambiguation": "English heavy metal band",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "disambiguation": ""
+            "length": 222360,
+            "title": "Turn Up the Night",
+            "video": false
           },
-          "id": "3b27dad5-b6a3-3450-82b9-fe71d3281f3b",
-          "position": 7,
-          "number": "7",
-          "length": 222360,
-          "title": "Turn Up the Night",
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "name": "Black Sabbath",
-                "disambiguation": "English heavy metal band",
-                "type": "Group"
-              },
-              "joinphrase": "",
-              "name": "Black Sabbath"
-            }
-          ]
+          "title": "Turn Up the Night"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "disambiguation": "English heavy metal band",
                 "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                 "name": "Black Sabbath",
                 "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Black Sabbath",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Black Sabbath"
             }
           ],
+          "id": "de440ef4-39c7-304c-92f2-8f0c1f33b3f8",
           "length": 274653,
-          "title": "Voodoo",
           "number": "8",
           "position": 8,
-          "id": "de440ef4-39c7-304c-92f2-8f0c1f33b3f8",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1981-11-04",
-            "length": 273000,
-            "title": "Voodoo",
+            "id": "9f34b1a2-e449-4cf4-a3b6-6c15bdfce548",
             "isrcs": [
               "GBUM70900382",
               "USRH12003575",
               "USWB10700224"
             ],
-            "video": false,
-            "id": "9f34b1a2-e449-4cf4-a3b6-6c15bdfce548",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": ""
-          }
+            "length": 273000,
+            "title": "Voodoo",
+            "video": false
+          },
+          "title": "Voodoo"
         },
         {
-          "number": "9",
-          "length": 304960,
-          "title": "Falling off the Edge of the World",
-          "artist-credit": [
-            {
-              "name": "Black Sabbath",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "English heavy metal band",
-                "name": "Black Sabbath"
-              }
-            }
-          ],
-          "recording": {
-            "first-release-date": "1981-11-04",
-            "length": 303853,
-            "title": "Falling off the Edge of the World",
-            "isrcs": [
-              "GBUM70900388",
-              "USRH12003581",
-              "USWB10700225"
-            ],
-            "video": false,
-            "id": "d38cea8d-1ce6-46a4-abdf-779dc5da8539",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Black Sabbath",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "name": "Black Sabbath",
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-                }
-              }
-            ],
-            "disambiguation": ""
-          },
-          "id": "054eb327-e90d-364a-8c8c-bf2d70f36131",
-          "position": 9
-        },
-        {
-          "recording": {
-            "video": false,
-            "id": "e46093fb-a8e4-4d05-831d-2953a06f8523",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Black Sabbath",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "English heavy metal band",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "type": "Group",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath"
-                }
-              }
-            ],
-            "disambiguation": "",
-            "first-release-date": "1992-06-22",
-            "isrcs": [
-              "USCA21003160",
-              "USRE10700051"
-            ],
-            "length": 341626,
-            "title": "After All (The Dead)"
-          },
-          "id": "3b4ba360-13db-3ef3-bba0-23416769a1d5",
-          "position": 10,
-          "number": "10",
           "artist-credit": [
             {
               "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
                 "country": "GB",
                 "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                 "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
@@ -545,218 +473,313 @@
               "name": "Black Sabbath"
             }
           ],
-          "length": 342253,
-          "title": "After All (The Dead)"
-        },
-        {
-          "length": 242160,
-          "title": "TV Crimes",
-          "artist-credit": [
-            {
-              "name": "Black Sabbath",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "disambiguation": "English heavy metal band",
-                "country": "GB",
-                "name": "Black Sabbath"
-              }
-            }
-          ],
-          "number": "11",
-          "id": "9646f132-4de4-3a37-896b-928179b8970b",
-          "position": 11,
+          "id": "054eb327-e90d-364a-8c8c-bf2d70f36131",
+          "length": 304960,
+          "number": "9",
+          "position": 9,
           "recording": {
-            "first-release-date": "1992-06-01",
-            "title": "TV Crimes",
-            "length": 242000,
-            "isrcs": [
-              "USCA21003161",
-              "USRE10700052"
-            ],
-            "id": "fe2763b1-332f-4281-b785-c2fb032a9d5b",
-            "video": false,
-            "disambiguation": "",
             "artist-credit": [
               {
-                "name": "Black Sabbath",
-                "joinphrase": "",
                 "artist": {
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Black Sabbath",
                   "country": "GB",
                   "disambiguation": "English heavy metal band",
-                  "type": "Group"
-                }
-              }
-            ]
-          }
-        },
-        {
-          "title": "I",
-          "length": 313506,
-          "artist-credit": [
-            {
-              "name": "Black Sabbath",
-              "joinphrase": "",
-              "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Black Sabbath",
-                "country": "GB",
-                "disambiguation": "English heavy metal band",
-                "type": "Group"
-              }
-            }
-          ],
-          "number": "12",
-          "id": "297938ec-a80f-3632-9f58-82472d1495fc",
-          "position": 12,
-          "recording": {
-            "video": false,
-            "id": "31ef8b7a-e849-49c5-bb6c-778d71497e3b",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Black Sabbath",
                   "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
                   "type": "Group",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "disambiguation": "English heavy metal band",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1981-11-04",
+            "id": "d38cea8d-1ce6-46a4-abdf-779dc5da8539",
+            "isrcs": [
+              "GBUM70900388",
+              "USRH12003581",
+              "USWB10700225"
+            ],
+            "length": 303853,
+            "title": "Falling off the Edge of the World",
+            "video": false
+          },
+          "title": "Falling off the Edge of the World"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                 "name": "Black Sabbath",
-                "joinphrase": ""
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "3b4ba360-13db-3ef3-bba0-23416769a1d5",
+          "length": 342253,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
               }
             ],
             "disambiguation": "",
             "first-release-date": "1992-06-22",
+            "id": "e46093fb-a8e4-4d05-831d-2953a06f8523",
             "isrcs": [
-              "USCA21003167",
-              "USRE10700053"
+              "USCA21003160",
+              "USRE10700051"
             ],
-            "title": "I",
-            "length": 313000
-          }
+            "length": 341626,
+            "title": "After All (The Dead)",
+            "video": false
+          },
+          "title": "After All (The Dead)"
         },
         {
-          "recording": {
-            "id": "56c21ffe-3f9c-470f-852c-754070075d7b",
-            "video": false,
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type": "Group",
-                  "name": "Black Sabbath",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2007-03-30",
-            "isrcs": [
-              "USWB10700226"
-            ],
-            "title": "Children of the Sea (live)",
-            "length": 374013
-          },
-          "id": "3f9cc9dd-1bd1-3ed3-a31e-e49ca91ced76",
-          "position": 13,
-          "number": "13",
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                 "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Black Sabbath",
-              "joinphrase": ""
-            }
-          ],
-          "title": "Children of the Sea (live)",
-          "length": 374013
-        },
-        {
-          "number": "14",
-          "length": 361066,
-          "title": "The Devil Cried",
-          "artist-credit": [
-            {
               "joinphrase": "",
-              "name": "Black Sabbath",
-              "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "country": "GB",
-                "name": "Black Sabbath",
-                "disambiguation": "English heavy metal band",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              "name": "Black Sabbath"
             }
           ],
+          "id": "9646f132-4de4-3a37-896b-928179b8970b",
+          "length": 242160,
+          "number": "11",
+          "position": 11,
           "recording": {
-            "first-release-date": "2007-03-13",
-            "title": "The Devil Cried",
-            "length": 361066,
-            "isrcs": [
-              "USRH10720699"
-            ],
-            "id": "94deece5-cc53-415f-a5ea-7ace353b1331",
-            "video": false,
-            "disambiguation": "",
             "artist-credit": [
               {
                 "artist": {
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath",
-                  "disambiguation": "English heavy metal band",
                   "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                   "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
                   "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Black Sabbath"
               }
-            ]
+            ],
+            "disambiguation": "",
+            "first-release-date": "1992-06-01",
+            "id": "fe2763b1-332f-4281-b785-c2fb032a9d5b",
+            "isrcs": [
+              "USCA21003161",
+              "USRE10700052"
+            ],
+            "length": 242000,
+            "title": "TV Crimes",
+            "video": false
           },
-          "position": 14,
-          "id": "df99baba-5501-340a-87c5-28ad921acffc"
+          "title": "TV Crimes"
         },
         {
-          "id": "13668a48-b263-3337-aa36-2bf3ac6a690a",
-          "position": 15,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "297938ec-a80f-3632-9f58-82472d1495fc",
+          "length": 313506,
+          "number": "12",
+          "position": 12,
           "recording": {
-            "video": false,
-            "id": "6659a234-056a-436f-93bd-8d7f9eb74277",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type": "Group",
                   "country": "GB",
-                  "name": "Black Sabbath",
                   "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1992-06-22",
+            "id": "31ef8b7a-e849-49c5-bb6c-778d71497e3b",
+            "isrcs": [
+              "USCA21003167",
+              "USRE10700053"
+            ],
+            "length": 313000,
+            "title": "I",
+            "video": false
+          },
+          "title": "I"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "3f9cc9dd-1bd1-3ed3-a31e-e49ca91ced76",
+          "length": 374013,
+          "number": "13",
+          "position": 13,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-03-30",
+            "id": "56c21ffe-3f9c-470f-852c-754070075d7b",
+            "isrcs": [
+              "USWB10700226"
+            ],
+            "length": 374013,
+            "title": "Children of the Sea (live)",
+            "video": false
+          },
+          "title": "Children of the Sea (live)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "df99baba-5501-340a-87c5-28ad921acffc",
+          "length": 361066,
+          "number": "14",
+          "position": 14,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-03-13",
+            "id": "94deece5-cc53-415f-a5ea-7ace353b1331",
+            "isrcs": [
+              "USRH10720699"
+            ],
+            "length": 361066,
+            "title": "The Devil Cried",
+            "video": false
+          },
+          "title": "The Devil Cried"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "13668a48-b263-3337-aa36-2bf3ac6a690a",
+          "length": 340360,
+          "number": "15",
+          "position": 15,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
@@ -765,143 +788,120 @@
             ],
             "disambiguation": "",
             "first-release-date": "2007-03-27",
-            "length": 340360,
-            "title": "Shadow of the Wind",
+            "id": "6659a234-056a-436f-93bd-8d7f9eb74277",
             "isrcs": [
               "USRH10720700"
-            ]
+            ],
+            "length": 340360,
+            "title": "Shadow of the Wind",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Black Sabbath",
-              "artist": {
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "English heavy metal band",
-                "name": "Black Sabbath"
-              }
-            }
-          ],
-          "title": "Shadow of the Wind",
-          "length": 340360,
-          "number": "15"
+          "title": "Shadow of the Wind"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "bbb17464-aac7-3c75-a464-475de6df496d",
+          "length": 244853,
+          "number": "16",
+          "position": 16,
           "recording": {
-            "isrcs": [
-              "USRH10720701"
-            ],
-            "length": 244853,
-            "title": "Ear in the Wall",
-            "first-release-date": "2007-03-30",
-            "disambiguation": "",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type": "Group",
-                  "name": "Black Sabbath",
                   "country": "GB",
                   "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Black Sabbath"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2007-03-30",
             "id": "dc8d14c0-51ae-4409-85c0-05ae27e60363",
+            "isrcs": [
+              "USRH10720701"
+            ],
+            "length": 244853,
+            "title": "Ear in the Wall",
             "video": false
           },
-          "id": "bbb17464-aac7-3c75-a464-475de6df496d",
-          "position": 16,
-          "number": "16",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Black Sabbath",
-              "artist": {
-                "country": "GB",
-                "name": "Black Sabbath",
-                "disambiguation": "English heavy metal band",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath"
-              }
-            }
-          ],
-          "length": 244853,
           "title": "Ear in the Wall"
         }
-      ],
-      "format": "CD",
-      "track-count": 16
+      ]
     }
   ],
-  "status": "Official",
-  "quality": "normal",
-  "cover-art-archive": {
-    "back": true,
-    "front": true,
-    "darkened": false,
-    "count": 6,
-    "artwork": true
-  },
-  "title": "The Dio Years",
-  "asin": "B000NA77YO",
-  "id": "9764a202-87e6-4bd1-9cf9-147a5d089f77",
   "packaging": "Jewel Case",
-  "country": "DE",
-  "disambiguation": "",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
   "release-events": [
     {
       "area": {
+        "disambiguation": "",
+        "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
         "iso-3166-1-codes": [
           "DE"
         ],
-        "type-id": null,
         "name": "Germany",
-        "disambiguation": "",
+        "sort-name": "Germany",
         "type": null,
-        "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
-        "sort-name": "Germany"
+        "type-id": null
       },
       "date": "2007-03-30"
     }
   ],
   "release-group": {
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "first-release-date": "2007-03-30",
-    "title": "The Dio Years",
-    "id": "ebe9bc5e-d5da-31c4-8e8a-8c5c54700b48",
-    "primary-type": "Album",
-    "secondary-type-ids": [
-      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
-    ],
     "artist-credit": [
       {
         "artist": {
-          "sort-name": "Black Sabbath",
-          "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "type": "Group",
           "country": "GB",
           "disambiguation": "English heavy metal band",
-          "name": "Black Sabbath"
+          "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+          "name": "Black Sabbath",
+          "sort-name": "Black Sabbath",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
         },
         "joinphrase": "",
         "name": "Black Sabbath"
       }
     ],
+    "disambiguation": "",
+    "first-release-date": "2007-03-30",
+    "id": "ebe9bc5e-d5da-31c4-8e8a-8c5c54700b48",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [
+      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
+    ],
     "secondary-types": [
       "Compilation"
     ],
-    "disambiguation": ""
-  }
+    "title": "The Dio Years"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "The Dio Years"
 }

--- a/scripts/eval_matching/corpus/eval_release_97c0a036.json
+++ b/scripts/eval_matching/corpus/eval_release_97c0a036.json
@@ -1,3688 +1,3688 @@
 {
-  "status": "Official",
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "GB",
+        "disambiguation": "Electronic/DnB producer from UK",
+        "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+        "name": "Matt Pelling",
+        "sort-name": "Pelling, Matthew Robert",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+      },
+      "joinphrase": ", ",
+      "name": "Matthew R. Pelling"
+    },
+    {
+      "artist": {
+        "country": "GB",
+        "disambiguation": "Electronic/DnB producer",
+        "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+        "name": "Andre Touhey",
+        "sort-name": "Touhey, Andre",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+      },
+      "joinphrase": " & ",
+      "name": "Andre N. Touhey"
+    },
+    {
+      "artist": {
+        "country": "GB",
+        "disambiguation": "Electronic/DnB producer from the UK",
+        "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+        "name": "Paul Willard",
+        "sort-name": "Willard, Paul",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+      },
+      "joinphrase": "",
+      "name": "Paul I. Willard"
+    }
+  ],
+  "asin": null,
+  "barcode": null,
+  "country": "XW",
+  "cover-art-archive": {
+    "artwork": false,
+    "back": false,
+    "count": 0,
+    "darkened": false,
+    "front": false
+  },
+  "date": "2010-06-03",
   "disambiguation": "",
-  "quality": "normal",
+  "id": "97c0a036-2ecb-4662-b011-bc61b671c64d",
   "label-info": [
     {
       "catalog-number": "WOM 219",
       "label": {
-        "name": "West One Music",
-        "type": "Original Production",
-        "label-code": null,
+        "disambiguation": "production music label, prefix: WOM",
         "id": "320d1d76-d454-4a41-a96b-d3021f766f64",
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
+        "label-code": null,
+        "name": "West One Music",
         "sort-name": "West One Music",
-        "disambiguation": "production music label, prefix: WOM"
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
-  "id": "97c0a036-2ecb-4662-b011-bc61b671c64d",
-  "release-group": {
-    "secondary-type-ids": [],
-    "artist-credit": [
-      {
-        "joinphrase": ", ",
-        "artist": {
-          "disambiguation": "Electronic/DnB producer from UK",
-          "sort-name": "Pelling, Matthew Robert",
-          "type": "Person",
-          "name": "Matt Pelling",
-          "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "country": "GB"
-        },
-        "name": "Matthew R. Pelling"
-      },
-      {
-        "artist": {
-          "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-          "name": "Andre Touhey",
-          "type": "Person",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "country": "GB",
-          "disambiguation": "Electronic/DnB producer",
-          "sort-name": "Touhey, Andre"
-        },
-        "name": "Andre N. Touhey",
-        "joinphrase": " & "
-      },
-      {
-        "joinphrase": "",
-        "artist": {
-          "type": "Person",
-          "name": "Paul Willard",
-          "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-          "country": "GB",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "sort-name": "Willard, Paul",
-          "disambiguation": "Electronic/DnB producer from the UK"
-        },
-        "name": "Paul I. Willard"
-      }
-    ],
-    "primary-type-id": "4fc3be2b-de1e-396b-a933-beb8f1607a22",
-    "title": "Explosive Drum & Bass",
-    "disambiguation": "",
-    "first-release-date": "2010-06-03",
-    "secondary-types": [],
-    "primary-type": "Other",
-    "id": "7473f354-1c3d-440f-8e8b-bda8eb1e2f86"
-  },
   "media": [
     {
-      "track-offset": 0,
-      "position": 1,
-      "title": "",
       "format": "Digital Media",
       "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+      "id": "ec091624-bdf7-3bf1-995b-76436c345daa",
+      "position": 1,
+      "title": "",
+      "track-count": 36,
+      "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
-              "joinphrase": ", ",
               "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
                 "type": "Person",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": ", ",
               "name": "Matthew R. Pelling"
             },
             {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
               "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "name": "Andre Touhey",
-                "type": "Person"
-              }
-            },
-            {
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-              },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
-            }
-          ],
-          "length": 192000,
-          "number": "1",
-          "position": 1,
-          "title": "Are You Ready? (full)",
-          "recording": {
-            "id": "1d8642be-a00c-48a4-ae32-48553a640298",
-            "isrcs": [],
-            "video": false,
-            "first-release-date": "2010-06-03",
-            "title": "Are You Ready? (full)",
-            "disambiguation": "",
-            "length": 192000,
-            "artist-credit": [
-              {
-                "name": "Matthew R. Pelling",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert"
-                },
-                "joinphrase": ", "
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
-                }
-              },
-              {
-                "name": "Paul I. Willard",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
-                },
-                "joinphrase": ""
-              }
-            ]
-          },
-          "id": "04a425f8-13e1-356d-8d38-1dac0dc51ac3"
-        },
-        {
-          "title": "Razor Wire (full)",
-          "position": 2,
-          "number": "2",
-          "length": 191000,
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK"
-              },
-              "name": "Matthew R. Pelling",
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
                 "sort-name": "Touhey, Andre",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "name": "Andre Touhey",
-                "type": "Person"
-              }
-            },
-            {
-              "name": "Paul I. Willard",
-              "artist": {
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                 "type": "Person",
-                "name": "Paul Willard",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
-            }
-          ],
-          "id": "37a239d0-cbd4-3c01-a283-489b1cb4f4df",
-          "recording": {
-            "disambiguation": "",
-            "title": "Razor Wire (full)",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44"
-                },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
-              },
-              {
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
-                },
-                "name": "Andre N. Touhey",
-                "joinphrase": " & "
-              },
-              {
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "length": 191000,
-            "isrcs": [],
-            "video": false,
-            "id": "fd524f77-6034-46f6-828a-aaefe6c1274a",
-            "first-release-date": "2010-06-03"
-          }
-        },
-        {
-          "length": 140000,
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
-                "name": "Matt Pelling"
-              },
-              "name": "Matthew R. Pelling"
-            },
-            {
               "joinphrase": " & ",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "name": "Andre Touhey",
-                "type": "Person"
-              },
               "name": "Andre N. Touhey"
             },
             {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
               "artist": {
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type": "Person",
-                "name": "Paul Willard",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "GB",
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
-              }
-            }
-          ],
-          "title": "Rear View Mirror (full)",
-          "position": 3,
-          "number": "3",
-          "id": "f8405581-00c7-3b6c-96f1-299c1699b092",
-          "recording": {
-            "first-release-date": "2010-06-03",
-            "id": "ff1def69-15a8-4278-b196-d6df5af2debb",
-            "isrcs": [],
-            "video": false,
-            "length": 140000,
-            "artist-credit": [
-              {
-                "name": "Matthew R. Pelling",
-                "artist": {
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                },
-                "joinphrase": ", "
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                }
-              },
-              {
-                "artist": {
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "title": "Rear View Mirror (full)",
-            "disambiguation": ""
-          }
-        },
-        {
-          "length": 192000,
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              }
-            },
-            {
-              "name": "Andre N. Touhey",
-              "artist": {
-                "type": "Person",
-                "name": "Andre Touhey",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              },
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
-              "artist": {
                 "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
                 "sort-name": "Willard, Paul",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "name": "Paul Willard",
                 "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              }
-            }
-          ],
-          "title": "Effervescence (full)",
-          "position": 4,
-          "number": "4",
-          "id": "a8b30ea1-7d99-3237-b3bb-286d7831c8ef",
-          "recording": {
-            "disambiguation": "",
-            "title": "Effervescence (full)",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person"
-                },
-                "name": "Paul I. Willard"
-              }
-            ],
-            "length": 192000,
-            "isrcs": [],
-            "video": false,
-            "id": "fe9ee4bf-c11d-461e-b6a6-b07a85bf29e2",
-            "first-release-date": "2010-06-03"
-          }
-        },
-        {
-          "recording": {
-            "title": "Trigger Happy (full)",
-            "disambiguation": "",
-            "length": 187000,
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                },
-                "name": "Matthew R. Pelling"
-              },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type": "Person",
-                  "name": "Andre Touhey"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "id": "70aa7fe0-dd46-4d3c-8769-b2bf34f4ceb8",
-            "isrcs": [],
-            "video": false,
-            "first-release-date": "2010-06-03"
-          },
-          "id": "0f8b7612-3e55-386e-87ae-2ecf31ace3ce",
-          "number": "5",
-          "position": 5,
-          "title": "Trigger Happy (full)",
-          "artist-credit": [
-            {
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person"
-              },
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
-              "artist": {
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              }
-            },
-            {
               "joinphrase": "",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
-              },
               "name": "Paul I. Willard"
             }
           ],
-          "length": 187000
+          "id": "04a425f8-13e1-356d-8d38-1dac0dc51ac3",
+          "length": 192000,
+          "number": "1",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "1d8642be-a00c-48a4-ae32-48553a640298",
+            "isrcs": [],
+            "length": 192000,
+            "title": "Are You Ready? (full)",
+            "video": false
+          },
+          "title": "Are You Ready? (full)"
         },
         {
-          "position": 6,
-          "title": "Cardiac Attack (full)",
-          "number": "6",
-          "length": 207000,
           "artist-credit": [
             {
-              "joinphrase": ", ",
               "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
                 "type": "Person",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": ", ",
               "name": "Matthew R. Pelling"
             },
             {
               "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "name": "Andre Touhey",
-                "type": "Person"
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Andre N. Touhey",
-              "joinphrase": " & "
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
             },
             {
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
                 "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                 "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
                 "type": "Person",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Paul I. Willard"
             }
           ],
-          "id": "5d16dffc-addc-3901-9d76-c5595baae6c7",
+          "id": "37a239d0-cbd4-3c01-a283-489b1cb4f4df",
+          "length": 191000,
+          "number": "2",
+          "position": 2,
           "recording": {
-            "isrcs": [],
-            "video": false,
-            "id": "879faf96-7f96-4555-bf15-f08665393502",
-            "first-release-date": "2010-06-03",
-            "disambiguation": "",
-            "title": "Cardiac Attack (full)",
             "artist-credit": [
               {
-                "joinphrase": ", ",
                 "artist": {
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
                   "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
                   "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": ", ",
                 "name": "Matthew R. Pelling"
               },
               {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-                },
-                "name": "Paul I. Willard"
-              }
-            ],
-            "length": 207000
-          }
-        },
-        {
-          "id": "451f8671-0393-3131-94b3-0b5b057ee961",
-          "recording": {
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "b2782778-77b9-4eb6-8323-0a6c9e0337e2",
-            "artist-credit": [
-              {
-                "name": "Matthew R. Pelling",
                 "artist": {
                   "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert"
-                },
-                "joinphrase": ", "
-              },
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                   "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Andre N. Touhey",
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "name": "Paul I. Willard",
-                "artist": {
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
-                }
-              }
-            ],
-            "length": 164000,
-            "disambiguation": "",
-            "title": "True Grit (full)"
-          },
-          "position": 7,
-          "title": "True Grit (full)",
-          "number": "7",
-          "length": 164000,
-          "artist-credit": [
-            {
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              },
-              "joinphrase": ", "
-            },
-            {
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              },
-              "name": "Andre N. Touhey",
-              "joinphrase": " & "
-            },
-            {
-              "artist": {
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "name": "Paul Willard",
-                "type": "Person",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "id": "35e4ac41-9443-33c5-a7d7-3bf91dede420",
-          "recording": {
-            "video": false,
-            "isrcs": [],
-            "id": "4b5b0103-d6d4-4641-be03-0fb8f04da008",
-            "first-release-date": "2010-06-03",
-            "disambiguation": "",
-            "title": "Reflux Deluxe (full)",
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "name": "Matthew R. Pelling",
-                "artist": {
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                }
-              },
-              {
                 "joinphrase": " & ",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre",
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                },
                 "name": "Andre N. Touhey"
               },
               {
-                "name": "Paul I. Willard",
                 "artist": {
-                  "sort-name": "Willard, Paul",
+                  "country": "GB",
                   "disambiguation": "Electronic/DnB producer from the UK",
-                  "type": "Person",
-                  "name": "Paul Willard",
                   "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Paul I. Willard"
               }
             ],
-            "length": 191000
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "fd524f77-6034-46f6-828a-aaefe6c1274a",
+            "isrcs": [],
+            "length": 191000,
+            "title": "Razor Wire (full)",
+            "video": false
           },
-          "title": "Reflux Deluxe (full)",
-          "position": 8,
-          "number": "8",
-          "length": 191000,
-          "artist-credit": [
-            {
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "type": "Person",
-                "name": "Matt Pelling",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK"
-              },
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              }
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
-              },
-              "name": "Paul I. Willard"
-            }
-          ]
+          "title": "Razor Wire (full)"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "f8405581-00c7-3b6c-96f1-299c1699b092",
+          "length": 140000,
+          "number": "3",
+          "position": 3,
           "recording": {
-            "length": 191000,
             "artist-credit": [
               {
                 "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
                   "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                   "name": "Matt Pelling",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
                   "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
               },
               {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
                 "artist": {
                   "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type": "Person",
-                  "name": "Andre Touhey",
                   "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
-                }
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
               },
               {
-                "joinphrase": "",
-                "name": "Paul I. Willard",
                 "artist": {
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                   "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
                   "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
-                }
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
               }
             ],
-            "title": "Sonic Grenade (full)",
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "ff1def69-15a8-4278-b196-d6df5af2debb",
+            "isrcs": [],
+            "length": 140000,
+            "title": "Rear View Mirror (full)",
+            "video": false
+          },
+          "title": "Rear View Mirror (full)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "a8b30ea1-7d99-3237-b3bb-286d7831c8ef",
+          "length": 192000,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "fe9ee4bf-c11d-461e-b6a6-b07a85bf29e2",
+            "isrcs": [],
+            "length": 192000,
+            "title": "Effervescence (full)",
+            "video": false
+          },
+          "title": "Effervescence (full)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "0f8b7612-3e55-386e-87ae-2ecf31ace3ce",
+          "length": 187000,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "70aa7fe0-dd46-4d3c-8769-b2bf34f4ceb8",
+            "isrcs": [],
+            "length": 187000,
+            "title": "Trigger Happy (full)",
+            "video": false
+          },
+          "title": "Trigger Happy (full)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "5d16dffc-addc-3901-9d76-c5595baae6c7",
+          "length": 207000,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "879faf96-7f96-4555-bf15-f08665393502",
+            "isrcs": [],
+            "length": 207000,
+            "title": "Cardiac Attack (full)",
+            "video": false
+          },
+          "title": "Cardiac Attack (full)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "451f8671-0393-3131-94b3-0b5b057ee961",
+          "length": 164000,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "b2782778-77b9-4eb6-8323-0a6c9e0337e2",
+            "isrcs": [],
+            "length": 164000,
+            "title": "True Grit (full)",
+            "video": false
+          },
+          "title": "True Grit (full)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "35e4ac41-9443-33c5-a7d7-3bf91dede420",
+          "length": 191000,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "4b5b0103-d6d4-4641-be03-0fb8f04da008",
+            "isrcs": [],
+            "length": 191000,
+            "title": "Reflux Deluxe (full)",
+            "video": false
+          },
+          "title": "Reflux Deluxe (full)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "9c8af283-565d-3925-8707-9eed319ca74b",
+          "length": 191000,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
             "disambiguation": "",
             "first-release-date": "2010-06-03",
             "id": "0cced5a5-47e2-42b5-b241-f3dc70d5b0c1",
             "isrcs": [],
+            "length": 191000,
+            "title": "Sonic Grenade (full)",
             "video": false
           },
-          "id": "9c8af283-565d-3925-8707-9eed319ca74b",
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
-              }
-            },
-            {
-              "name": "Andre N. Touhey",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "Andre Touhey",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-              },
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
-              },
-              "name": "Paul I. Willard"
-            }
-          ],
-          "length": 191000,
-          "number": "9",
-          "position": 9,
           "title": "Sonic Grenade (full)"
         },
         {
           "artist-credit": [
             {
-              "name": "Matthew R. Pelling",
               "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
                 "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "name": "Matt Pelling",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
                 "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ", "
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
             },
             {
               "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "name": "Andre Touhey",
-                "type": "Person"
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Andre N. Touhey",
-              "joinphrase": " & "
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
             },
             {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
               "artist": {
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                 "name": "Paul Willard",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-              }
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
             }
           ],
+          "id": "97fb18ef-0d48-3451-b556-973db4ba815c",
           "length": 167000,
           "number": "10",
           "position": 10,
-          "title": "Bunker Boys (full)",
           "recording": {
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "bb987245-837d-44f5-ac2a-98ea394dcdea",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
+                  "country": "GB",
                   "disambiguation": "Electronic/DnB producer from UK",
-                  "name": "Matt Pelling",
-                  "type": "Person",
                   "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
               },
               {
                 "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
                   "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                   "name": "Andre Touhey",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
                   "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Andre N. Touhey",
-                "joinphrase": " & "
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
               },
               {
-                "joinphrase": "",
-                "name": "Paul I. Willard",
                 "artist": {
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
                   "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
-                }
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
               }
             ],
-            "length": 167000,
             "disambiguation": "",
-            "title": "Bunker Boys (full)"
+            "first-release-date": "2010-06-03",
+            "id": "bb987245-837d-44f5-ac2a-98ea394dcdea",
+            "isrcs": [],
+            "length": 167000,
+            "title": "Bunker Boys (full)",
+            "video": false
           },
-          "id": "97fb18ef-0d48-3451-b556-973db4ba815c"
+          "title": "Bunker Boys (full)"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": ", ",
               "artist": {
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
-                "name": "Matt Pelling",
                 "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": ", ",
               "name": "Matthew R. Pelling"
             },
             {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
               "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
                 "type": "Person",
-                "name": "Andre Touhey"
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
             },
             {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
               "artist": {
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
                 "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
                 "type": "Person",
-                "name": "Paul Willard"
-              }
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
             }
           ],
+          "id": "c8197467-99f0-3db3-9f47-6071def00903",
           "length": 171000,
           "number": "11",
-          "title": "Alter Ego (full)",
           "position": 11,
           "recording": {
-            "length": 171000,
             "artist-credit": [
               {
-                "joinphrase": ", ",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                   "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert"
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": ", ",
                 "name": "Matthew R. Pelling"
               },
               {
-                "joinphrase": " & ",
                 "artist": {
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
                   "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " & ",
                 "name": "Andre N. Touhey"
               },
               {
-                "joinphrase": "",
                 "artist": {
+                  "country": "GB",
                   "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
                   "sort-name": "Willard, Paul",
                   "type": "Person",
-                  "name": "Paul Willard",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "country": "GB",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Paul I. Willard"
               }
             ],
-            "title": "Alter Ego (full)",
             "disambiguation": "",
             "first-release-date": "2010-06-03",
             "id": "673bc14b-4478-4411-a2cf-8a85ea82c53c",
             "isrcs": [],
+            "length": 171000,
+            "title": "Alter Ego (full)",
             "video": false
           },
-          "id": "c8197467-99f0-3db3-9f47-6071def00903"
+          "title": "Alter Ego (full)"
         },
         {
-          "recording": {
-            "video": false,
-            "isrcs": [],
-            "id": "79f616a6-30f6-4156-8f70-b701d8ff9dd0",
-            "first-release-date": "2010-06-03",
-            "disambiguation": "",
-            "title": "Asymmetric Terror (full)",
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "name": "Matthew R. Pelling",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert"
-                }
-              },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
-                },
-                "name": "Paul I. Willard"
-              }
-            ],
-            "length": 187000
-          },
-          "id": "46d32e1a-4566-30d3-ba4d-820113c7f1f2",
-          "number": "12",
-          "title": "Asymmetric Terror (full)",
-          "position": 12,
           "artist-credit": [
             {
-              "joinphrase": ", ",
               "artist": {
-                "sort-name": "Pelling, Matthew Robert",
+                "country": "GB",
                 "disambiguation": "Electronic/DnB producer from UK",
                 "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
                 "name": "Matt Pelling",
-                "country": "GB",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": ", ",
               "name": "Matthew R. Pelling"
             },
             {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
               "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
             },
             {
-              "joinphrase": "",
               "artist": {
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer from the UK",
                 "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                 "name": "Paul Willard",
-                "type": "Person"
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Paul I. Willard"
             }
           ],
-          "length": 187000
-        },
-        {
-          "id": "66f27db9-cb98-3101-b7f8-e5673d02a07e",
+          "id": "46d32e1a-4566-30d3-ba4d-820113c7f1f2",
+          "length": 187000,
+          "number": "12",
+          "position": 12,
           "recording": {
-            "length": 191000,
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
-                  "name": "Matt Pelling",
-                  "type": "Person",
+                  "disambiguation": "Electronic/DnB producer from UK",
                   "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
                   "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
               },
               {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
                 "artist": {
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
                   "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
-                }
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
               },
               {
-                "name": "Paul I. Willard",
                 "artist": {
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                   "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
                   "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Paul I. Willard"
               }
             ],
-            "title": "Are You Ready? (underscore)",
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "79f616a6-30f6-4156-8f70-b701d8ff9dd0",
+            "isrcs": [],
+            "length": 187000,
+            "title": "Asymmetric Terror (full)",
+            "video": false
+          },
+          "title": "Asymmetric Terror (full)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "66f27db9-cb98-3101-b7f8-e5673d02a07e",
+          "length": 191000,
+          "number": "13",
+          "position": 13,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
             "disambiguation": "",
             "first-release-date": "2010-06-03",
             "id": "a444d27c-46d1-46d5-9d81-e939a6c115a5",
             "isrcs": [],
+            "length": 191000,
+            "title": "Are You Ready? (underscore)",
             "video": false
           },
-          "length": 191000,
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44"
-              }
-            },
-            {
-              "name": "Andre N. Touhey",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "name": "Andre Touhey",
-                "type": "Person"
-              },
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type": "Person",
-                "name": "Paul Willard"
-              },
-              "name": "Paul I. Willard"
-            }
-          ],
-          "position": 13,
-          "title": "Are You Ready? (underscore)",
-          "number": "13"
+          "title": "Are You Ready? (underscore)"
         },
         {
-          "recording": {
-            "title": "Razor Wire (underscore)",
-            "disambiguation": "",
-            "length": 191000,
-            "artist-credit": [
-              {
-                "name": "Matthew R. Pelling",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert"
-                },
-                "joinphrase": ", "
-              },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
-                },
-                "name": "Paul I. Willard"
-              }
-            ],
-            "id": "434988a7-6151-4f6a-9dae-2b6ad3404d6c",
-            "video": false,
-            "isrcs": [],
-            "first-release-date": "2010-06-03"
-          },
-          "id": "7b0c8715-e101-3647-bbc8-bbd9fb6b64f0",
           "artist-credit": [
             {
-              "name": "Matthew R. Pelling",
               "artist": {
+                "country": "GB",
                 "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
                 "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
                 "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ", "
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
             },
             {
-              "joinphrase": " & ",
               "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "name": "Andre Touhey",
-                "type": "Person"
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " & ",
               "name": "Andre N. Touhey"
             },
             {
-              "joinphrase": "",
               "artist": {
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "Paul Willard",
+                "disambiguation": "Electronic/DnB producer from the UK",
                 "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
                 "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Paul I. Willard"
             }
           ],
+          "id": "7b0c8715-e101-3647-bbc8-bbd9fb6b64f0",
           "length": 191000,
           "number": "14",
-          "title": "Razor Wire (underscore)",
-          "position": 14
-        },
-        {
-          "id": "0715f67f-fd15-3d97-83f4-df13eed816b4",
+          "position": 14,
           "recording": {
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "f5cc2678-aafb-415b-8fa3-da86b3f8c301",
             "artist-credit": [
               {
                 "artist": {
-                  "type": "Person",
-                  "name": "Matt Pelling",
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
                   "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "name": "Matt Pelling",
                   "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "name": "Andre Touhey",
                   "type": "Person",
-                  "country": "GB",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              },
-              {
-                "artist": {
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul"
                 },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "length": 140000,
-            "disambiguation": "",
-            "title": "Rear View Mirror (underscore)"
-          },
-          "length": 140000,
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "artist": {
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
               },
-              "name": "Matthew R. Pelling"
-            },
-            {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-              }
-            },
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type": "Person",
-                "name": "Paul Willard",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
-              },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
-            }
-          ],
-          "title": "Rear View Mirror (underscore)",
-          "position": 15,
-          "number": "15"
-        },
-        {
-          "recording": {
-            "title": "Effervescence (underscore)",
-            "disambiguation": "",
-            "length": 192000,
-            "artist-credit": [
               {
-                "name": "Matthew R. Pelling",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                },
-                "joinphrase": ", "
-              },
-              {
-                "joinphrase": " & ",
-                "artist": {
                   "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
                   "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                   "name": "Andre Touhey",
-                  "type": "Person"
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " & ",
                 "name": "Andre N. Touhey"
               },
               {
                 "artist": {
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Paul I. Willard"
               }
             ],
-            "id": "99a23efa-e81e-4e63-9587-958d6d6ca8db",
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "434988a7-6151-4f6a-9dae-2b6ad3404d6c",
             "isrcs": [],
-            "video": false,
-            "first-release-date": "2010-06-03"
+            "length": 191000,
+            "title": "Razor Wire (underscore)",
+            "video": false
           },
-          "id": "8cd124dc-edad-36d0-a371-d6b0321a7a6d",
+          "title": "Razor Wire (underscore)"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
               "artist": {
+                "country": "GB",
                 "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
                 "sort-name": "Pelling, Matthew Robert",
                 "type": "Person",
-                "name": "Matt Pelling",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              }
-            },
-            {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
-              "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-              }
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
               "name": "Paul I. Willard"
             }
           ],
+          "id": "0715f67f-fd15-3d97-83f4-df13eed816b4",
+          "length": 140000,
+          "number": "15",
+          "position": 15,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "f5cc2678-aafb-415b-8fa3-da86b3f8c301",
+            "isrcs": [],
+            "length": 140000,
+            "title": "Rear View Mirror (underscore)",
+            "video": false
+          },
+          "title": "Rear View Mirror (underscore)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "8cd124dc-edad-36d0-a371-d6b0321a7a6d",
           "length": 192000,
           "number": "16",
-          "title": "Effervescence (underscore)",
-          "position": 16
-        },
-        {
-          "id": "b88e47c2-1093-3c52-ab83-84473d56aa9c",
+          "position": 16,
           "recording": {
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "a138e7da-6d4b-41d5-974d-489a438e04a7",
             "artist-credit": [
               {
-                "name": "Matthew R. Pelling",
                 "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
                   "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
                   "type": "Person",
-                  "name": "Matt Pelling"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "joinphrase": ", "
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
               },
               {
-                "joinphrase": " & ",
                 "artist": {
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                   "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
                   "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " & ",
                 "name": "Andre N. Touhey"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
                   "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Paul I. Willard"
               }
             ],
-            "length": 187000,
             "disambiguation": "",
-            "title": "Trigger Happy (underscore)"
+            "first-release-date": "2010-06-03",
+            "id": "99a23efa-e81e-4e63-9587-958d6d6ca8db",
+            "isrcs": [],
+            "length": 192000,
+            "title": "Effervescence (underscore)",
+            "video": false
           },
-          "title": "Trigger Happy (underscore)",
-          "position": 17,
-          "number": "17",
-          "length": 187000,
+          "title": "Effervescence (underscore)"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": ", ",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
                 "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "name": "Matt Pelling",
-                "type": "Person",
                 "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": ", ",
               "name": "Matthew R. Pelling"
             },
             {
-              "joinphrase": " & ",
               "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "name": "Andre Touhey",
-                "type": "Person"
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " & ",
               "name": "Andre N. Touhey"
             },
             {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
               "artist": {
-                "name": "Paul Willard",
-                "type": "Person",
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
                 "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
-              }
-            }
-          ]
-        },
-        {
-          "recording": {
-            "isrcs": [],
-            "video": false,
-            "id": "56ff95ad-0feb-4980-b138-eef70be28fac",
-            "first-release-date": "2010-06-03",
-            "disambiguation": "",
-            "title": "Cardiac Attack (underscore)",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
-              },
-              {
-                "joinphrase": " & ",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
-                },
-                "name": "Andre N. Touhey"
-              },
-              {
-                "joinphrase": "",
-                "name": "Paul I. Willard",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul"
-                }
-              }
-            ],
-            "length": 208000
-          },
-          "id": "9ba38835-dc16-3868-ab8b-744e75d151ae",
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "artist": {
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "name": "Matthew R. Pelling"
-            },
-            {
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type": "Person",
-                "name": "Andre Touhey",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              },
-              "name": "Andre N. Touhey",
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from the UK",
+                "name": "Paul Willard",
                 "sort-name": "Willard, Paul",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "name": "Paul Willard",
                 "type": "Person",
-                "country": "GB",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Paul I. Willard"
             }
           ],
-          "length": 208000,
-          "number": "18",
-          "title": "Cardiac Attack (underscore)",
-          "position": 18
+          "id": "b88e47c2-1093-3c52-ab83-84473d56aa9c",
+          "length": 187000,
+          "number": "17",
+          "position": 17,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "a138e7da-6d4b-41d5-974d-489a438e04a7",
+            "isrcs": [],
+            "length": 187000,
+            "title": "Trigger Happy (underscore)",
+            "video": false
+          },
+          "title": "Trigger Happy (underscore)"
         },
         {
-          "length": 164000,
           "artist-credit": [
             {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
               "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer from UK",
                 "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "name": "Matt Pelling",
-                "type": "Person"
-              }
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
             },
             {
-              "joinphrase": " & ",
               "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
                 "type": "Person",
-                "name": "Andre Touhey"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": " & ",
               "name": "Andre N. Touhey"
             },
             {
               "artist": {
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer from the UK",
                 "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
                 "type": "Person",
-                "name": "Paul Willard"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Paul I. Willard"
             }
           ],
-          "position": 19,
-          "title": "True Grit (underscore)",
-          "number": "19",
-          "id": "f2cbbb05-87be-302d-9134-5bd2e69c6e98",
+          "id": "9ba38835-dc16-3868-ab8b-744e75d151ae",
+          "length": 208000,
+          "number": "18",
+          "position": 18,
           "recording": {
-            "id": "76b9273c-6802-4e2c-a351-0d73a73decf2",
-            "isrcs": [],
-            "video": false,
-            "first-release-date": "2010-06-03",
-            "title": "True Grit (underscore)",
-            "disambiguation": "",
-            "length": 164000,
             "artist-credit": [
               {
-                "joinphrase": ", ",
-                "name": "Matthew R. Pelling",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
-                  "type": "Person",
-                  "name": "Matt Pelling",
+                  "disambiguation": "Electronic/DnB producer from UK",
                   "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
                   "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                }
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
               },
               {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
                 "artist": {
                   "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                  "disambiguation": "Electronic/DnB producer",
                   "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                   "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
                   "type": "Person",
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
-                }
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
                   "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                   "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
                   "type": "Person",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Paul I. Willard"
               }
-            ]
-          }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "56ff95ad-0feb-4980-b138-eef70be28fac",
+            "isrcs": [],
+            "length": 208000,
+            "title": "Cardiac Attack (underscore)",
+            "video": false
+          },
+          "title": "Cardiac Attack (underscore)"
         },
         {
           "artist-credit": [
             {
-              "name": "Matthew R. Pelling",
               "artist": {
-                "name": "Matt Pelling",
-                "type": "Person",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ", "
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
             },
             {
               "artist": {
-                "sort-name": "Touhey, Andre",
+                "country": "GB",
                 "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
                 "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Andre N. Touhey",
-              "joinphrase": " & "
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
             },
             {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
               "artist": {
-                "type": "Person",
-                "name": "Paul Willard",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
-              }
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
             }
           ],
+          "id": "f2cbbb05-87be-302d-9134-5bd2e69c6e98",
+          "length": 164000,
+          "number": "19",
+          "position": 19,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "76b9273c-6802-4e2c-a351-0d73a73decf2",
+            "isrcs": [],
+            "length": 164000,
+            "title": "True Grit (underscore)",
+            "video": false
+          },
+          "title": "True Grit (underscore)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "490467cd-7400-3868-93dd-5c7a1e1289e1",
           "length": 191000,
           "number": "20",
           "position": 20,
-          "title": "Reflux Deluxe (underscore)",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
+                  "country": "GB",
                   "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert",
                   "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                   "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
                   "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
               },
               {
-                "joinphrase": " & ",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type": "Person",
-                  "name": "Andre Touhey",
                   "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": " & ",
                 "name": "Andre N. Touhey"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Paul I. Willard"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "0e3f352b-452b-4655-96a8-80870fcf0973",
+            "isrcs": [],
             "length": 191000,
-            "disambiguation": "",
             "title": "Reflux Deluxe (underscore)",
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "0e3f352b-452b-4655-96a8-80870fcf0973"
+            "video": false
           },
-          "id": "490467cd-7400-3868-93dd-5c7a1e1289e1"
+          "title": "Reflux Deluxe (underscore)"
         },
         {
-          "id": "31aacdac-6c2d-3b66-b123-44e7f934deb7",
-          "recording": {
-            "id": "caab21dc-75a6-4aa5-a9a4-e054c6c8e309",
-            "video": false,
-            "isrcs": [],
-            "first-release-date": "2010-06-03",
-            "title": "Sonic Grenade (underscore)",
-            "disambiguation": "",
-            "length": 190000,
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert"
-                },
-                "name": "Matthew R. Pelling"
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              },
-              {
-                "joinphrase": "",
-                "name": "Paul I. Willard",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                }
-              }
-            ]
-          },
-          "length": 190000,
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Pelling, Matthew Robert",
+                "country": "GB",
                 "disambiguation": "Electronic/DnB producer from UK",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
                 "type": "Person",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Matthew R. Pelling",
-              "joinphrase": ", "
-            },
-            {
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "Andre Touhey",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              },
-              "name": "Andre N. Touhey",
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
-              "artist": {
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type": "Person",
-                "name": "Paul Willard"
-              }
-            }
-          ],
-          "title": "Sonic Grenade (underscore)",
-          "position": 21,
-          "number": "21"
-        },
-        {
-          "length": 167000,
-          "artist-credit": [
-            {
               "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
-              }
-            },
-            {
-              "name": "Andre N. Touhey",
-              "artist": {
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              },
-              "joinphrase": " & "
-            },
-            {
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "name": "Paul Willard",
-                "type": "Person"
-              },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
-            }
-          ],
-          "title": "Bunker Boys (underscore)",
-          "position": 22,
-          "number": "22",
-          "id": "c866d432-ddaf-3bde-9996-5c46b47c9001",
-          "recording": {
-            "id": "694f45a2-26a3-4fb7-8be0-2ddfad5d7bee",
-            "video": false,
-            "isrcs": [],
-            "first-release-date": "2010-06-03",
-            "title": "Bunker Boys (underscore)",
-            "disambiguation": "",
-            "length": 167000,
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert"
-                },
-                "name": "Matthew R. Pelling"
-              },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "name": "Paul I. Willard",
-                "artist": {
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type": "Person",
-                  "name": "Paul Willard"
-                },
-                "joinphrase": ""
-              }
-            ]
-          }
-        },
-        {
-          "artist-credit": [
-            {
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44"
-              },
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-              },
-              "name": "Andre N. Touhey"
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "type": "Person",
-                "name": "Paul Willard",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
-              },
-              "name": "Paul I. Willard"
-            }
-          ],
-          "length": 159000,
-          "number": "23",
-          "position": 23,
-          "title": "Alter Ego (underscore)",
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "name": "Matthew R. Pelling",
-                "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
-                }
-              },
-              {
-                "joinphrase": "",
-                "name": "Paul I. Willard",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                }
-              }
-            ],
-            "length": 159000,
-            "disambiguation": "",
-            "title": "Alter Ego (underscore)",
-            "first-release-date": "2010-06-03",
-            "video": false,
-            "isrcs": [],
-            "id": "a4a23a7d-f4ab-4a27-95fd-47308c2a6ace"
-          },
-          "id": "55bccdf3-848e-3973-b204-6fb6c06cf741"
-        },
-        {
-          "recording": {
-            "id": "44d46247-4a82-457a-84fc-565b29ede0dc",
-            "isrcs": [],
-            "video": false,
-            "first-release-date": "2010-06-03",
-            "title": "Asymmetric Terror (underscore)",
-            "disambiguation": "",
-            "length": 188000,
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "name": "Matthew R. Pelling"
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type": "Person",
-                  "name": "Andre Touhey"
-                }
-              },
-              {
-                "artist": {
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ]
-          },
-          "id": "65a54683-12ac-3064-825f-bb15915deea1",
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK"
-              }
-            },
-            {
-              "name": "Andre N. Touhey",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "name": "Andre Touhey",
-                "type": "Person"
-              },
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
-              "artist": {
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "name": "Paul Willard",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              }
-            }
-          ],
-          "length": 188000,
-          "number": "24",
-          "position": 24,
-          "title": "Asymmetric Terror (underscore)"
-        },
-        {
-          "recording": {
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "9088def2-d8b9-4b18-b906-92bc84de18e6",
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "name": "Matthew R. Pelling",
-                "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling"
-                }
-              },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "name": "Paul I. Willard",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul"
-                }
-              }
-            ],
-            "length": 30000,
-            "disambiguation": "",
-            "title": "Are You Ready? (30 second)"
-          },
-          "id": "c2ce3804-6f6f-3489-a057-69b4a046743e",
-          "number": "25",
-          "title": "Are You Ready? (30 second)",
-          "position": 25,
-          "artist-credit": [
-            {
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44"
-              },
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              },
-              "name": "Andre N. Touhey"
-            },
-            {
-              "name": "Paul I. Willard",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "name": "Paul Willard",
-                "type": "Person",
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "length": 30000
-        },
-        {
-          "position": 26,
-          "title": "Razor Wire (30 second)",
-          "number": "26",
-          "length": 30000,
-          "artist-credit": [
-            {
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              },
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
-              "artist": {
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type": "Person",
-                "name": "Andre Touhey",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              }
-            },
-            {
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "name": "Paul Willard",
-                "type": "Person",
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
-              },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
-            }
-          ],
-          "id": "57d09c42-15f9-3d03-bd24-dc23aba6868c",
-          "recording": {
-            "title": "Razor Wire (30 second)",
-            "disambiguation": "",
-            "length": 30000,
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                },
-                "name": "Matthew R. Pelling"
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
-                }
-              },
-              {
-                "artist": {
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "id": "520044db-0aa9-43f3-b72f-1f071ad93cd0",
-            "isrcs": [],
-            "video": false,
-            "first-release-date": "2010-06-03"
-          }
-        },
-        {
-          "position": 27,
-          "title": "Rear View Mirror (30 second)",
-          "number": "27",
-          "length": 30000,
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "artist": {
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
-              },
               "name": "Matthew R. Pelling"
             },
             {
-              "joinphrase": " & ",
-              "name": "Andre N. Touhey",
               "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "GB",
-                "type": "Person",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "name": "Andre Touhey",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-              }
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
             },
             {
-              "name": "Paul I. Willard",
               "artist": {
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type": "Person",
-                "name": "Paul Willard",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Paul I. Willard"
             }
           ],
-          "id": "df97e016-c3ab-3537-b590-09e9b35f7fe7",
+          "id": "31aacdac-6c2d-3b66-b123-44e7f934deb7",
+          "length": 190000,
+          "number": "21",
+          "position": 21,
           "recording": {
-            "length": 30000,
             "artist-credit": [
               {
-                "joinphrase": ", ",
                 "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": ", ",
                 "name": "Matthew R. Pelling"
               },
               {
                 "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                   "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
                   "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Andre N. Touhey",
-                "joinphrase": " & "
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
               },
               {
                 "artist": {
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
                   "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Paul I. Willard"
               }
             ],
-            "title": "Rear View Mirror (30 second)",
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "caab21dc-75a6-4aa5-a9a4-e054c6c8e309",
+            "isrcs": [],
+            "length": 190000,
+            "title": "Sonic Grenade (underscore)",
+            "video": false
+          },
+          "title": "Sonic Grenade (underscore)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "c866d432-ddaf-3bde-9996-5c46b47c9001",
+          "length": 167000,
+          "number": "22",
+          "position": 22,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "694f45a2-26a3-4fb7-8be0-2ddfad5d7bee",
+            "isrcs": [],
+            "length": 167000,
+            "title": "Bunker Boys (underscore)",
+            "video": false
+          },
+          "title": "Bunker Boys (underscore)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "55bccdf3-848e-3973-b204-6fb6c06cf741",
+          "length": 159000,
+          "number": "23",
+          "position": 23,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "a4a23a7d-f4ab-4a27-95fd-47308c2a6ace",
+            "isrcs": [],
+            "length": 159000,
+            "title": "Alter Ego (underscore)",
+            "video": false
+          },
+          "title": "Alter Ego (underscore)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "65a54683-12ac-3064-825f-bb15915deea1",
+          "length": 188000,
+          "number": "24",
+          "position": 24,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "44d46247-4a82-457a-84fc-565b29ede0dc",
+            "isrcs": [],
+            "length": 188000,
+            "title": "Asymmetric Terror (underscore)",
+            "video": false
+          },
+          "title": "Asymmetric Terror (underscore)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "c2ce3804-6f6f-3489-a057-69b4a046743e",
+          "length": 30000,
+          "number": "25",
+          "position": 25,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "9088def2-d8b9-4b18-b906-92bc84de18e6",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Are You Ready? (30 second)",
+            "video": false
+          },
+          "title": "Are You Ready? (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "57d09c42-15f9-3d03-bd24-dc23aba6868c",
+          "length": 30000,
+          "number": "26",
+          "position": 26,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "520044db-0aa9-43f3-b72f-1f071ad93cd0",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Razor Wire (30 second)",
+            "video": false
+          },
+          "title": "Razor Wire (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "df97e016-c3ab-3537-b590-09e9b35f7fe7",
+          "length": 30000,
+          "number": "27",
+          "position": 27,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
             "disambiguation": "",
             "first-release-date": "2010-06-03",
             "id": "1e6f7744-2472-4feb-8c5f-3b2b86a24b42",
             "isrcs": [],
+            "length": 30000,
+            "title": "Rear View Mirror (30 second)",
             "video": false
-          }
+          },
+          "title": "Rear View Mirror (30 second)"
         },
         {
-          "title": "Effervescence (30 second)",
-          "position": 28,
-          "number": "28",
-          "length": 30000,
           "artist-credit": [
             {
               "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
                 "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                 "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
                 "type": "Person",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Matthew R. Pelling",
-              "joinphrase": ", "
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
             },
             {
-              "name": "Andre N. Touhey",
               "artist": {
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer",
                 "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                 "name": "Andre Touhey",
-                "type": "Person",
                 "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": " & "
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
             },
             {
-              "joinphrase": "",
               "artist": {
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type": "Person",
-                "name": "Paul Willard",
                 "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
                 "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Paul I. Willard"
             }
           ],
           "id": "44376d01-4604-393d-a9a6-7c9707ba8442",
+          "length": 30000,
+          "number": "28",
+          "position": 28,
           "recording": {
-            "disambiguation": "",
-            "title": "Effervescence (30 second)",
             "artist-credit": [
               {
-                "name": "Matthew R. Pelling",
                 "artist": {
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
-                "joinphrase": ", "
-              },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "length": 30000,
-            "isrcs": [],
-            "video": false,
-            "id": "95debbcf-6a34-4e50-b1fb-55ae33bfa7f0",
-            "first-release-date": "2010-06-03"
-          }
-        },
-        {
-          "length": 30000,
-          "artist-credit": [
-            {
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              },
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type": "Person",
-                "name": "Andre Touhey",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              },
-              "name": "Andre N. Touhey"
-            },
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
-              },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
-            }
-          ],
-          "position": 29,
-          "title": "Trigger Happy (30 second)",
-          "number": "29",
-          "id": "e429c2a7-9304-3eeb-a2d5-6793401e6a61",
-          "recording": {
-            "disambiguation": "",
-            "title": "Trigger Happy (30 second)",
-            "artist-credit": [
-              {
                 "joinphrase": ", ",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert"
-                },
                 "name": "Matthew R. Pelling"
               },
               {
-                "name": "Andre N. Touhey",
                 "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                   "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
                   "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
                   "name": "Andre Touhey",
-                  "type": "Person",
                   "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "name": "Paul Willard",
                   "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "length": 30000,
-            "isrcs": [],
-            "video": false,
-            "id": "fbdf74ab-fca5-49ae-bc44-9116b4e04375",
-            "first-release-date": "2010-06-03"
-          }
-        },
-        {
-          "recording": {
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "6a592bd5-cb23-4d13-ad31-cd6fbe4e7f5a",
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "name": "Matthew R. Pelling",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "country": "GB",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              },
-              {
+                },
                 "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-                }
+                "name": "Andre N. Touhey"
               },
               {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
                 "joinphrase": "",
-                "name": "Paul I. Willard",
-                "artist": {
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul"
-                }
-              }
-            ],
-            "length": 30000,
-            "disambiguation": "",
-            "title": "Cardiac Attack (30 second)"
-          },
-          "id": "afe00e0f-4271-3be4-b6c5-00a27613249e",
-          "number": "30",
-          "title": "Cardiac Attack (30 second)",
-          "position": 30,
-          "artist-credit": [
-            {
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "artist": {
-                "type": "Person",
-                "name": "Andre Touhey",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer"
-              },
-              "name": "Andre N. Touhey"
-            },
-            {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
-              "artist": {
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul"
-              }
-            }
-          ],
-          "length": 30000
-        },
-        {
-          "position": 31,
-          "title": "True Grit (30 second)",
-          "number": "31",
-          "length": 30000,
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
-              }
-            },
-            {
-              "joinphrase": " & ",
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type": "Person",
-                "name": "Andre Touhey",
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre"
-              },
-              "name": "Andre N. Touhey"
-            },
-            {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
-              "artist": {
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-              }
-            }
-          ],
-          "id": "65d8b72a-f9b2-3235-ae3f-a28589eaa1ee",
-          "recording": {
-            "isrcs": [],
-            "video": false,
-            "id": "5d9f25f6-17d9-4707-905f-61aa4fb64348",
-            "first-release-date": "2010-06-03",
-            "disambiguation": "",
-            "title": "True Grit (30 second)",
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                },
-                "name": "Matthew R. Pelling"
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre"
-                }
-              },
-              {
-                "artist": {
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "length": 30000
-          }
-        },
-        {
-          "number": "32",
-          "position": 32,
-          "title": "Reflux Deluxe (30 second)",
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              }
-            },
-            {
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "name": "Andre Touhey",
-                "type": "Person",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "name": "Andre N. Touhey",
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
-              },
-              "name": "Paul I. Willard"
-            }
-          ],
-          "length": 30000,
-          "recording": {
-            "disambiguation": "",
-            "title": "Reflux Deluxe (30 second)",
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling"
-                },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
-                }
-              },
-              {
-                "artist": {
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "length": 30000,
-            "video": false,
-            "isrcs": [],
-            "id": "40816588-81b8-48bf-8af5-6b104a47427a",
-            "first-release-date": "2010-06-03"
-          },
-          "id": "b4bb8bfc-38df-3779-863b-8f74196fe2b1"
-        },
-        {
-          "id": "c2292a10-2bac-37e1-a793-6e6a0420adb0",
-          "recording": {
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "363eb690-c272-453b-a9cf-5f131da9ea7e",
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
-              },
-              {
-                "joinphrase": " & ",
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
-                }
-              },
-              {
-                "name": "Paul I. Willard",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 30000,
-            "disambiguation": "",
-            "title": "Sonic Grenade (30 second)"
-          },
-          "length": 30000,
-          "artist-credit": [
-            {
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "type": "Person",
-                "name": "Matt Pelling",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
-              },
-              "name": "Matthew R. Pelling",
-              "joinphrase": ", "
-            },
-            {
-              "joinphrase": " & ",
-              "artist": {
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "name": "Andre Touhey",
-                "type": "Person"
-              },
-              "name": "Andre N. Touhey"
-            },
-            {
-              "artist": {
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "Paul Willard",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
-              },
-              "name": "Paul I. Willard",
-              "joinphrase": ""
-            }
-          ],
-          "title": "Sonic Grenade (30 second)",
-          "position": 33,
-          "number": "33"
-        },
-        {
-          "number": "34",
-          "title": "Bunker Boys (30 second)",
-          "position": 34,
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
-            },
-            {
-              "name": "Andre N. Touhey",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type": "Person",
-                "name": "Andre Touhey"
-              },
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "name": "Paul I. Willard",
-              "artist": {
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type": "Person",
-                "name": "Paul Willard",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
-              }
-            }
-          ],
-          "length": 30000,
-          "recording": {
-            "first-release-date": "2010-06-03",
-            "id": "bac7a01f-f636-4f16-8948-381b25004d2d",
-            "isrcs": [],
-            "video": false,
-            "length": 30000,
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "name": "Matt Pelling",
-                  "type": "Person",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                },
-                "name": "Matthew R. Pelling"
-              },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "name": "Andre Touhey",
-                  "type": "Person",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "name": "Paul I. Willard",
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                  "name": "Paul Willard",
-                  "type": "Person"
-                }
-              }
-            ],
-            "title": "Bunker Boys (30 second)",
-            "disambiguation": ""
-          },
-          "id": "5fe2ab4d-10ba-3ca9-bbf4-4d711d52e828"
-        },
-        {
-          "recording": {
-            "first-release-date": "2010-06-03",
-            "id": "5b7652ec-5344-40e7-9ed3-383c0251f028",
-            "isrcs": [],
-            "video": false,
-            "length": 30000,
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from UK",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB"
-                },
-                "name": "Matthew R. Pelling",
-                "joinphrase": ", "
-              },
-              {
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer",
-                  "sort-name": "Touhey, Andre",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                  "name": "Andre Touhey",
-                  "type": "Person"
-                },
-                "name": "Andre N. Touhey",
-                "joinphrase": " & "
-              },
-              {
-                "artist": {
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "sort-name": "Willard, Paul",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "type": "Person",
-                  "name": "Paul Willard",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-                },
-                "name": "Paul I. Willard",
-                "joinphrase": ""
-              }
-            ],
-            "title": "Alter Ego (30 second)",
-            "disambiguation": ""
-          },
-          "id": "a365846f-aeb2-3a92-b6cb-075322f55f75",
-          "number": "35",
-          "title": "Alter Ego (30 second)",
-          "position": 35,
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "sort-name": "Pelling, Matthew Robert"
-              },
-              "name": "Matthew R. Pelling",
-              "joinphrase": ", "
-            },
-            {
-              "name": "Andre N. Touhey",
-              "artist": {
-                "type": "Person",
-                "name": "Andre Touhey",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "sort-name": "Touhey, Andre",
-                "disambiguation": "Electronic/DnB producer"
-              },
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer from the UK",
-                "sort-name": "Willard, Paul",
-                "type": "Person",
-                "name": "Paul Willard",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              },
-              "name": "Paul I. Willard"
-            }
-          ],
-          "length": 30000
-        },
-        {
-          "artist-credit": [
-            {
-              "joinphrase": ", ",
-              "name": "Matthew R. Pelling",
-              "artist": {
-                "sort-name": "Pelling, Matthew Robert",
-                "disambiguation": "Electronic/DnB producer from UK",
-                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                "name": "Matt Pelling",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB"
-              }
-            },
-            {
-              "name": "Andre N. Touhey",
-              "artist": {
-                "disambiguation": "Electronic/DnB producer",
-                "sort-name": "Touhey, Andre",
-                "country": "GB",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-                "type": "Person",
-                "name": "Andre Touhey"
-              },
-              "joinphrase": " & "
-            },
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "GB",
-                "name": "Paul Willard",
-                "type": "Person",
-                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-                "sort-name": "Willard, Paul",
-                "disambiguation": "Electronic/DnB producer from the UK"
-              },
-              "name": "Paul I. Willard"
-            }
-          ],
-          "length": 30000,
-          "number": "36",
-          "position": 36,
-          "title": "Asymmetric Terror (30 second)",
-          "recording": {
-            "first-release-date": "2010-06-03",
-            "isrcs": [],
-            "video": false,
-            "id": "ee05fe43-8ad9-44ea-b6f2-6a2d5648824b",
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "artist": {
-                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-                  "type": "Person",
-                  "name": "Matt Pelling",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "sort-name": "Pelling, Matthew Robert",
-                  "disambiguation": "Electronic/DnB producer from UK"
-                },
-                "name": "Matthew R. Pelling"
-              },
-              {
-                "name": "Andre N. Touhey",
-                "artist": {
-                  "sort-name": "Touhey, Andre",
-                  "disambiguation": "Electronic/DnB producer",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "GB",
-                  "type": "Person",
-                  "name": "Andre Touhey",
-                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1"
-                },
-                "joinphrase": " & "
-              },
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Willard, Paul",
-                  "disambiguation": "Electronic/DnB producer from the UK",
-                  "country": "GB",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "name": "Paul Willard",
-                  "type": "Person",
-                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb"
-                },
                 "name": "Paul I. Willard"
               }
             ],
-            "length": 30000,
             "disambiguation": "",
-            "title": "Asymmetric Terror (30 second)"
+            "first-release-date": "2010-06-03",
+            "id": "95debbcf-6a34-4e50-b1fb-55ae33bfa7f0",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Effervescence (30 second)",
+            "video": false
           },
-          "id": "1c367d82-c107-30ed-8597-2819126227b9"
+          "title": "Effervescence (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "e429c2a7-9304-3eeb-a2d5-6793401e6a61",
+          "length": 30000,
+          "number": "29",
+          "position": 29,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "fbdf74ab-fca5-49ae-bc44-9116b4e04375",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Trigger Happy (30 second)",
+            "video": false
+          },
+          "title": "Trigger Happy (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "afe00e0f-4271-3be4-b6c5-00a27613249e",
+          "length": 30000,
+          "number": "30",
+          "position": 30,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "6a592bd5-cb23-4d13-ad31-cd6fbe4e7f5a",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Cardiac Attack (30 second)",
+            "video": false
+          },
+          "title": "Cardiac Attack (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "65d8b72a-f9b2-3235-ae3f-a28589eaa1ee",
+          "length": 30000,
+          "number": "31",
+          "position": 31,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "5d9f25f6-17d9-4707-905f-61aa4fb64348",
+            "isrcs": [],
+            "length": 30000,
+            "title": "True Grit (30 second)",
+            "video": false
+          },
+          "title": "True Grit (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "b4bb8bfc-38df-3779-863b-8f74196fe2b1",
+          "length": 30000,
+          "number": "32",
+          "position": 32,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "40816588-81b8-48bf-8af5-6b104a47427a",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Reflux Deluxe (30 second)",
+            "video": false
+          },
+          "title": "Reflux Deluxe (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "c2292a10-2bac-37e1-a793-6e6a0420adb0",
+          "length": 30000,
+          "number": "33",
+          "position": 33,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "363eb690-c272-453b-a9cf-5f131da9ea7e",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Sonic Grenade (30 second)",
+            "video": false
+          },
+          "title": "Sonic Grenade (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "5fe2ab4d-10ba-3ca9-bbf4-4d711d52e828",
+          "length": 30000,
+          "number": "34",
+          "position": 34,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "bac7a01f-f636-4f16-8948-381b25004d2d",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Bunker Boys (30 second)",
+            "video": false
+          },
+          "title": "Bunker Boys (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "a365846f-aeb2-3a92-b6cb-075322f55f75",
+          "length": 30000,
+          "number": "35",
+          "position": 35,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "5b7652ec-5344-40e7-9ed3-383c0251f028",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Alter Ego (30 second)",
+            "video": false
+          },
+          "title": "Alter Ego (30 second)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from UK",
+                "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                "name": "Matt Pelling",
+                "sort-name": "Pelling, Matthew Robert",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": ", ",
+              "name": "Matthew R. Pelling"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer",
+                "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                "name": "Andre Touhey",
+                "sort-name": "Touhey, Andre",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " & ",
+              "name": "Andre N. Touhey"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "Electronic/DnB producer from the UK",
+                "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                "name": "Paul Willard",
+                "sort-name": "Willard, Paul",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Paul I. Willard"
+            }
+          ],
+          "id": "1c367d82-c107-30ed-8597-2819126227b9",
+          "length": 30000,
+          "number": "36",
+          "position": 36,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from UK",
+                  "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+                  "name": "Matt Pelling",
+                  "sort-name": "Pelling, Matthew Robert",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": ", ",
+                "name": "Matthew R. Pelling"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer",
+                  "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+                  "name": "Andre Touhey",
+                  "sort-name": "Touhey, Andre",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " & ",
+                "name": "Andre N. Touhey"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "Electronic/DnB producer from the UK",
+                  "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+                  "name": "Paul Willard",
+                  "sort-name": "Willard, Paul",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Paul I. Willard"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2010-06-03",
+            "id": "ee05fe43-8ad9-44ea-b6f2-6a2d5648824b",
+            "isrcs": [],
+            "length": 30000,
+            "title": "Asymmetric Terror (30 second)",
+            "video": false
+          },
+          "title": "Asymmetric Terror (30 second)"
         }
-      ],
-      "id": "ec091624-bdf7-3bf1-995b-76436c345daa",
-      "track-count": 36
-    }
-  ],
-  "artist-credit": [
-    {
-      "joinphrase": ", ",
-      "name": "Matthew R. Pelling",
-      "artist": {
-        "country": "GB",
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
-        "type": "Person",
-        "name": "Matt Pelling",
-        "sort-name": "Pelling, Matthew Robert",
-        "disambiguation": "Electronic/DnB producer from UK"
-      }
-    },
-    {
-      "joinphrase": " & ",
-      "name": "Andre N. Touhey",
-      "artist": {
-        "country": "GB",
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "type": "Person",
-        "name": "Andre Touhey",
-        "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
-        "disambiguation": "Electronic/DnB producer",
-        "sort-name": "Touhey, Andre"
-      }
-    },
-    {
-      "joinphrase": "",
-      "name": "Paul I. Willard",
-      "artist": {
-        "disambiguation": "Electronic/DnB producer from the UK",
-        "sort-name": "Willard, Paul",
-        "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
-        "name": "Paul Willard",
-        "type": "Person",
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "country": "GB"
-      }
+      ]
     }
   ],
   "packaging": null,
-  "barcode": null,
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "title": "Explosive Drum & Bass",
-  "asin": null,
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "date": "2010-06-03",
   "packaging-id": null,
-  "country": "XW",
+  "quality": "normal",
   "release-events": [
     {
       "area": {
         "disambiguation": "",
-        "sort-name": "[Worldwide]",
+        "id": "525d4e18-3d00-31b9-a58b-a146a916de8f",
         "iso-3166-1-codes": [
           "XW"
         ],
         "name": "[Worldwide]",
+        "sort-name": "[Worldwide]",
         "type": null,
-        "id": "525d4e18-3d00-31b9-a58b-a146a916de8f",
         "type-id": null
       },
       "date": "2010-06-03"
     }
   ],
-  "cover-art-archive": {
-    "front": false,
-    "back": false,
-    "darkened": false,
-    "count": 0,
-    "artwork": false
-  }
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "Electronic/DnB producer from UK",
+          "id": "e869aea3-6be7-48e5-bd4f-b4f814817a44",
+          "name": "Matt Pelling",
+          "sort-name": "Pelling, Matthew Robert",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": ", ",
+        "name": "Matthew R. Pelling"
+      },
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "Electronic/DnB producer",
+          "id": "1474213f-95da-4a48-97f6-922a3115c8d1",
+          "name": "Andre Touhey",
+          "sort-name": "Touhey, Andre",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": " & ",
+        "name": "Andre N. Touhey"
+      },
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "Electronic/DnB producer from the UK",
+          "id": "dfe6e46d-aeaa-4fc3-8ed8-3ab05a55d3cb",
+          "name": "Paul Willard",
+          "sort-name": "Willard, Paul",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "",
+        "name": "Paul I. Willard"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2010-06-03",
+    "id": "7473f354-1c3d-440f-8e8b-bda8eb1e2f86",
+    "primary-type": "Other",
+    "primary-type-id": "4fc3be2b-de1e-396b-a933-beb8f1607a22",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Explosive Drum & Bass"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Explosive Drum & Bass"
 }

--- a/scripts/eval_matching/corpus/eval_release_a72497d5.json
+++ b/scripts/eval_matching/corpus/eval_release_a72497d5.json
@@ -1,1094 +1,1094 @@
 {
-  "release-events": [
-    {
-      "area": {
-        "type-id": null,
-        "sort-name": "Europe",
-        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
-        "iso-3166-1-codes": [
-          "XE"
-        ],
-        "disambiguation": "",
-        "type": null,
-        "name": "Europe"
-      },
-      "date": "2004-11-29"
-    }
-  ],
-  "cover-art-archive": {
-    "back": true,
-    "artwork": true,
-    "front": true,
-    "count": 9,
-    "darkened": false
-  },
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "text-representation": {
-    "language": "eng",
-    "script": "Latn"
-  },
-  "release-group": {
-    "disambiguation": "",
-    "id": "8ef859e3-feb2-4dd1-93da-22b91280d768",
-    "first-release-date": "2004-11-29",
-    "artist-credit": [
-      {
-        "name": "Jay\u2010Z",
-        "joinphrase": " / ",
-        "artist": {
-          "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-          "type": "Person",
-          "name": "JAY\u2010Z",
-          "country": "US",
-          "disambiguation": "US rapper",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "sort-name": "JAY\u2010Z"
-        }
-      },
-      {
-        "artist": {
-          "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-          "disambiguation": "American rock band",
-          "country": "US",
-          "name": "Linkin Park",
-          "type": "Group",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "sort-name": "Linkin Park"
-        },
-        "joinphrase": "",
-        "name": "Linkin Park"
-      }
-    ],
-    "title": "Collision Course",
-    "secondary-types": [],
-    "secondary-type-ids": [],
-    "primary-type-id": "6d0c5bf6-7a33-3420-a519-44fc63eedebf",
-    "primary-type": "EP"
-  },
-  "label-info": [
-    {
-      "catalog-number": "9362-48963-2",
-      "label": {
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "sort-name": "Warner Bros. Records",
-        "label-code": 392,
-        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
-        "name": "Warner Bros. Records",
-        "type": "Imprint",
-        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across"
-      }
-    }
-  ],
-  "country": "XE",
-  "title": "MTV Ultimate Mash\u2010Ups Presents: Collision Course",
-  "packaging": "Jewel Case",
-  "status": "Official",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "barcode": "093624896326",
-  "date": "2004-11-29",
-  "asin": "B0006FWZ20",
-  "media": [
-    {
-      "tracks": [
-        {
-          "position": 1,
-          "length": 244693,
-          "number": "1",
-          "recording": {
-            "disambiguation": "explicit",
-            "video": false,
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "country": "US",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z"
-                },
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z"
-              },
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "name": "Linkin Park",
-                  "type": "Group"
-                },
-                "joinphrase": "",
-                "name": "Linkin Park"
-              }
-            ],
-            "first-release-date": "2004-11-15",
-            "id": "3dfe34e4-2768-4179-8b3f-a8e0b3e80006",
-            "title": "Dirt Off Your Shoulder / Lying From You",
-            "isrcs": [
-              "USWB10403678"
-            ],
-            "length": 244693
-          },
-          "title": "Dirt Off Your Shoulder / Lying From You",
-          "id": "93562a7f-d27a-3f3e-8223-65170e9283e9",
-          "artist-credit": [
-            {
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z",
-              "artist": {
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "disambiguation": "US rapper",
-                "country": "US",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
-            },
-            {
-              "artist": {
-                "country": "US",
-                "disambiguation": "American rock band",
-                "name": "Linkin Park",
-                "type": "Group",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "joinphrase": "",
-              "name": "Linkin Park"
-            }
-          ]
-        },
-        {
-          "recording": {
-            "length": 156320,
-            "isrcs": [
-              "USWB10403679"
-            ],
-            "disambiguation": "explicit",
-            "video": false,
-            "id": "648f62a1-8786-45a6-90fb-d9fd5a136bd6",
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "country": "US",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-                }
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "country": "US",
-                  "disambiguation": "American rock band",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park"
-                }
-              }
-            ],
-            "first-release-date": "2004-11-29",
-            "title": "Big Pimpin\u2019 / Papercut"
-          },
-          "length": 156320,
-          "number": "2",
-          "position": 2,
-          "id": "83050d19-dd56-34a3-8265-cd448fb0383c",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "joinphrase": " / ",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "JAY\u2010Z",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "country": "US",
-                "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-              }
-            },
-            {
-              "artist": {
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "country": "US",
-                "disambiguation": "American rock band",
-                "name": "Linkin Park",
-                "type": "Group"
-              },
-              "name": "Linkin Park",
-              "joinphrase": ""
-            }
-          ],
-          "title": "Big Pimpin\u2019 / Papercut"
-        },
-        {
-          "recording": {
-            "length": 211173,
-            "isrcs": [
-              "USWB10403680"
-            ],
-            "video": false,
-            "disambiguation": "explicit",
-            "title": "Jigga What / Faint",
-            "id": "5d8d54f1-db6b-4b84-9a8e-4b68122b063e",
-            "first-release-date": "2004-11-29",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "disambiguation": "US rapper",
-                  "country": "US",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-                },
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z"
-              },
-              {
-                "artist": {
-                  "country": "US",
-                  "disambiguation": "American rock band",
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park"
-                },
-                "joinphrase": "",
-                "name": "Linkin Park"
-              }
-            ]
-          },
-          "position": 3,
-          "number": "3",
-          "length": 211173,
-          "title": "Jigga What / Faint",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "country": "US"
-              },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
-            },
-            {
-              "joinphrase": "",
-              "name": "Linkin Park",
-              "artist": {
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Linkin Park",
-                "type": "Group",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-              }
-            }
-          ],
-          "id": "e2ac50b8-2fee-380c-94d5-a8317bfe5128"
-        },
-        {
-          "position": 4,
-          "length": 205280,
-          "number": "4",
-          "recording": {
-            "isrcs": [
-              "USWB10403681",
-              "USWB12400678"
-            ],
-            "length": 205280,
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "sort-name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "country": "US",
-                  "disambiguation": "US rapper",
-                  "name": "JAY\u2010Z",
-                  "type": "Person"
-                }
-              },
-              {
-                "artist": {
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "country": "US",
-                  "disambiguation": "American rock band",
-                  "sort-name": "Linkin Park",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "joinphrase": "",
-                "name": "Linkin Park"
-              }
-            ],
-            "first-release-date": "2004-11-29",
-            "id": "daccb724-8023-432a-854c-e0accb6c8678",
-            "title": "Numb / Encore",
-            "disambiguation": "explicit",
-            "video": false
-          },
-          "title": "Numb / Encore",
-          "id": "8b2aa493-bb14-359f-8d97-55260e46f3be",
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "country": "US",
-                "disambiguation": "US rapper",
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z"
-            },
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Linkin Park",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "country": "US",
-                "disambiguation": "American rock band",
-                "type": "Group",
-                "name": "Linkin Park"
-              },
-              "name": "Linkin Park",
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "position": 5,
-          "number": "5",
-          "length": 164866,
-          "recording": {
-            "video": false,
-            "disambiguation": "explicit",
-            "title": "Izzo / In the End",
-            "id": "9be2b5c5-717f-4bf5-9f12-4c14a96fde58",
-            "first-release-date": "2004-11-29",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "disambiguation": "US rapper",
-                  "country": "US"
-                },
-                "name": "Jay\u2010Z",
-                "joinphrase": " / "
-              },
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "type": "Group",
-                  "name": "Linkin Park"
-                },
-                "joinphrase": "",
-                "name": "Linkin Park"
-              }
-            ],
-            "length": 164866,
-            "isrcs": [
-              "USWB10403682"
-            ]
-          },
-          "title": "Izzo / In the End",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "country": "US",
-                "disambiguation": "US rapper"
-              },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
-            },
-            {
-              "artist": {
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "name": "Linkin Park",
-                "type": "Group",
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "joinphrase": "",
-              "name": "Linkin Park"
-            }
-          ],
-          "id": "480dd81a-a823-3052-8d6b-63d32c6bf479"
-        },
-        {
-          "artist-credit": [
-            {
-              "artist": {
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "country": "US",
-                "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z"
-            },
-            {
-              "name": "Linkin Park",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "disambiguation": "American rock band",
-                "name": "Linkin Park",
-                "type": "Group",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-              }
-            }
-          ],
-          "id": "4dea65ad-9cd5-334a-bb09-a3344b00374d",
-          "title": "Points of Authority / 99 Problems / One Step Closer",
-          "number": "6",
-          "length": 297826,
-          "position": 6,
-          "recording": {
-            "id": "d6199ea7-fe69-45c7-b455-59bdaa58f257",
-            "first-release-date": "2004-11-15",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "disambiguation": "US rapper",
-                  "type": "Person",
-                  "name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-                },
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z"
-              },
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "country": "US",
-                  "disambiguation": "American rock band"
-                },
-                "joinphrase": "",
-                "name": "Linkin Park"
-              }
-            ],
-            "title": "Points of Authority / 99 Problems / One Step Closer",
-            "disambiguation": "explicit",
-            "video": false,
-            "length": 295826,
-            "isrcs": [
-              "USWB10403683"
-            ]
-          }
-        }
-      ],
-      "track-count": 6,
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "format": "CD",
-      "title": "",
-      "position": 1,
-      "track-offset": 0,
-      "id": "e0fc8351-f4ec-34e4-8624-96ad7b6fefe1"
-    },
-    {
-      "title": "",
-      "position": 2,
-      "format": "DVD-Video",
-      "id": "d44c95c5-1a43-387b-a539-07f6c08da552",
-      "track-offset": 0,
-      "track-count": 7,
-      "tracks": [
-        {
-          "length": 84000,
-          "number": "1",
-          "position": 1,
-          "recording": {
-            "id": "9ca8d9d8-9d5a-4852-9733-9f4747632125",
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "country": "US",
-                  "disambiguation": "US rapper"
-                }
-              },
-              {
-                "name": "Linkin Park",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park",
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-                }
-              }
-            ],
-            "first-release-date": "2004-11-29",
-            "title": "Intro",
-            "disambiguation": "",
-            "video": true,
-            "length": 33000,
-            "isrcs": []
-          },
-          "id": "a1151d98-67c4-3895-af18-303318e06f54",
-          "artist-credit": [
-            {
-              "artist": {
-                "country": "US",
-                "disambiguation": "US rapper",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z"
-            },
-            {
-              "joinphrase": "",
-              "name": "Linkin Park",
-              "artist": {
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type": "Group",
-                "name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "country": "US"
-              }
-            }
-          ],
-          "title": "Intro"
-        },
-        {
-          "position": 2,
-          "length": 268000,
-          "number": "2",
-          "recording": {
-            "length": 268000,
-            "isrcs": [],
-            "title": "Dirt Off Your Shoulder / Lying From You",
-            "id": "c4d62c71-0506-4fea-a6be-20161a3a3a45",
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "country": "US",
-                  "disambiguation": "US rapper",
-                  "name": "JAY\u2010Z",
-                  "type": "Person"
-                }
-              },
-              {
-                "name": "Linkin Park",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Linkin Park",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-                }
-              }
-            ],
-            "first-release-date": "2004-11-29",
-            "video": true,
-            "disambiguation": ""
-          },
-          "title": "Dirt Off Your Shoulder / Lying From You",
-          "id": "b6184595-a97c-38c2-a182-1f00fa6c182e",
-          "artist-credit": [
-            {
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "JAY\u2010Z",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "country": "US",
-                "disambiguation": "US rapper",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-              }
-            },
-            {
-              "artist": {
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type": "Group",
-                "name": "Linkin Park",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Linkin Park"
-              },
-              "joinphrase": "",
-              "name": "Linkin Park"
-            }
-          ]
-        },
-        {
-          "position": 3,
-          "number": "3",
-          "length": 156000,
-          "recording": {
-            "disambiguation": "",
-            "video": true,
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "disambiguation": "US rapper",
-                  "country": "US",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "sort-name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z"
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "country": "US",
-                  "disambiguation": "American rock band",
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park"
-                }
-              }
-            ],
-            "first-release-date": "2004-11-29",
-            "id": "e5403a7c-cf01-42a7-a5e5-71db0eedadf3",
-            "title": "Big Pimpin\u2019 / Papercut",
-            "isrcs": [],
-            "length": 156000
-          },
-          "title": "Big Pimpin\u2019 / Papercut",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "JAY\u2010Z",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "country": "US",
-                "disambiguation": "US rapper",
-                "name": "JAY\u2010Z",
-                "type": "Person"
-              },
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z"
-            },
-            {
-              "name": "Linkin Park",
-              "joinphrase": "",
-              "artist": {
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type": "Group",
-                "name": "Linkin Park",
-                "country": "US",
-                "disambiguation": "American rock band",
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "id": "7fa74f82-d840-3d94-8458-98f7d5385993"
-        },
-        {
-          "recording": {
-            "disambiguation": "",
-            "video": true,
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z",
-                  "country": "US",
-                  "disambiguation": "US rapper",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-                }
-              },
-              {
-                "name": "Linkin Park",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "name": "Linkin Park",
-                  "type": "Group"
-                }
-              }
-            ],
-            "first-release-date": "2004-11-29",
-            "id": "7cd76b0b-73fd-4e48-a691-41a0c91b3256",
-            "title": "Jigga What / Faint",
-            "isrcs": [],
-            "length": 248000
-          },
-          "position": 4,
-          "number": "4",
-          "length": 248000,
-          "title": "Jigga What / Faint",
-          "artist-credit": [
-            {
-              "name": "Jay\u2010Z",
-              "joinphrase": " / ",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "disambiguation": "US rapper",
-                "country": "US"
-              }
-            },
-            {
-              "artist": {
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "country": "US",
-                "disambiguation": "American rock band",
-                "type": "Group",
-                "name": "Linkin Park",
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "joinphrase": "",
-              "name": "Linkin Park"
-            }
-          ],
-          "id": "5e0c61c8-878c-38ce-b531-158628f5d041"
-        },
-        {
-          "title": "Numb / Encore",
-          "id": "2eb84139-f78c-3c09-ba4a-c1059bda8dd1",
-          "artist-credit": [
-            {
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z",
-              "artist": {
-                "disambiguation": "US rapper",
-                "country": "US",
-                "name": "JAY\u2010Z",
-                "type": "Person",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "JAY\u2010Z"
-              }
-            },
-            {
-              "artist": {
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "name": "Linkin Park",
-                "type": "Group",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Linkin Park"
-              },
-              "joinphrase": "",
-              "name": "Linkin Park"
-            }
-          ],
-          "position": 5,
-          "length": 209000,
-          "number": "5",
-          "recording": {
-            "id": "bc264735-06dd-41a5-b755-924567f2258c",
-            "first-release-date": "2004-11-29",
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "US rapper",
-                  "country": "US",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "JAY\u2010Z"
-                },
-                "name": "Jay\u2010Z",
-                "joinphrase": " / "
-              },
-              {
-                "artist": {
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "sort-name": "Linkin Park",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Linkin Park",
-                "joinphrase": ""
-              }
-            ],
-            "title": "Numb / Encore",
-            "disambiguation": "",
-            "video": true,
-            "length": 209000,
-            "isrcs": []
-          }
-        },
-        {
-          "position": 6,
-          "number": "6",
-          "length": 160000,
-          "recording": {
-            "length": 160000,
-            "isrcs": [],
-            "disambiguation": "",
-            "video": true,
-            "id": "917b11f9-2e42-4662-a326-e45329493b74",
-            "artist-credit": [
-              {
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z",
-                "artist": {
-                  "sort-name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                  "country": "US",
-                  "disambiguation": "US rapper",
-                  "type": "Person",
-                  "name": "JAY\u2010Z"
-                }
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "sort-name": "Linkin Park",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                  "name": "Linkin Park",
-                  "type": "Group",
-                  "country": "US",
-                  "disambiguation": "American rock band"
-                }
-              }
-            ],
-            "first-release-date": "2004-11-29",
-            "title": "Izzo / In the End"
-          },
-          "title": "Izzo / In the End",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "JAY\u2010Z",
-                "disambiguation": "US rapper",
-                "country": "US",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-              },
-              "name": "Jay\u2010Z",
-              "joinphrase": " / "
-            },
-            {
-              "joinphrase": "",
-              "name": "Linkin Park",
-              "artist": {
-                "type": "Group",
-                "name": "Linkin Park",
-                "country": "US",
-                "disambiguation": "American rock band",
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "id": "9e718ad7-37c4-3b09-9779-e08c77032aa8"
-        },
-        {
-          "recording": {
-            "first-release-date": "2004-11-29",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "JAY\u2010Z",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "US rapper",
-                  "country": "US",
-                  "name": "JAY\u2010Z",
-                  "type": "Person",
-                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac"
-                },
-                "joinphrase": " / ",
-                "name": "Jay\u2010Z"
-              },
-              {
-                "joinphrase": "",
-                "name": "Linkin Park",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Linkin Park",
-                  "disambiguation": "American rock band",
-                  "country": "US",
-                  "type": "Group",
-                  "name": "Linkin Park",
-                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419"
-                }
-              }
-            ],
-            "id": "db93cea0-25e7-4549-bb35-cbac518cb1fd",
-            "title": "Points of Authority / 99 Problems / One Step Closer",
-            "disambiguation": "",
-            "video": true,
-            "isrcs": [],
-            "length": 467000
-          },
-          "length": 467000,
-          "number": "7",
-          "position": 7,
-          "id": "91985594-d54e-3525-a0ad-c263eed3ae0f",
-          "artist-credit": [
-            {
-              "joinphrase": " / ",
-              "name": "Jay\u2010Z",
-              "artist": {
-                "sort-name": "JAY\u2010Z",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
-                "country": "US",
-                "disambiguation": "US rapper",
-                "name": "JAY\u2010Z",
-                "type": "Person"
-              }
-            },
-            {
-              "name": "Linkin Park",
-              "joinphrase": "",
-              "artist": {
-                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
-                "type": "Group",
-                "name": "Linkin Park",
-                "country": "US",
-                "disambiguation": "American rock band",
-                "sort-name": "Linkin Park",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "title": "Points of Authority / 99 Problems / One Step Closer"
-        }
-      ],
-      "format-id": "bb71fd58-ff93-32b4-a201-4ad1b2a80e5f"
-    }
-  ],
-  "disambiguation": "",
-  "quality": "normal",
-  "id": "a72497d5-b677-3738-8e39-16af84ddb171",
   "artist-credit": [
     {
       "artist": {
         "country": "US",
         "disambiguation": "US rapper",
-        "type": "Person",
-        "name": "JAY\u2010Z",
         "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+        "name": "JAY\u2010Z",
         "sort-name": "JAY\u2010Z",
+        "type": "Person",
         "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
       },
       "joinphrase": " / ",
       "name": "Jay\u2010Z"
     },
     {
-      "name": "Linkin Park",
-      "joinphrase": "",
       "artist": {
-        "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
         "country": "US",
         "disambiguation": "American rock band",
-        "type": "Group",
+        "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
         "name": "Linkin Park",
         "sort-name": "Linkin Park",
+        "type": "Group",
         "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Linkin Park"
+    }
+  ],
+  "asin": "B0006FWZ20",
+  "barcode": "093624896326",
+  "country": "XE",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 9,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2004-11-29",
+  "disambiguation": "",
+  "id": "a72497d5-b677-3738-8e39-16af84ddb171",
+  "label-info": [
+    {
+      "catalog-number": "9362-48963-2",
+      "label": {
+        "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
+        "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
+        "label-code": 392,
+        "name": "Warner Bros. Records",
+        "sort-name": "Warner Bros. Records",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
       }
     }
-  ]
+  ],
+  "media": [
+    {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "e0fc8351-f4ec-34e4-8624-96ad7b6fefe1",
+      "position": 1,
+      "title": "",
+      "track-count": 6,
+      "track-offset": 0,
+      "tracks": [
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "93562a7f-d27a-3f3e-8223-65170e9283e9",
+          "length": 244693,
+          "number": "1",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-15",
+            "id": "3dfe34e4-2768-4179-8b3f-a8e0b3e80006",
+            "isrcs": [
+              "USWB10403678"
+            ],
+            "length": 244693,
+            "title": "Dirt Off Your Shoulder / Lying From You",
+            "video": false
+          },
+          "title": "Dirt Off Your Shoulder / Lying From You"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "83050d19-dd56-34a3-8265-cd448fb0383c",
+          "length": 156320,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-29",
+            "id": "648f62a1-8786-45a6-90fb-d9fd5a136bd6",
+            "isrcs": [
+              "USWB10403679"
+            ],
+            "length": 156320,
+            "title": "Big Pimpin\u2019 / Papercut",
+            "video": false
+          },
+          "title": "Big Pimpin\u2019 / Papercut"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "e2ac50b8-2fee-380c-94d5-a8317bfe5128",
+          "length": 211173,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-29",
+            "id": "5d8d54f1-db6b-4b84-9a8e-4b68122b063e",
+            "isrcs": [
+              "USWB10403680"
+            ],
+            "length": 211173,
+            "title": "Jigga What / Faint",
+            "video": false
+          },
+          "title": "Jigga What / Faint"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "8b2aa493-bb14-359f-8d97-55260e46f3be",
+          "length": 205280,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-29",
+            "id": "daccb724-8023-432a-854c-e0accb6c8678",
+            "isrcs": [
+              "USWB10403681",
+              "USWB12400678"
+            ],
+            "length": 205280,
+            "title": "Numb / Encore",
+            "video": false
+          },
+          "title": "Numb / Encore"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "480dd81a-a823-3052-8d6b-63d32c6bf479",
+          "length": 164866,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-29",
+            "id": "9be2b5c5-717f-4bf5-9f12-4c14a96fde58",
+            "isrcs": [
+              "USWB10403682"
+            ],
+            "length": 164866,
+            "title": "Izzo / In the End",
+            "video": false
+          },
+          "title": "Izzo / In the End"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "4dea65ad-9cd5-334a-bb09-a3344b00374d",
+          "length": 297826,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "explicit",
+            "first-release-date": "2004-11-15",
+            "id": "d6199ea7-fe69-45c7-b455-59bdaa58f257",
+            "isrcs": [
+              "USWB10403683"
+            ],
+            "length": 295826,
+            "title": "Points of Authority / 99 Problems / One Step Closer",
+            "video": false
+          },
+          "title": "Points of Authority / 99 Problems / One Step Closer"
+        }
+      ]
+    },
+    {
+      "format": "DVD-Video",
+      "format-id": "bb71fd58-ff93-32b4-a201-4ad1b2a80e5f",
+      "id": "d44c95c5-1a43-387b-a539-07f6c08da552",
+      "position": 2,
+      "title": "",
+      "track-count": 7,
+      "track-offset": 0,
+      "tracks": [
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "a1151d98-67c4-3895-af18-303318e06f54",
+          "length": 84000,
+          "number": "1",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "9ca8d9d8-9d5a-4852-9733-9f4747632125",
+            "isrcs": [],
+            "length": 33000,
+            "title": "Intro",
+            "video": true
+          },
+          "title": "Intro"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "b6184595-a97c-38c2-a182-1f00fa6c182e",
+          "length": 268000,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "c4d62c71-0506-4fea-a6be-20161a3a3a45",
+            "isrcs": [],
+            "length": 268000,
+            "title": "Dirt Off Your Shoulder / Lying From You",
+            "video": true
+          },
+          "title": "Dirt Off Your Shoulder / Lying From You"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "7fa74f82-d840-3d94-8458-98f7d5385993",
+          "length": 156000,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "e5403a7c-cf01-42a7-a5e5-71db0eedadf3",
+            "isrcs": [],
+            "length": 156000,
+            "title": "Big Pimpin\u2019 / Papercut",
+            "video": true
+          },
+          "title": "Big Pimpin\u2019 / Papercut"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "5e0c61c8-878c-38ce-b531-158628f5d041",
+          "length": 248000,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "7cd76b0b-73fd-4e48-a691-41a0c91b3256",
+            "isrcs": [],
+            "length": 248000,
+            "title": "Jigga What / Faint",
+            "video": true
+          },
+          "title": "Jigga What / Faint"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "2eb84139-f78c-3c09-ba4a-c1059bda8dd1",
+          "length": 209000,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "bc264735-06dd-41a5-b755-924567f2258c",
+            "isrcs": [],
+            "length": 209000,
+            "title": "Numb / Encore",
+            "video": true
+          },
+          "title": "Numb / Encore"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "9e718ad7-37c4-3b09-9779-e08c77032aa8",
+          "length": 160000,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "917b11f9-2e42-4662-a326-e45329493b74",
+            "isrcs": [],
+            "length": 160000,
+            "title": "Izzo / In the End",
+            "video": true
+          },
+          "title": "Izzo / In the End"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "US rapper",
+                "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                "name": "JAY\u2010Z",
+                "sort-name": "JAY\u2010Z",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": " / ",
+              "name": "Jay\u2010Z"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                "name": "Linkin Park",
+                "sort-name": "Linkin Park",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Linkin Park"
+            }
+          ],
+          "id": "91985594-d54e-3525-a0ad-c263eed3ae0f",
+          "length": 467000,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "US rapper",
+                  "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+                  "name": "JAY\u2010Z",
+                  "sort-name": "JAY\u2010Z",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": " / ",
+                "name": "Jay\u2010Z"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+                  "name": "Linkin Park",
+                  "sort-name": "Linkin Park",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Linkin Park"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2004-11-29",
+            "id": "db93cea0-25e7-4549-bb35-cbac518cb1fd",
+            "isrcs": [],
+            "length": 467000,
+            "title": "Points of Authority / 99 Problems / One Step Closer",
+            "video": true
+          },
+          "title": "Points of Authority / 99 Problems / One Step Closer"
+        }
+      ]
+    }
+  ],
+  "packaging": "Jewel Case",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+        "iso-3166-1-codes": [
+          "XE"
+        ],
+        "name": "Europe",
+        "sort-name": "Europe",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2004-11-29"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "US rapper",
+          "id": "f82bcf78-5b69-4622-a5ef-73800768d9ac",
+          "name": "JAY\u2010Z",
+          "sort-name": "JAY\u2010Z",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": " / ",
+        "name": "Jay\u2010Z"
+      },
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "American rock band",
+          "id": "f59c5520-5f46-4d2c-b2c4-822eabf53419",
+          "name": "Linkin Park",
+          "sort-name": "Linkin Park",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Linkin Park"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2004-11-29",
+    "id": "8ef859e3-feb2-4dd1-93da-22b91280d768",
+    "primary-type": "EP",
+    "primary-type-id": "6d0c5bf6-7a33-3420-a519-44fc63eedebf",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Collision Course"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "MTV Ultimate Mash\u2010Ups Presents: Collision Course"
 }

--- a/scripts/eval_matching/corpus/eval_release_a9897d0b.json
+++ b/scripts/eval_matching/corpus/eval_release_a9897d0b.json
@@ -1,588 +1,588 @@
 {
-  "title": "Weezer",
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "US",
+        "disambiguation": "American rock band",
+        "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+        "name": "Weezer",
+        "sort-name": "Weezer",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Weezer"
+    }
+  ],
+  "asin": null,
+  "barcode": "606949304522",
+  "country": "CA",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 5,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2001-05-15",
+  "disambiguation": "green album",
+  "id": "a9897d0b-b05a-41d9-baa5-68a754e917c3",
+  "label-info": [
+    {
+      "catalog-number": "0694930452",
+      "label": {
+        "disambiguation": "",
+        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
+        "label-code": 7266,
+        "name": "Geffen Records",
+        "sort-name": "Geffen Records",
+        "type": "Production",
+        "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678"
+      }
+    }
+  ],
   "media": [
     {
-      "id": "1f982571-137d-39fa-b6a7-558ff1b77588",
-      "title": "",
-      "position": 1,
       "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "1f982571-137d-39fa-b6a7-558ff1b77588",
+      "position": 1,
+      "title": "",
+      "track-count": 10,
+      "track-offset": 0,
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "493d62bc-6ef5-4e60-ba15-9c0411db558f",
           "length": 179533,
+          "number": "1",
           "position": 1,
-          "title": "Don\u2019t Let Go",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2001-05-07",
+            "id": "129d60a4-6d2a-4728-aac6-4a61f150aef1",
             "isrcs": [
               "USIR10110357"
             ],
-            "id": "129d60a4-6d2a-4728-aac6-4a61f150aef1",
-            "disambiguation": "",
-            "title": "Don\u2019t Let Go",
-            "video": false,
-            "first-release-date": "2001-05-07",
             "length": 179533,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Weezer",
-                  "country": "US",
-                  "type": "Group",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "disambiguation": "American rock band",
-                  "sort-name": "Weezer"
-                },
-                "name": "Weezer"
-              }
-            ]
+            "title": "Don\u2019t Let Go",
+            "video": false
           },
-          "id": "493d62bc-6ef5-4e60-ba15-9c0411db558f",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Weezer",
-                "type": "Group",
-                "country": "US",
-                "sort-name": "Weezer",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band"
-              },
-              "name": "Weezer"
-            }
-          ],
-          "number": "1"
+          "title": "Don\u2019t Let Go"
         },
         {
           "artist-credit": [
             {
-              "name": "Weezer",
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Weezer",
                 "country": "US",
-                "type": "Group",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                 "disambiguation": "American rock band",
-                "sort-name": "Weezer"
-              }
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
             }
           ],
-          "number": "2",
-          "length": 139093,
           "id": "81089776-5842-46e2-aa88-6be55f7441bd",
+          "length": 139093,
+          "number": "2",
           "position": 2,
-          "title": "Photograph",
           "recording": {
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2001-05-07",
-            "length": 139093,
-            "title": "Photograph",
+            "id": "a22d4155-cbc4-40a9-972a-b71bcb7503ef",
             "isrcs": [
               "USIR10110364"
             ],
-            "id": "a22d4155-cbc4-40a9-972a-b71bcb7503ef",
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "name": "Weezer",
-                "artist": {
-                  "sort-name": "Weezer",
-                  "disambiguation": "American rock band",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "type": "Group",
-                  "country": "US",
-                  "name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "joinphrase": ""
-              }
-            ]
-          }
+            "length": 139093,
+            "title": "Photograph",
+            "video": false
+          },
+          "title": "Photograph"
         },
         {
-          "number": "3",
           "artist-credit": [
             {
-              "name": "Weezer",
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Weezer",
-                "type": "Group",
                 "country": "US",
-                "sort-name": "Weezer",
                 "disambiguation": "American rock band",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
-              }
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
             }
           ],
           "id": "998c482c-3683-41ed-b991-a282d475c8d2",
-          "title": "Hash Pipe",
+          "length": 186533,
+          "number": "3",
+          "position": 3,
           "recording": {
             "artist-credit": [
               {
-                "name": "Weezer",
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Weezer",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "disambiguation": "American rock band",
-                  "type": "Group",
                   "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                   "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "2001-04",
-            "video": false,
-            "length": 186533,
+            "id": "b465ee62-8189-4aac-a294-43f4958dffae",
             "isrcs": [
               "USIR10110319"
             ],
-            "id": "b465ee62-8189-4aac-a294-43f4958dffae",
-            "disambiguation": "",
-            "title": "Hash Pipe"
+            "length": 186533,
+            "title": "Hash Pipe",
+            "video": false
           },
-          "position": 3,
-          "length": 186533
+          "title": "Hash Pipe"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
           "id": "6eb94557-9a23-4eeb-b178-acd8cc6f8b96",
-          "title": "Island in the Sun",
+          "length": 200306,
+          "number": "4",
+          "position": 4,
           "recording": {
             "artist-credit": [
               {
-                "name": "Weezer",
-                "joinphrase": "",
                 "artist": {
-                  "name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "US",
                   "disambiguation": "American rock band",
                   "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
                   "sort-name": "Weezer",
-                  "country": "US",
-                  "type": "Group"
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
-            "title": "Island in the Sun",
+            "disambiguation": "",
+            "first-release-date": "2001-05-07",
+            "id": "58044028-9a7e-4da6-9ca8-e5322a25d9a2",
             "isrcs": [
               "USIR10110358"
             ],
-            "id": "58044028-9a7e-4da6-9ca8-e5322a25d9a2",
-            "disambiguation": "",
             "length": 200053,
-            "video": false,
-            "first-release-date": "2001-05-07"
+            "title": "Island in the Sun",
+            "video": false
           },
-          "position": 4,
-          "length": 200306,
-          "number": "4",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Weezer",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band",
-                "type": "Group",
-                "country": "US",
-                "name": "Weezer",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "name": "Weezer"
-            }
-          ]
+          "title": "Island in the Sun"
         },
         {
-          "number": "5",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Weezer",
-                "type": "Group",
                 "country": "US",
-                "sort-name": "Weezer",
+                "disambiguation": "American rock band",
                 "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band"
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Weezer"
             }
           ],
           "id": "70479f74-fbf7-49e0-94a0-c745877255e4",
+          "length": 154560,
+          "number": "5",
           "position": 5,
-          "title": "Crab",
-          "recording": {
-            "title": "Crab",
-            "id": "92969b64-efd9-4f7d-bea5-c9154e56d8e2",
-            "disambiguation": "",
-            "isrcs": [
-              "USIR10110356"
-            ],
-            "first-release-date": "1998-11",
-            "video": false,
-            "length": 154560,
-            "artist-credit": [
-              {
-                "name": "Weezer",
-                "joinphrase": "",
-                "artist": {
-                  "type": "Group",
-                  "country": "US",
-                  "sort-name": "Weezer",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "disambiguation": "American rock band",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Weezer"
-                }
-              }
-            ]
-          },
-          "length": 154560
-        },
-        {
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Weezer",
-                "type": "Group",
-                "country": "US",
-                "sort-name": "Weezer",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band"
-              },
-              "name": "Weezer"
-            }
-          ],
-          "number": "6",
-          "length": 128333,
-          "id": "edb2eff1-679d-4282-8cd8-13513235a551",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
                   "country": "US",
-                  "type": "Group",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                   "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
                   "sort-name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Weezer"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Weezer"
               }
             ],
-            "length": 128333,
-            "video": false,
+            "disambiguation": "",
+            "first-release-date": "1998-11",
+            "id": "92969b64-efd9-4f7d-bea5-c9154e56d8e2",
+            "isrcs": [
+              "USIR10110356"
+            ],
+            "length": 154560,
+            "title": "Crab",
+            "video": false
+          },
+          "title": "Crab"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "edb2eff1-679d-4282-8cd8-13513235a551",
+          "length": 128333,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2001-05-07",
             "id": "4ca0da9c-bd6d-4071-9614-c8684e4978f1",
-            "disambiguation": "",
             "isrcs": [
               "USIR10110359"
             ],
-            "title": "Knock\u2010Down Drag\u2010Out"
+            "length": 128333,
+            "title": "Knock\u2010Down Drag\u2010Out",
+            "video": false
           },
-          "position": 6,
           "title": "Knock\u2010Down Drag\u2010Out"
         },
         {
-          "length": 158666,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
           "id": "07540b24-8c51-4eb1-bd1f-e5ae3b34c24d",
-          "title": "Smile",
+          "length": 158666,
+          "number": "7",
           "position": 7,
           "recording": {
-            "title": "Smile",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2001-05-07",
             "id": "e8e01316-8be1-4028-85e7-9d28a2f35945",
             "isrcs": [
               "USIR10110360"
             ],
-            "disambiguation": "",
-            "first-release-date": "2001-05-07",
-            "video": false,
             "length": 158626,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "type": "Group",
-                  "country": "US",
-                  "sort-name": "Weezer",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "disambiguation": "American rock band",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Weezer"
-                },
-                "name": "Weezer"
-              }
-            ]
+            "title": "Smile",
+            "video": false
           },
+          "title": "Smile"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
                 "country": "US",
-                "type": "Group",
                 "disambiguation": "American rock band",
                 "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
                 "sort-name": "Weezer",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Weezer"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Weezer"
             }
           ],
-          "number": "7"
-        },
-        {
-          "title": "Simple Pages",
+          "id": "4fad0cd1-1d91-4591-be40-91e09712eebb",
+          "length": 176706,
+          "number": "8",
+          "position": 8,
           "recording": {
             "artist-credit": [
               {
-                "name": "Weezer",
                 "artist": {
                   "country": "US",
-                  "type": "Group",
                   "disambiguation": "American rock band",
                   "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
                   "sort-name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Weezer"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "2001-05-07",
-            "video": false,
-            "length": 176706,
             "id": "2c623d93-4e45-4886-86af-a153db6da6b5",
             "isrcs": [
               "USIR10110362"
             ],
-            "disambiguation": "",
-            "title": "Simple Pages"
+            "length": 176706,
+            "title": "Simple Pages",
+            "video": false
           },
-          "position": 8,
-          "id": "4fad0cd1-1d91-4591-be40-91e09712eebb",
-          "length": 176706,
-          "number": "8",
-          "artist-credit": [
-            {
-              "name": "Weezer",
-              "joinphrase": "",
-              "artist": {
-                "name": "Weezer",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band",
-                "sort-name": "Weezer",
-                "country": "US",
-                "type": "Group"
-              }
-            }
-          ]
+          "title": "Simple Pages"
         },
         {
-          "length": 160826,
-          "id": "4a49de21-61d2-4e3a-8ffe-be580ed4c7d1",
-          "recording": {
-            "first-release-date": "2001-05-07",
-            "video": false,
-            "length": 160826,
-            "title": "Glorious Day",
-            "id": "b855eea9-ca26-43e2-8304-0e83e3f9b46a",
-            "disambiguation": "",
-            "isrcs": [
-              "USIR10110363"
-            ],
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "disambiguation": "American rock band",
-                  "sort-name": "Weezer",
-                  "country": "US",
-                  "type": "Group",
-                  "name": "Weezer",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Weezer"
-              }
-            ]
-          },
-          "position": 9,
-          "title": "Glorious Day",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Weezer",
                 "country": "US",
-                "type": "Group",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                 "disambiguation": "American rock band",
-                "sort-name": "Weezer"
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Weezer"
             }
           ],
-          "number": "9"
+          "id": "4a49de21-61d2-4e3a-8ffe-be580ed4c7d1",
+          "length": 160826,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2001-05-07",
+            "id": "b855eea9-ca26-43e2-8304-0e83e3f9b46a",
+            "isrcs": [
+              "USIR10110363"
+            ],
+            "length": 160826,
+            "title": "Glorious Day",
+            "video": false
+          },
+          "title": "Glorious Day"
         },
         {
           "artist-credit": [
             {
-              "name": "Weezer",
-              "joinphrase": "",
               "artist": {
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band",
-                "sort-name": "Weezer",
                 "country": "US",
-                "type": "Group",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                 "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Weezer"
             }
           ],
-          "number": "10",
+          "id": "b830844a-fda2-4c77-ae3f-c760928ebe12",
           "length": 229733,
+          "number": "10",
           "position": 10,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Weezer",
                   "country": "US",
-                  "type": "Group",
                   "disambiguation": "American rock band",
                   "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "sort-name": "Weezer"
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Weezer"
               }
             ],
-            "title": "O Girlfriend",
+            "disambiguation": "",
+            "first-release-date": "2001-05-07",
+            "id": "f1db7477-f8f1-4624-9d70-2df7753a3124",
             "isrcs": [
               "USIR10110361"
             ],
-            "id": "f1db7477-f8f1-4624-9d70-2df7753a3124",
-            "disambiguation": "",
-            "first-release-date": "2001-05-07",
-            "video": false,
-            "length": 229733
+            "length": 229733,
+            "title": "O Girlfriend",
+            "video": false
           },
-          "title": "O Girlfriend",
-          "id": "b830844a-fda2-4c77-ae3f-c760928ebe12"
+          "title": "O Girlfriend"
         }
-      ],
-      "track-count": 10,
-      "track-offset": 0
+      ]
     }
   ],
+  "packaging": "Jewel Case",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
   "release-events": [
     {
-      "date": "2001-05-15",
       "area": {
-        "type": null,
-        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
         "disambiguation": "",
-        "sort-name": "Canada",
+        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
         "iso-3166-1-codes": [
           "CA"
         ],
-        "type-id": null,
-        "name": "Canada"
-      }
-    }
-  ],
-  "id": "a9897d0b-b05a-41d9-baa5-68a754e917c3",
-  "disambiguation": "green album",
-  "date": "2001-05-15",
-  "label-info": [
-    {
-      "catalog-number": "0694930452",
-      "label": {
-        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
-        "disambiguation": "",
-        "sort-name": "Geffen Records",
-        "type": "Production",
-        "name": "Geffen Records",
-        "label-code": 7266,
-        "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678"
-      }
+        "name": "Canada",
+        "sort-name": "Canada",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2001-05-15"
     }
   ],
   "release-group": {
-    "secondary-types": [],
-    "primary-type": "Album",
-    "secondary-type-ids": [],
     "artist-credit": [
       {
-        "name": "Weezer",
-        "joinphrase": "",
         "artist": {
-          "name": "Weezer",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+          "country": "US",
           "disambiguation": "American rock band",
           "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+          "name": "Weezer",
           "sort-name": "Weezer",
-          "country": "US",
-          "type": "Group"
-        }
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Weezer"
       }
     ],
-    "id": "923d5ba6-7eee-3bce-bcb2-c913b2bd69d4",
     "disambiguation": "Green Album",
-    "title": "Weezer",
     "first-release-date": "2001-05-07",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc"
+    "id": "923d5ba6-7eee-3bce-bcb2-c913b2bd69d4",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Weezer"
   },
-  "asin": null,
-  "artist-credit": [
-    {
-      "name": "Weezer",
-      "artist": {
-        "type": "Group",
-        "country": "US",
-        "sort-name": "Weezer",
-        "disambiguation": "American rock band",
-        "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "name": "Weezer"
-      },
-      "joinphrase": ""
-    }
-  ],
   "status": "Official",
-  "barcode": "606949304522",
-  "packaging": "Jewel Case",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "country": "CA",
   "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "cover-art-archive": {
-    "front": true,
-    "back": true,
-    "darkened": false,
-    "count": 5,
-    "artwork": true
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
   },
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "quality": "normal"
+  "title": "Weezer"
 }

--- a/scripts/eval_matching/corpus/eval_release_a9d4cf0c.json
+++ b/scripts/eval_matching/corpus/eval_release_a9d4cf0c.json
@@ -1,615 +1,615 @@
 {
-  "cover-art-archive": {
-    "artwork": true,
-    "count": 1,
-    "darkened": false,
-    "front": false,
-    "back": true
-  },
-  "quality": "normal",
-  "status": "Official",
-  "media": [
-    {
-      "tracks": [
-        {
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "John, Elton",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "country": "GB",
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "name": "Elton John"
-              },
-              "joinphrase": "",
-              "name": "Elton John"
-            }
-          ],
-          "title": "Your Song",
-          "length": 241000,
-          "number": "1",
-          "position": 1,
-          "id": "e7b34fb1-dd09-4f07-b1a9-2b9290ee6562",
-          "recording": {
-            "id": "1bd4ae30-8643-4431-a503-65e8363a8c94",
-            "video": false,
-            "disambiguation": "Superior Sound remix",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Elton John",
-                "artist": {
-                  "name": "Elton John",
-                  "country": "GB",
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "sort-name": "John, Elton"
-                }
-              }
-            ],
-            "first-release-date": "1974-11-04",
-            "title": "Your Song",
-            "length": 241000,
-            "isrcs": [
-              "GBAMB9500072"
-            ]
-          }
-        },
-        {
-          "length": 233106,
-          "title": "Daniel",
-          "artist-credit": [
-            {
-              "name": "Elton John",
-              "joinphrase": "",
-              "artist": {
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                "sort-name": "John, Elton",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Elton John",
-                "country": "GB",
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "type": "Person"
-              }
-            }
-          ],
-          "number": "2",
-          "id": "d17cdb85-5cef-4252-8ac0-b3abdd6d0869",
-          "position": 2,
-          "recording": {
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "sort-name": "John, Elton",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "country": "GB",
-                  "name": "Elton John",
-                  "type": "Person"
-                },
-                "joinphrase": "",
-                "name": "Elton John"
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "d373ce6a-d746-4516-9950-7ed3835982f1",
-            "isrcs": [
-              "GBAMB9500001",
-              "GBUM71700212"
-            ],
-            "title": "Daniel",
-            "length": 233880,
-            "first-release-date": "1973-01-26"
-          }
-        },
-        {
-          "position": 3,
-          "id": "f7ebe9ae-6355-455b-b6d6-47c2cfd536ad",
-          "recording": {
-            "first-release-date": "1972-05-19",
-            "isrcs": [
-              "GBAMB7200002",
-              "GBAMB9200002",
-              "GBUM71700180"
-            ],
-            "title": "Honky Cat",
-            "length": 313200,
-            "video": false,
-            "id": "aefaa021-b6f9-4ac3-b0ec-b99cc27acb63",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Elton John",
-                "artist": {
-                  "sort-name": "John, Elton",
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "country": "GB",
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "name": "Elton John"
-                }
-              }
-            ],
-            "disambiguation": ""
-          },
-          "length": 313200,
-          "title": "Honky Cat",
-          "artist-credit": [
-            {
-              "artist": {
-                "type": "Person",
-                "country": "GB",
-                "name": "Elton John",
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "John, Elton",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822"
-              },
-              "name": "Elton John",
-              "joinphrase": ""
-            }
-          ],
-          "number": "3"
-        },
-        {
-          "recording": {
-            "title": "Goodbye Yellow Brick Road",
-            "length": 194773,
-            "isrcs": [
-              "GBAMB9500058",
-              "GBF080300779",
-              "GBUM71304956"
-            ],
-            "first-release-date": "1973-10-05",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "sort-name": "John, Elton",
-                  "name": "Elton John",
-                  "country": "GB",
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": "",
-                "name": "Elton John"
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "e492bc5b-469e-497b-903d-64a9713deee0"
-          },
-          "position": 4,
-          "id": "368dce5a-9342-4145-82b0-003afcdc162c",
-          "number": "4",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "John, Elton",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                "type": "Person",
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "country": "GB",
-                "name": "Elton John",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": "",
-              "name": "Elton John"
-            }
-          ],
-          "title": "Goodbye Yellow Brick Road",
-          "length": 194733
-        },
-        {
-          "length": 293000,
-          "title": "Saturday Night\u2019s Alright for Fighting",
-          "artist-credit": [
-            {
-              "name": "Elton John",
-              "joinphrase": "",
-              "artist": {
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "country": "GB",
-                "name": "Elton John",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                "sort-name": "John, Elton"
-              }
-            }
-          ],
-          "number": "5",
-          "id": "90a3ea4a-0ec8-4d5a-a500-1349dffba0fe",
-          "position": 5,
-          "recording": {
-            "video": false,
-            "id": "f8f27c10-47d7-40dc-a0a1-49eaba96d8ca",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Elton John",
-                "artist": {
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "sort-name": "John, Elton",
-                  "country": "GB",
-                  "name": "Elton John",
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
-              }
-            ],
-            "disambiguation": "",
-            "first-release-date": "1973-06-29",
-            "isrcs": [
-              "GBAMB9500068",
-              "GBF080300786",
-              "GBUM71304966"
-            ],
-            "length": 294973,
-            "title": "Saturday Night\u2019s Alright for Fighting"
-          }
-        },
-        {
-          "id": "d498cac2-9e34-4981-9995-c6589bf54444",
-          "position": 6,
-          "recording": {
-            "video": false,
-            "id": "4c2a08bd-26df-4e68-835a-5bc8ff9bcf8a",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "sort-name": "John, Elton",
-                  "name": "Elton John",
-                  "country": "GB",
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "name": "Elton John",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": "",
-            "first-release-date": "1972-05-19",
-            "title": "Rocket Man (I Think It\u2019s Going to Be a Long, Long Time)",
-            "length": 282000,
-            "isrcs": [
-              "GBAMB7200006",
-              "GBAMB9200006",
-              "GBUM71700184"
-            ]
-          },
-          "title": "Rocket Man",
-          "length": 282000,
-          "artist-credit": [
-            {
-              "artist": {
-                "name": "Elton John",
-                "country": "GB",
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                "sort-name": "John, Elton"
-              },
-              "joinphrase": "",
-              "name": "Elton John"
-            }
-          ],
-          "number": "6"
-        },
-        {
-          "position": 7,
-          "id": "27160d6a-36b4-4bed-9967-f2b984468257",
-          "recording": {
-            "length": 322826,
-            "title": "Bennie and the Jets",
-            "isrcs": [
-              "GBAMB9500057",
-              "GBF080300775",
-              "GBUM71304955"
-            ],
-            "first-release-date": "1973-10-05",
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Elton John",
-                "artist": {
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "country": "GB",
-                  "name": "Elton John",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "sort-name": "John, Elton"
-                }
-              }
-            ],
-            "id": "5df9640d-217a-4480-bdc8-8173d137dd54",
-            "video": false
-          },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Elton John",
-              "artist": {
-                "country": "GB",
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "name": "Elton John",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                "sort-name": "John, Elton"
-              }
-            }
-          ],
-          "title": "Bennie and the Jets",
-          "length": 322000,
-          "number": "7"
-        },
-        {
-          "recording": {
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "John, Elton",
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "name": "Elton John",
-                  "country": "GB",
-                  "disambiguation": "English singer, songwriter, pianist, and composer"
-                },
-                "joinphrase": "",
-                "name": "Elton John"
-              }
-            ],
-            "id": "e3710ecc-2578-4a03-9a0e-11d3843abd9a",
-            "video": false,
-            "title": "Don\u2019t Let the Sun Go Down on Me",
-            "length": 337280,
-            "isrcs": [
-              "GBAMB9500047"
-            ],
-            "first-release-date": "1974-06-24"
-          },
-          "position": 8,
-          "id": "80f4090d-cda3-4b76-9838-f76314ec70bc",
-          "number": "8",
-          "title": "Don\u2019t Let the Sun Go Down on Me",
-          "length": 337933,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Elton John",
-              "artist": {
-                "sort-name": "John, Elton",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "country": "GB",
-                "name": "Elton John",
-                "disambiguation": "English singer, songwriter, pianist, and composer"
-              }
-            }
-          ]
-        },
-        {
-          "number": "9",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "name": "Elton John",
-                "country": "GB",
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "type": "Person",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                "sort-name": "John, Elton"
-              },
-              "name": "Elton John",
-              "joinphrase": ""
-            }
-          ],
-          "length": 202066,
-          "title": "Border Song",
-          "recording": {
-            "title": "Border Song",
-            "length": 202066,
-            "isrcs": [
-              "GBAMB9500078",
-              "GBUM71604270"
-            ],
-            "first-release-date": "1970-07-22",
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "name": "Elton John",
-                "joinphrase": "",
-                "artist": {
-                  "country": "GB",
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "name": "Elton John",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "sort-name": "John, Elton"
-                }
-              }
-            ],
-            "id": "9bb24681-db91-45dc-ae75-fe37965480a3",
-            "video": false
-          },
-          "position": 9,
-          "id": "149cda11-5879-4428-9840-3e6d209c9bd2"
-        },
-        {
-          "id": "6354eda5-d365-4ea5-88f5-a8d0611bb833",
-          "position": 10,
-          "recording": {
-            "isrcs": [
-              "GBAMB7200001",
-              "GBAMB9200001",
-              "GBAMB9500009",
-              "GBUM71700220"
-            ],
-            "title": "Crocodile Rock",
-            "length": 235760,
-            "first-release-date": "1972-10-27",
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Elton John",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "disambiguation": "English singer, songwriter, pianist, and composer",
-                  "country": "GB",
-                  "name": "Elton John",
-                  "type": "Person",
-                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-                  "sort-name": "John, Elton"
-                }
-              }
-            ],
-            "id": "8388fed5-e41f-44d1-b6b5-a5b04ffffbd5",
-            "video": false
-          },
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "name": "Elton John",
-                "country": "GB",
-                "disambiguation": "English singer, songwriter, pianist, and composer",
-                "sort-name": "John, Elton",
-                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822"
-              },
-              "name": "Elton John",
-              "joinphrase": ""
-            }
-          ],
-          "length": 235200,
-          "title": "Crocodile Rock",
-          "number": "10"
-        }
-      ],
-      "format": "CD",
-      "id": "d9627f6a-1ae5-3cc5-8196-dd87e3c90a1c",
-      "track-count": 10,
-      "position": 1,
-      "track-offset": 0,
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "title": ""
-    }
-  ],
-  "asin": null,
-  "title": "Greatest Hits",
-  "packaging": "Jewel Case",
-  "id": "a9d4cf0c-750c-4de6-b811-db3cc9431149",
-  "release-events": [
-    {
-      "date": "1984",
-      "area": {
-        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
-        "sort-name": "Canada",
-        "iso-3166-1-codes": [
-          "CA"
-        ],
-        "type-id": null,
-        "disambiguation": "",
-        "name": "Canada",
-        "type": null
-      }
-    }
-  ],
-  "release-group": {
-    "id": "6619f357-4115-3d8a-bd52-238641c23c28",
-    "secondary-type-ids": [
-      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
-    ],
-    "artist-credit": [
-      {
-        "name": "Elton John",
-        "joinphrase": "",
-        "artist": {
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "country": "GB",
-          "name": "Elton John",
-          "disambiguation": "English singer, songwriter, pianist, and composer",
-          "type": "Person",
-          "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-          "sort-name": "John, Elton"
-        }
-      }
-    ],
-    "disambiguation": "",
-    "secondary-types": [
-      "Compilation"
-    ],
-    "primary-type": "Album",
-    "first-release-date": "1974-11-04",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "title": "Greatest Hits"
-  },
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "disambiguation": "",
-  "country": "CA",
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "barcode": "",
-  "label-info": [
-    {
-      "label": null,
-      "catalog-number": "DIDX 189"
-    },
-    {
-      "label": null,
-      "catalog-number": "DIDX 52"
-    },
-    {
-      "label": {
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "label-code": 1056,
-        "type": "Imprint",
-        "disambiguation": "1967\u20132003; name as in imprint during 1972\u20131990",
-        "name": "MCA Records",
-        "sort-name": "MCA Records",
-        "id": "46a3941a-c810-47a1-974f-955effec4d09"
-      },
-      "catalog-number": "MCAD-37215"
-    }
-  ],
-  "date": "1984",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
   "artist-credit": [
     {
       "artist": {
-        "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
-        "sort-name": "John, Elton",
         "country": "GB",
-        "name": "Elton John",
         "disambiguation": "English singer, songwriter, pianist, and composer",
+        "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+        "name": "Elton John",
+        "sort-name": "John, Elton",
         "type": "Person",
         "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
       },
       "joinphrase": "",
       "name": "Elton John"
     }
-  ]
+  ],
+  "asin": null,
+  "barcode": "",
+  "country": "CA",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 1,
+    "darkened": false,
+    "front": false
+  },
+  "date": "1984",
+  "disambiguation": "",
+  "id": "a9d4cf0c-750c-4de6-b811-db3cc9431149",
+  "label-info": [
+    {
+      "catalog-number": "DIDX 189",
+      "label": null
+    },
+    {
+      "catalog-number": "DIDX 52",
+      "label": null
+    },
+    {
+      "catalog-number": "MCAD-37215",
+      "label": {
+        "disambiguation": "1967\u20132003; name as in imprint during 1972\u20131990",
+        "id": "46a3941a-c810-47a1-974f-955effec4d09",
+        "label-code": 1056,
+        "name": "MCA Records",
+        "sort-name": "MCA Records",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    }
+  ],
+  "media": [
+    {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "d9627f6a-1ae5-3cc5-8196-dd87e3c90a1c",
+      "position": 1,
+      "title": "",
+      "track-count": 10,
+      "track-offset": 0,
+      "tracks": [
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "e7b34fb1-dd09-4f07-b1a9-2b9290ee6562",
+          "length": 241000,
+          "number": "1",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "Superior Sound remix",
+            "first-release-date": "1974-11-04",
+            "id": "1bd4ae30-8643-4431-a503-65e8363a8c94",
+            "isrcs": [
+              "GBAMB9500072"
+            ],
+            "length": 241000,
+            "title": "Your Song",
+            "video": false
+          },
+          "title": "Your Song"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "d17cdb85-5cef-4252-8ac0-b3abdd6d0869",
+          "length": 233106,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1973-01-26",
+            "id": "d373ce6a-d746-4516-9950-7ed3835982f1",
+            "isrcs": [
+              "GBAMB9500001",
+              "GBUM71700212"
+            ],
+            "length": 233906,
+            "title": "Daniel",
+            "video": false
+          },
+          "title": "Daniel"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "f7ebe9ae-6355-455b-b6d6-47c2cfd536ad",
+          "length": 313200,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1972-05-19",
+            "id": "aefaa021-b6f9-4ac3-b0ec-b99cc27acb63",
+            "isrcs": [
+              "GBAMB7200002",
+              "GBAMB9200002",
+              "GBUM71700180"
+            ],
+            "length": 313200,
+            "title": "Honky Cat",
+            "video": false
+          },
+          "title": "Honky Cat"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "368dce5a-9342-4145-82b0-003afcdc162c",
+          "length": 194733,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1973-10-05",
+            "id": "e492bc5b-469e-497b-903d-64a9713deee0",
+            "isrcs": [
+              "GBAMB9500058",
+              "GBF080300779",
+              "GBUM71304956"
+            ],
+            "length": 194773,
+            "title": "Goodbye Yellow Brick Road",
+            "video": false
+          },
+          "title": "Goodbye Yellow Brick Road"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "90a3ea4a-0ec8-4d5a-a500-1349dffba0fe",
+          "length": 293000,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1973-06-29",
+            "id": "f8f27c10-47d7-40dc-a0a1-49eaba96d8ca",
+            "isrcs": [
+              "GBAMB9500068",
+              "GBF080300786",
+              "GBUM71304966"
+            ],
+            "length": 294973,
+            "title": "Saturday Night\u2019s Alright for Fighting",
+            "video": false
+          },
+          "title": "Saturday Night\u2019s Alright for Fighting"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "d498cac2-9e34-4981-9995-c6589bf54444",
+          "length": 282000,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1972-05-19",
+            "id": "4c2a08bd-26df-4e68-835a-5bc8ff9bcf8a",
+            "isrcs": [
+              "GBAMB7200006",
+              "GBAMB9200006",
+              "GBUM71700184"
+            ],
+            "length": 282000,
+            "title": "Rocket Man (I Think It\u2019s Going to Be a Long, Long Time)",
+            "video": false
+          },
+          "title": "Rocket Man"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "27160d6a-36b4-4bed-9967-f2b984468257",
+          "length": 322000,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1973-10-05",
+            "id": "5df9640d-217a-4480-bdc8-8173d137dd54",
+            "isrcs": [
+              "GBAMB9500057",
+              "GBF080300775",
+              "GBUM71304955"
+            ],
+            "length": 322826,
+            "title": "Bennie and the Jets",
+            "video": false
+          },
+          "title": "Bennie and the Jets"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "80f4090d-cda3-4b76-9838-f76314ec70bc",
+          "length": 337933,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1974-06-24",
+            "id": "e3710ecc-2578-4a03-9a0e-11d3843abd9a",
+            "isrcs": [
+              "GBAMB9500047"
+            ],
+            "length": 337280,
+            "title": "Don\u2019t Let the Sun Go Down on Me",
+            "video": false
+          },
+          "title": "Don\u2019t Let the Sun Go Down on Me"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "149cda11-5879-4428-9840-3e6d209c9bd2",
+          "length": 202066,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1970-07-22",
+            "id": "9bb24681-db91-45dc-ae75-fe37965480a3",
+            "isrcs": [
+              "GBAMB9500078",
+              "GBUM71604270"
+            ],
+            "length": 202066,
+            "title": "Border Song",
+            "video": false
+          },
+          "title": "Border Song"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer, songwriter, pianist, and composer",
+                "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                "name": "Elton John",
+                "sort-name": "John, Elton",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Elton John"
+            }
+          ],
+          "id": "6354eda5-d365-4ea5-88f5-a8d0611bb833",
+          "length": 235200,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer, songwriter, pianist, and composer",
+                  "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+                  "name": "Elton John",
+                  "sort-name": "John, Elton",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Elton John"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1972-10-27",
+            "id": "8388fed5-e41f-44d1-b6b5-a5b04ffffbd5",
+            "isrcs": [
+              "GBAMB7200001",
+              "GBAMB9200001",
+              "GBAMB9500009",
+              "GBUM71700220"
+            ],
+            "length": 235760,
+            "title": "Crocodile Rock",
+            "video": false
+          },
+          "title": "Crocodile Rock"
+        }
+      ]
+    }
+  ],
+  "packaging": "Jewel Case",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
+        "iso-3166-1-codes": [
+          "CA"
+        ],
+        "name": "Canada",
+        "sort-name": "Canada",
+        "type": null,
+        "type-id": null
+      },
+      "date": "1984"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "English singer, songwriter, pianist, and composer",
+          "id": "b83bc61f-8451-4a5d-8b8e-7e9ed295e822",
+          "name": "Elton John",
+          "sort-name": "John, Elton",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "",
+        "name": "Elton John"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1974-11-04",
+    "id": "6619f357-4115-3d8a-bd52-238641c23c28",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [
+      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
+    ],
+    "secondary-types": [
+      "Compilation"
+    ],
+    "title": "Greatest Hits"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Greatest Hits"
 }

--- a/scripts/eval_matching/corpus/eval_release_b072b162.json
+++ b/scripts/eval_matching/corpus/eval_release_b072b162.json
@@ -1,609 +1,609 @@
 {
-  "country": "DE",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "US",
+        "disambiguation": "American rock band",
+        "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+        "name": "Weezer",
+        "sort-name": "Weezer",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Weezer"
+    }
+  ],
+  "asin": "B000003TAW",
   "barcode": "720642462928",
-  "text-representation": {
-    "language": "eng",
-    "script": "Latn"
+  "country": "DE",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 11,
+    "darkened": false,
+    "front": true
   },
   "date": "1994-05-16",
-  "id": "b072b162-a733-3137-a4a0-4375172d98c9",
   "disambiguation": "blue album",
+  "id": "b072b162-a733-3137-a4a0-4375172d98c9",
   "label-info": [
     {
       "catalog-number": "GED 24629",
       "label": {
-        "label-code": 7266,
-        "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678",
-        "type": "Production",
-        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
         "disambiguation": "",
+        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
+        "label-code": 7266,
+        "name": "Geffen Records",
         "sort-name": "Geffen Records",
-        "name": "Geffen Records"
+        "type": "Production",
+        "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678"
       }
     },
     {
       "catalog-number": "GEFD 24629",
       "label": {
-        "name": "Geffen Records",
-        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
         "disambiguation": "",
-        "sort-name": "Geffen Records",
+        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
         "label-code": 7266,
-        "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678",
-        "type": "Production"
+        "name": "Geffen Records",
+        "sort-name": "Geffen Records",
+        "type": "Production",
+        "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678"
       }
     }
   ],
-  "release-group": {
-    "title": "Weezer",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "secondary-types": [],
-    "first-release-date": "1994-05-10",
-    "artist-credit": [
-      {
-        "joinphrase": "",
-        "name": "Weezer",
-        "artist": {
-          "type": "Group",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-          "disambiguation": "American rock band",
-          "sort-name": "Weezer",
-          "country": "US",
-          "name": "Weezer"
-        }
-      }
-    ],
-    "secondary-type-ids": [],
-    "disambiguation": "Blue Album",
-    "id": "c7b245c9-8099-32ea-af95-893acedde2cf",
-    "primary-type": "Album"
-  },
-  "title": "Weezer",
-  "quality": "normal",
   "media": [
     {
       "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "8ba83815-4e62-315d-8929-0f3ef246ffab",
+      "position": 1,
+      "title": "",
+      "track-count": 10,
+      "track-offset": 0,
       "tracks": [
         {
-          "id": "9e0b1186-f382-3ff9-931f-a080cf24ccc7",
-          "position": 1,
-          "length": 204466,
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "sort-name": "Weezer",
-                "disambiguation": "American rock band",
                 "country": "US",
-                "name": "Weezer"
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Weezer",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Weezer"
             }
           ],
+          "id": "9e0b1186-f382-3ff9-931f-a080cf24ccc7",
+          "length": 204466,
           "number": "1",
-          "title": "My Name Is Jonas",
+          "position": 1,
           "recording": {
-            "id": "392cea06-94c2-416b-80aa-f5b1e7d0fb1c",
-            "length": 204466,
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "392cea06-94c2-416b-80aa-f5b1e7d0fb1c",
             "isrcs": [
               "USGF19562904",
               "USGF19962901"
             ],
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Weezer",
-                "artist": {
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "sort-name": "Weezer",
-                  "disambiguation": "American rock band",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "name": "Weezer"
-                }
-              }
-            ],
-            "first-release-date": "1994-05-10",
-            "title": "My Name Is Jonas"
-          }
+            "length": 204466,
+            "title": "My Name Is Jonas",
+            "video": false
+          },
+          "title": "My Name Is Jonas"
         },
         {
-          "number": "2",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
+                "country": "US",
                 "disambiguation": "American rock band",
-                "sort-name": "Weezer",
                 "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
                 "name": "Weezer",
-                "country": "US"
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Weezer"
             }
           ],
-          "length": 184666,
-          "position": 2,
           "id": "10c41f28-413e-3d59-894f-64e0ed305ac2",
-          "title": "No One Else",
+          "length": 184666,
+          "number": "2",
+          "position": 2,
           "recording": {
-            "first-release-date": "1994-05-10",
-            "title": "No One Else",
-            "disambiguation": "",
-            "video": false,
-            "length": 184666,
-            "id": "271a81af-6c2d-44cf-a0b8-a25ad74c82f9",
             "artist-credit": [
               {
-                "name": "Weezer",
                 "artist": {
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "country": "US",
                   "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
                   "sort-name": "Weezer",
                   "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "name": "Weezer"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "271a81af-6c2d-44cf-a0b8-a25ad74c82f9",
             "isrcs": [
               "USGF19562905",
               "USGF19962902"
-            ]
-          }
+            ],
+            "length": 184666,
+            "title": "No One Else",
+            "video": false
+          },
+          "title": "No One Else"
         },
         {
           "artist-credit": [
             {
-              "name": "Weezer",
               "artist": {
                 "country": "US",
-                "name": "Weezer",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
+                "disambiguation": "American rock band",
                 "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
                 "sort-name": "Weezer",
-                "disambiguation": "American rock band"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Weezer"
             }
           ],
-          "number": "3",
-          "position": 3,
           "id": "b3944b6b-7096-3934-b250-76d5cbcca81c",
           "length": 259266,
+          "number": "3",
+          "position": 3,
           "recording": {
-            "first-release-date": "1994-05-10",
-            "title": "The World Has Turned and Left Me Here",
-            "id": "5d7e41b2-ec4b-44dd-b25a-a576d7a08adb",
-            "length": 259266,
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "5d7e41b2-ec4b-44dd-b25a-a576d7a08adb",
             "isrcs": [
               "USGF19562906",
               "USGF19962903"
             ],
-            "artist-credit": [
-              {
-                "name": "Weezer",
-                "artist": {
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Weezer",
-                  "disambiguation": "American rock band",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "name": "Weezer",
-                  "country": "US"
-                },
-                "joinphrase": ""
-              }
-            ]
+            "length": 259266,
+            "title": "The World Has Turned and Left Me Here",
+            "video": false
           },
           "title": "The World Has Turned and Left Me Here"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "78d7855e-5a0f-336b-8101-54fbc6fe0bdd",
+          "length": 159400,
+          "number": "4",
+          "position": 4,
           "recording": {
-            "length": 160000,
-            "id": "d615590b-1546-441d-9703-b3cf88487cbd",
-            "disambiguation": "",
-            "video": false,
             "artist-credit": [
               {
-                "name": "Weezer",
                 "artist": {
-                  "name": "Weezer",
                   "country": "US",
-                  "sort-name": "Weezer",
                   "disambiguation": "American rock band",
                   "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group"
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "d615590b-1546-441d-9703-b3cf88487cbd",
             "isrcs": [
               "USGF19562907"
             ],
-            "first-release-date": "1994-05-10",
-            "title": "Buddy Holly"
+            "length": 160000,
+            "title": "Buddy Holly",
+            "video": false
           },
-          "title": "Buddy Holly",
-          "number": "4",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Weezer",
-              "artist": {
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "sort-name": "Weezer",
-                "disambiguation": "American rock band",
-                "country": "US",
-                "name": "Weezer"
-              }
-            }
-          ],
-          "length": 159400,
-          "position": 4,
-          "id": "78d7855e-5a0f-336b-8101-54fbc6fe0bdd"
+          "title": "Buddy Holly"
         },
         {
-          "position": 5,
-          "length": 305400,
-          "id": "59df98f1-8e59-38a0-bc09-221ad57636d6",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band",
-                "sort-name": "Weezer",
                 "country": "US",
-                "name": "Weezer"
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Weezer",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Weezer"
             }
           ],
+          "id": "59df98f1-8e59-38a0-bc09-221ad57636d6",
+          "length": 305400,
           "number": "5",
+          "position": 5,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Weezer",
                   "country": "US",
                   "disambiguation": "American rock band",
-                  "sort-name": "Weezer",
                   "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group"
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Weezer",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "48908d8b-3a40-46fa-bfee-3a88012c2689",
             "isrcs": [
               "USGF19562908",
               "USGF19962905"
             ],
-            "id": "48908d8b-3a40-46fa-bfee-3a88012c2689",
             "length": 305400,
-            "disambiguation": "",
-            "video": false,
             "title": "Undone \u2013 The Sweater Song",
-            "first-release-date": "1994-05-10"
+            "video": false
           },
           "title": "Undone \u2014 The Sweater Song"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "26d89e96-639a-3145-9ef3-e231c069fac6",
+          "length": 186506,
+          "number": "6",
+          "position": 6,
           "recording": {
-            "isrcs": [
-              "USGF19562909"
-            ],
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Weezer",
                   "country": "US",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Weezer",
                   "disambiguation": "American rock band",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Weezer",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
-            "id": "d8f04ba0-8f7e-4016-b818-5f07514d11e8",
-            "length": 186506,
-            "video": false,
             "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "d8f04ba0-8f7e-4016-b818-5f07514d11e8",
+            "isrcs": [
+              "USGF19562909"
+            ],
+            "length": 186506,
             "title": "Surf Wax America",
-            "first-release-date": "1994-05-10"
+            "video": false
           },
-          "title": "Surf Wax America",
-          "length": 186506,
-          "position": 6,
-          "id": "26d89e96-639a-3145-9ef3-e231c069fac6",
-          "number": "6",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Weezer",
-              "artist": {
-                "name": "Weezer",
-                "country": "US",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Weezer",
-                "disambiguation": "American rock band",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
-              }
-            }
-          ]
+          "title": "Surf Wax America"
         },
         {
-          "title": "Say It Ain\u2019t So",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "08907b66-cd89-334d-b952-7c334721ca56",
+          "length": 258800,
+          "number": "7",
+          "position": 7,
           "recording": {
-            "id": "e7ada1d0-0604-4ff2-9361-939ebf5b53af",
-            "length": 258800,
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
             "disambiguation": "album version",
+            "first-release-date": "1994-05-10",
+            "id": "e7ada1d0-0604-4ff2-9361-939ebf5b53af",
             "isrcs": [
               "USGF19562901",
               "USGF19962907",
               "USIR10400084"
             ],
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "American rock band",
-                  "sort-name": "Weezer",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Weezer",
-                  "country": "US"
-                },
-                "name": "Weezer"
-              }
-            ],
-            "first-release-date": "1994-05-10",
-            "title": "Say It Ain\u2019t So"
+            "length": 258800,
+            "title": "Say It Ain\u2019t So",
+            "video": false
           },
-          "number": "7",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Weezer",
-              "artist": {
-                "country": "US",
-                "name": "Weezer",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band",
-                "sort-name": "Weezer"
-              }
-            }
-          ],
-          "position": 7,
-          "id": "08907b66-cd89-334d-b952-7c334721ca56",
-          "length": 258800
+          "title": "Say It Ain\u2019t So"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "name": "Weezer",
                 "country": "US",
                 "disambiguation": "American rock band",
-                "sort-name": "Weezer",
                 "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Weezer"
             }
           ],
-          "number": "8",
           "id": "3d9bd318-85b5-3218-9e6e-e638e886907f",
-          "position": 8,
           "length": 235760,
-          "title": "In the Garage",
+          "number": "8",
+          "position": 8,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "3761f313-1239-46e9-b720-9d24b06da5ab",
             "isrcs": [
               "USGF19562911",
               "USGF19962908"
             ],
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Weezer",
-                "artist": {
-                  "disambiguation": "American rock band",
-                  "sort-name": "Weezer",
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Weezer",
-                  "country": "US"
-                }
-              }
-            ],
-            "video": false,
-            "disambiguation": "",
             "length": 235760,
-            "id": "3761f313-1239-46e9-b720-9d24b06da5ab",
             "title": "In the Garage",
-            "first-release-date": "1994-05-10"
-          }
+            "video": false
+          },
+          "title": "In the Garage"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "name": "Weezer",
                 "country": "US",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
                 "sort-name": "Weezer",
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Weezer"
             }
           ],
-          "number": "9",
-          "length": 204866,
-          "position": 9,
           "id": "d95d81fc-4ae8-3d9c-b236-5c49bba61526",
-          "title": "Holiday",
+          "length": 204866,
+          "number": "9",
+          "position": 9,
           "recording": {
-            "title": "Holiday",
-            "first-release-date": "1994-05-10",
             "artist-credit": [
               {
                 "artist": {
                   "country": "US",
-                  "name": "Weezer",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "disambiguation": "American rock band",
                   "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
                   "sort-name": "Weezer",
-                  "disambiguation": "American rock band"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Weezer",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "e5b7a191-79d2-41ca-aa96-2d041c741aac",
             "isrcs": [
               "USGF19562912",
               "USGF19962909"
             ],
-            "id": "e5b7a191-79d2-41ca-aa96-2d041c741aac",
             "length": 204866,
-            "disambiguation": "",
+            "title": "Holiday",
             "video": false
-          }
+          },
+          "title": "Holiday"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "American rock band",
+                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                "name": "Weezer",
+                "sort-name": "Weezer",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Weezer"
+            }
+          ],
+          "id": "bacded83-7227-35bc-bf05-38f561958123",
+          "length": 478440,
+          "number": "10",
+          "position": 10,
           "recording": {
-            "title": "Only in Dreams",
-            "first-release-date": "1994-05-10",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Weezer",
                 "artist": {
-                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                  "sort-name": "Weezer",
-                  "disambiguation": "American rock band",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "US",
-                  "name": "Weezer"
-                }
+                  "disambiguation": "American rock band",
+                  "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+                  "name": "Weezer",
+                  "sort-name": "Weezer",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Weezer"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1994-05-10",
+            "id": "e1b7cd2e-bdf9-45d5-b52e-cc8a94d5d1da",
             "isrcs": [
               "USGF19562913",
               "USGF19962910"
             ],
-            "id": "e1b7cd2e-bdf9-45d5-b52e-cc8a94d5d1da",
             "length": 479000,
-            "disambiguation": "",
+            "title": "Only in Dreams",
             "video": false
           },
-          "title": "Only in Dreams",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Weezer",
-              "artist": {
-                "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-                "disambiguation": "American rock band",
-                "sort-name": "Weezer",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "US",
-                "name": "Weezer"
-              }
-            }
-          ],
-          "number": "10",
-          "position": 10,
-          "length": 478440,
-          "id": "bacded83-7227-35bc-bf05-38f561958123"
+          "title": "Only in Dreams"
         }
-      ],
-      "title": "",
-      "track-count": 10,
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "position": 1,
-      "id": "8ba83815-4e62-315d-8929-0f3ef246ffab",
-      "track-offset": 0
+      ]
     }
   ],
-  "cover-art-archive": {
-    "back": true,
-    "darkened": false,
-    "count": 11,
-    "front": true,
-    "artwork": true
-  },
-  "status": "Official",
+  "packaging": "Jewel Case",
   "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
   "release-events": [
     {
-      "date": "1994-05-16",
       "area": {
-        "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
         "disambiguation": "",
-        "sort-name": "Germany",
-        "type": null,
-        "type-id": null,
-        "name": "Germany",
+        "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
         "iso-3166-1-codes": [
           "DE"
-        ]
-      }
-    }
-  ],
-  "asin": "B000003TAW",
-  "artist-credit": [
-    {
-      "name": "Weezer",
-      "artist": {
-        "type": "Group",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "disambiguation": "American rock band",
-        "sort-name": "Weezer",
-        "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
-        "name": "Weezer",
-        "country": "US"
+        ],
+        "name": "Germany",
+        "sort-name": "Germany",
+        "type": null,
+        "type-id": null
       },
-      "joinphrase": ""
+      "date": "1994-05-16"
     }
   ],
-  "packaging": "Jewel Case"
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "American rock band",
+          "id": "6fe07aa5-fec0-4eca-a456-f29bff451b04",
+          "name": "Weezer",
+          "sort-name": "Weezer",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Weezer"
+      }
+    ],
+    "disambiguation": "Blue Album",
+    "first-release-date": "1994-05-10",
+    "id": "c7b245c9-8099-32ea-af95-893acedde2cf",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Weezer"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Weezer"
 }

--- a/scripts/eval_matching/corpus/eval_release_bab57bb1.json
+++ b/scripts/eval_matching/corpus/eval_release_bab57bb1.json
@@ -1,126 +1,95 @@
 {
-  "label-info": [
-    {
-      "label": {
-        "name": "Elektra",
-        "type": "Imprint",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "label-code": 192,
-        "disambiguation": "all releases with \u201cElektra\u201d or \u201cElektra Entertainment\u201d logo, 1950 to present",
-        "sort-name": "Elektra",
-        "id": "873f9f75-af68-4872-98e2-431058e4c9a9"
-      },
-      "catalog-number": "5E-564"
-    }
-  ],
-  "release-group": {
-    "secondary-types": [
-      "Compilation"
-    ],
-    "first-release-date": "1981-11-03",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "title": "Greatest Hits",
-    "id": "69ce61c8-127f-3809-95d8-62fdf3ae1347",
-    "primary-type": "Album",
-    "disambiguation": "",
-    "secondary-type-ids": [
-      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
-    ],
-    "artist-credit": [
-      {
-        "joinphrase": "",
-        "name": "Queen",
-        "artist": {
-          "country": "GB",
-          "name": "Queen",
-          "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-          "sort-name": "Queen",
-          "disambiguation": "UK rock group",
-          "type": "Group",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-        }
-      }
-    ]
-  },
-  "id": "bab57bb1-67a7-460a-a5c4-15c9a1df7d2d",
-  "disambiguation": "",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "date": "1981-11-03",
-  "country": "US",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "barcode": "",
-  "asin": null,
   "artist-credit": [
     {
-      "joinphrase": "",
-      "name": "Queen",
       "artist": {
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "type": "Group",
+        "country": "GB",
         "disambiguation": "UK rock group",
-        "sort-name": "Queen",
         "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
         "name": "Queen",
-        "country": "GB"
+        "sort-name": "Queen",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Queen"
+    }
+  ],
+  "asin": null,
+  "barcode": "",
+  "country": "US",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 6,
+    "darkened": false,
+    "front": true
+  },
+  "date": "1981-11-03",
+  "disambiguation": "",
+  "id": "bab57bb1-67a7-460a-a5c4-15c9a1df7d2d",
+  "label-info": [
+    {
+      "catalog-number": "5E-564",
+      "label": {
+        "disambiguation": "all releases with \u201cElektra\u201d or \u201cElektra Entertainment\u201d logo, 1950 to present",
+        "id": "873f9f75-af68-4872-98e2-431058e4c9a9",
+        "label-code": 192,
+        "name": "Elektra",
+        "sort-name": "Elektra",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
       }
     }
   ],
-  "packaging": "Cardboard/Paper Sleeve",
-  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
-  "status": "Official",
-  "release-events": [
-    {
-      "area": {
-        "type": null,
-        "type-id": null,
-        "id": "489ce91b-6658-3307-9877-795b68554c98",
-        "disambiguation": "",
-        "sort-name": "United States",
-        "iso-3166-1-codes": [
-          "US"
-        ],
-        "name": "United States"
-      },
-      "date": "1981-11-03"
-    }
-  ],
-  "title": "Greatest Hits",
-  "quality": "normal",
   "media": [
     {
-      "track-offset": 0,
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
       "id": "d00a3c2c-0fa1-34eb-9f9f-62e296de264c",
       "position": 1,
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
       "title": "",
       "track-count": 14,
+      "track-offset": 0,
       "tracks": [
         {
-          "number": "1",
           "artist-credit": [
             {
               "artist": {
+                "country": "GB",
                 "disambiguation": "UK rock group",
-                "sort-name": "Queen",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
                 "name": "Queen",
-                "country": "GB"
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Queen",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "position": 1,
           "id": "127d2e56-4bba-3d05-b5ed-aa453e177f37",
           "length": 216000,
+          "number": "1",
+          "position": 1,
           "recording": {
-            "title": "Another One Bites the Dust",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1980-06-24",
+            "id": "6b235773-16bd-4fc5-b57e-c966f9d1db6d",
             "isrcs": [
               "GBCEE0100113",
               "GBCEE0900132",
@@ -130,37 +99,51 @@
               "GBUM71029605",
               "USRHD0532298"
             ],
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Queen",
-                  "disambiguation": "UK rock group",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
-                  "country": "GB"
-                },
-                "name": "Queen"
-              }
-            ],
-            "id": "6b235773-16bd-4fc5-b57e-c966f9d1db6d",
             "length": 215053,
-            "video": false,
-            "disambiguation": ""
+            "title": "Another One Bites the Dust",
+            "video": false
           },
           "title": "Another One Bites the Dust"
         },
         {
-          "title": "Bohemian Rhapsody",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "28f53d2a-a04a-3380-bb97-827362703457",
+          "length": 355893,
+          "number": "2",
+          "position": 2,
           "recording": {
-            "first-release-date": "1975-11-21",
-            "title": "Bohemian Rhapsody",
-            "id": "b1a9c0e9-d987-4042-ae91-78d6a3267d69",
-            "length": 355106,
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1975-11-21",
+            "id": "b1a9c0e9-d987-4042-ae91-78d6a3267d69",
             "isrcs": [
               "GBCEE0100112",
               "GBCEE0500364",
@@ -170,60 +153,51 @@
               "GBCEE9800022",
               "GBUM71029604"
             ],
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "name": "Queen",
-                  "country": "GB",
-                  "sort-name": "Queen",
-                  "disambiguation": "UK rock group",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Queen"
-              }
-            ]
+            "length": 355106,
+            "title": "Bohemian Rhapsody",
+            "video": false
           },
-          "number": "2",
+          "title": "Bohemian Rhapsody"
+        },
+        {
           "artist-credit": [
             {
-              "name": "Queen",
               "artist": {
                 "country": "GB",
-                "name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
                 "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "id": "28f53d2a-a04a-3380-bb97-827362703457",
-          "position": 2,
-          "length": 355893
-        },
-        {
-          "title": "Crazy Little Thing Called Love",
+          "id": "9da239fc-2c6b-3278-9749-6cf2072fca55",
+          "length": 163826,
+          "number": "3",
+          "position": 3,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "name": "Queen",
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Queen",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1979-10-05",
+            "id": "fd125370-5ac9-45eb-86ad-ab99e258404b",
             "isrcs": [
               "GBCEE0100120",
               "GBCEE0900134",
@@ -231,71 +205,51 @@
               "GBCEE9300013",
               "GBUM71029612"
             ],
-            "id": "fd125370-5ac9-45eb-86ad-ab99e258404b",
             "length": 163706,
-            "disambiguation": "",
-            "video": false,
             "title": "Crazy Little Thing Called Love",
-            "first-release-date": "1979-10-05"
+            "video": false
           },
-          "artist-credit": [
-            {
-              "artist": {
-                "name": "Queen",
-                "country": "GB",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "UK rock group",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
-          "number": "3",
-          "position": 3,
-          "id": "9da239fc-2c6b-3278-9749-6cf2072fca55",
-          "length": 163826
+          "title": "Crazy Little Thing Called Love"
         },
         {
-          "position": 4,
-          "length": 181000,
-          "id": "db82788c-6110-3222-8186-75e478720766",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Queen",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "sort-name": "Queen",
+                "country": "GB",
                 "disambiguation": "UK rock group",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "name": "Queen",
-                "country": "GB"
-              }
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
+          "id": "db82788c-6110-3222-8186-75e478720766",
+          "length": 181000,
           "number": "4",
+          "position": 4,
           "recording": {
-            "title": "Killer Queen",
-            "first-release-date": "1974-10",
             "artist-credit": [
               {
-                "name": "Queen",
                 "artist": {
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "country": "GB",
                   "disambiguation": "UK rock group",
-                  "sort-name": "Queen",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "country": "GB"
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1974-10",
+            "id": "7b3d96c9-3e22-4337-be32-f8a26b816685",
             "isrcs": [
               "GBCEE0100114",
               "GBCEE0900140",
@@ -303,122 +257,178 @@
               "GBCEE9300004",
               "GBUM71029606"
             ],
-            "id": "7b3d96c9-3e22-4337-be32-f8a26b816685",
             "length": 180906,
-            "disambiguation": "",
+            "title": "Killer Queen",
             "video": false
           },
           "title": "Killer Queen"
         },
         {
-          "title": "Fat Bottomed Girls",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "ac3debd1-049e-3fdf-9fd2-a87f38419e3f",
+          "length": 257266,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "id": "0d538e7c-9261-46ec-bde9-cae13e42372c",
-            "length": 257000,
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1978-11-10",
+            "id": "0d538e7c-9261-46ec-bde9-cae13e42372c",
             "isrcs": [
               "GBCEG9800002",
               "GBUM71029607"
             ],
-            "artist-credit": [
-              {
-                "name": "Queen",
-                "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "disambiguation": "UK rock group",
-                  "sort-name": "Queen",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB",
-                  "name": "Queen"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1978-11-10",
-            "title": "Fat Bottomed Girls"
+            "length": 257000,
+            "title": "Fat Bottomed Girls",
+            "video": false
           },
-          "length": 257266,
-          "position": 5,
-          "id": "ac3debd1-049e-3fdf-9fd2-a87f38419e3f",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "disambiguation": "UK rock group",
-                "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "GB",
-                "name": "Queen"
-              }
-            }
-          ],
-          "number": "5"
+          "title": "Fat Bottomed Girls"
         },
         {
           "artist-credit": [
             {
-              "name": "Queen",
               "artist": {
-                "name": "Queen",
                 "country": "GB",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
                 "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
                 "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
+          "id": "91e2fecb-3bf7-344b-bcfc-5322014a44b9",
+          "length": 182493,
           "number": "6",
           "position": 6,
-          "length": 182493,
-          "id": "91e2fecb-3bf7-344b-bcfc-5322014a44b9",
-          "title": "Bicycle Race",
           "recording": {
-            "first-release-date": "1978-10-13",
-            "title": "Bicycle Race",
-            "disambiguation": "",
-            "video": false,
-            "id": "135214af-6058-4705-9f17-18d396f36191",
-            "length": 182000,
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "disambiguation": "UK rock group",
-                  "sort-name": "Queen",
                   "country": "GB",
-                  "name": "Queen"
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1978-10-13",
+            "id": "135214af-6058-4705-9f17-18d396f36191",
             "isrcs": [
               "GBCEE0100116",
               "GBCEE9300008",
               "GBCEG7800006",
               "GBCEG9800004",
               "GBUM71029608"
-            ]
-          }
+            ],
+            "length": 182000,
+            "title": "Bicycle Race",
+            "video": false
+          },
+          "title": "Bicycle Race"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": " & ",
+              "name": "Queen"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer\u2010songwriter",
+                "id": "5441c29d-3602-4898-b1a1-b77fa23b8e50",
+                "name": "David Bowie",
+                "sort-name": "Bowie, David",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "David Bowie"
+            }
+          ],
+          "id": "7680344d-c974-3999-ba4f-255aa66f97e0",
+          "length": 237933,
+          "number": "7",
+          "position": 7,
           "recording": {
-            "first-release-date": "1981-10",
-            "title": "Under Pressure",
-            "length": 243000,
-            "id": "32c7e292-14f1-4080-bddf-ef852e0a4c59",
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": " & ",
+                "name": "Queen"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer\u2010songwriter",
+                  "id": "5441c29d-3602-4898-b1a1-b77fa23b8e50",
+                  "name": "David Bowie",
+                  "sort-name": "Bowie, David",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "David Bowie"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1981-10",
+            "id": "32c7e292-14f1-4080-bddf-ef852e0a4c59",
             "isrcs": [
               "CBCEG8100001",
               "GBCEE0900136",
@@ -429,93 +439,51 @@
               "GBUM71106916",
               "GBUM71404523"
             ],
-            "artist-credit": [
-              {
-                "joinphrase": " & ",
-                "name": "Queen",
-                "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB",
-                  "name": "Queen"
-                }
-              },
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "type": "Person",
-                  "id": "5441c29d-3602-4898-b1a1-b77fa23b8e50",
-                  "disambiguation": "English singer\u2010songwriter",
-                  "sort-name": "Bowie, David",
-                  "country": "GB",
-                  "name": "David Bowie"
-                },
-                "name": "David Bowie",
-                "joinphrase": ""
-              }
-            ]
+            "length": 243000,
+            "title": "Under Pressure",
+            "video": false
           },
-          "title": "Under Pressure",
-          "position": 7,
-          "length": 237933,
-          "id": "7680344d-c974-3999-ba4f-255aa66f97e0",
-          "number": "7",
-          "artist-credit": [
-            {
-              "joinphrase": " & ",
-              "artist": {
-                "name": "Queen",
-                "country": "GB",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "UK rock group",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-              },
-              "name": "Queen"
-            },
-            {
-              "name": "David Bowie",
-              "artist": {
-                "name": "David Bowie",
-                "country": "GB",
-                "sort-name": "Bowie, David",
-                "disambiguation": "English singer\u2010songwriter",
-                "id": "5441c29d-3602-4898-b1a1-b77fa23b8e50",
-                "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              },
-              "joinphrase": ""
-            }
-          ]
+          "title": "Under Pressure"
         },
         {
-          "title": "We Will Rock You",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "3861a432-b684-33a5-b1de-742e3fdc6a86",
+          "length": 122133,
+          "number": "8",
+          "position": 8,
           "recording": {
-            "first-release-date": "1977-10-28",
-            "title": "We Will Rock You",
-            "length": 122000,
-            "id": "f8581c2b-61ac-465d-82ae-0fa2916a4799",
-            "disambiguation": "",
-            "video": false,
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
-                  "name": "Queen",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "sort-name": "Queen",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
                   "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1977-10-28",
+            "id": "f8581c2b-61ac-465d-82ae-0fa2916a4799",
             "isrcs": [
               "GBCEE0100127",
               "GBCEE0900129",
@@ -528,37 +496,52 @@
               "USEE10503137",
               "USHR10320404",
               "USHR10320405"
-            ]
+            ],
+            "length": 122000,
+            "title": "We Will Rock You",
+            "video": false
           },
-          "number": "8",
+          "title": "We Will Rock You"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
                 "country": "GB",
-                "name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
                 "sort-name": "Queen",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Queen",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "length": 122133,
-          "position": 8,
-          "id": "3861a432-b684-33a5-b1de-742e3fdc6a86"
-        },
-        {
-          "title": "We Are the Champions",
+          "id": "5416842c-87a9-3b19-b232-fa1f049e65d4",
+          "length": 181400,
+          "number": "9",
+          "position": 9,
           "recording": {
-            "first-release-date": "1977-10-28",
-            "title": "We Are the Champions",
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "1977-10-28",
             "id": "3604eb06-4bc2-4416-9b31-ceadae51bc70",
-            "length": 181026,
             "isrcs": [
               "GBCEE0100128",
               "GBCEE0900130",
@@ -569,83 +552,51 @@
               "GBUM71029619",
               "USRH10652606"
             ],
+            "length": 181026,
+            "title": "We Are the Champions",
+            "video": false
+          },
+          "title": "We Are the Champions"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "9af3a5ca-d9da-3a5f-8e08-c94ce2c104f3",
+          "length": 168400,
+          "number": "10",
+          "position": 10,
+          "recording": {
             "artist-credit": [
               {
-                "name": "Queen",
                 "artist": {
-                  "name": "Queen",
                   "country": "GB",
-                  "sort-name": "Queen",
                   "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
                   "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
-              }
-            ]
-          },
-          "number": "9",
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "artist": {
-                "country": "GB",
-                "name": "Queen",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "disambiguation": "UK rock group",
-                "sort-name": "Queen"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "position": 9,
-          "id": "5416842c-87a9-3b19-b232-fa1f049e65d4",
-          "length": 181400
-        },
-        {
-          "number": "10",
-          "artist-credit": [
-            {
-              "artist": {
-                "disambiguation": "UK rock group",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "name": "Queen",
-                "country": "GB"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
-          "length": 168400,
-          "position": 10,
-          "id": "9af3a5ca-d9da-3a5f-8e08-c94ce2c104f3",
-          "title": "Flash",
-          "recording": {
-            "length": 168426,
-            "id": "e61e12a1-118a-4441-9a58-b5eaff2ce9bc",
-            "disambiguation": "",
-            "video": false,
-            "artist-credit": [
-              {
                 "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "name": "Queen",
-                  "country": "GB",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Queen",
-                  "disambiguation": "UK rock group",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                }
+                "name": "Queen"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1980",
+            "id": "e61e12a1-118a-4441-9a58-b5eaff2ce9bc",
             "isrcs": [
               "GBCEE0100125",
               "GBCEE8000036",
@@ -653,15 +604,50 @@
               "GBUM71029616",
               "GBUM71103537"
             ],
-            "first-release-date": "1980",
-            "title": "Flash"
-          }
+            "length": 168426,
+            "title": "Flash",
+            "video": false
+          },
+          "title": "Flash"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "9e94c49d-6413-3b5e-8847-334f424a61b4",
+          "length": 296866,
+          "number": "11",
+          "position": 11,
           "recording": {
-            "video": false,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
             "disambiguation": "",
-            "length": 296466,
+            "first-release-date": "1976-11",
             "id": "3b286fbf-0dc9-45b8-bf4a-5036ac72526d",
             "isrcs": [
               "GBCEE0100121",
@@ -671,83 +657,51 @@
               "GBUM71029613",
               "GBUM71404710"
             ],
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Queen",
-                  "disambiguation": "UK rock group",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Queen",
-                  "country": "GB"
-                },
-                "name": "Queen"
-              }
-            ],
-            "first-release-date": "1976-11",
-            "title": "Somebody to Love"
+            "length": 296466,
+            "title": "Somebody to Love",
+            "video": false
           },
-          "title": "Somebody to Love",
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "artist": {
-                "disambiguation": "UK rock group",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "name": "Queen",
-                "country": "GB"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "number": "11",
-          "id": "9e94c49d-6413-3b5e-8847-334f424a61b4",
-          "position": 11,
-          "length": 296866
+          "title": "Somebody to Love"
         },
         {
-          "id": "1cee1da6-7b9b-3cbc-a3cb-ba15aa2f254f",
-          "position": 12,
-          "length": 172066,
-          "number": "12",
           "artist-credit": [
             {
-              "name": "Queen",
               "artist": {
                 "country": "GB",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "disambiguation": "UK rock group",
-                "sort-name": "Queen"
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
+          "id": "1cee1da6-7b9b-3cbc-a3cb-ba15aa2f254f",
+          "length": 172066,
+          "number": "12",
+          "position": 12,
           "recording": {
-            "title": "You\u2019re My Best Friend",
-            "first-release-date": "1975-11-21",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
+                  "country": "GB",
                   "disambiguation": "UK rock group",
-                  "sort-name": "Queen",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
                   "name": "Queen",
-                  "country": "GB"
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1975-11-21",
+            "id": "471dc436-80be-4f06-bc8f-7e2685876cfc",
             "isrcs": [
               "GBCEE0100117",
               "GBCEE0500375",
@@ -758,99 +712,96 @@
               "GBUM71029609"
             ],
             "length": 172000,
-            "id": "471dc436-80be-4f06-bc8f-7e2685876cfc",
-            "disambiguation": "",
+            "title": "You\u2019re My Best Friend",
             "video": false
           },
           "title": "You\u2019re My Best Friend"
         },
         {
-          "position": 13,
-          "length": 212000,
-          "id": "b189cd73-7972-335a-b00f-455cd6ea5c40",
-          "number": "13",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "disambiguation": "UK rock group",
-                "sort-name": "Queen",
                 "country": "GB",
-                "name": "Queen"
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
           ],
+          "id": "b189cd73-7972-335a-b00f-455cd6ea5c40",
+          "length": 212000,
+          "number": "13",
+          "position": 13,
           "recording": {
-            "id": "1231a0c3-7090-4216-baf9-44cb9b05ebe7",
-            "length": 212000,
-            "video": false,
-            "disambiguation": "mono single",
-            "isrcs": [],
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Queen",
+                  "country": "GB",
                   "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "name": "Queen",
-                  "country": "GB"
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Queen",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
+            "disambiguation": "mono single",
             "first-release-date": "1981-11-03",
-            "title": "Keep Yourself Alive"
+            "id": "1231a0c3-7090-4216-baf9-44cb9b05ebe7",
+            "isrcs": [],
+            "length": 212000,
+            "title": "Keep Yourself Alive",
+            "video": false
           },
           "title": "Keep Yourself Alive"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
                 "country": "GB",
-                "name": "Queen",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "disambiguation": "UK rock group",
-                "sort-name": "Queen"
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
           ],
-          "number": "14",
           "id": "7087c93c-5267-3a05-a870-8e53d5855293",
-          "position": 14,
           "length": 212066,
-          "title": "Play the Game",
+          "number": "14",
+          "position": 14,
           "recording": {
-            "length": 212066,
-            "id": "fd69655e-91e3-42d5-8cb5-27e3a3784067",
-            "disambiguation": "",
-            "video": false,
             "artist-credit": [
               {
                 "artist": {
                   "country": "GB",
-                  "name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
                   "sort-name": "Queen",
                   "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Queen",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1980-05",
+            "id": "fd69655e-91e3-42d5-8cb5-27e3a3784067",
             "isrcs": [
               "GBCEE0100124",
               "GBCEE8000025",
@@ -858,19 +809,68 @@
               "GBCEE9400026",
               "GBUM71029615"
             ],
-            "first-release-date": "1980-05",
-            "title": "Play the Game"
-          }
+            "length": 212066,
+            "title": "Play the Game",
+            "video": false
+          },
+          "title": "Play the Game"
         }
-      ],
-      "format": "12\" Vinyl"
+      ]
     }
   ],
-  "cover-art-archive": {
-    "front": true,
-    "artwork": true,
-    "back": true,
-    "darkened": false,
-    "count": 6
-  }
+  "packaging": "Cardboard/Paper Sleeve",
+  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
+        "iso-3166-1-codes": [
+          "US"
+        ],
+        "name": "United States",
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
+      },
+      "date": "1981-11-03"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "UK rock group",
+          "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+          "name": "Queen",
+          "sort-name": "Queen",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Queen"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1981-11-03",
+    "id": "69ce61c8-127f-3809-95d8-62fdf3ae1347",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [
+      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
+    ],
+    "secondary-types": [
+      "Compilation"
+    ],
+    "title": "Greatest Hits"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Greatest Hits"
 }

--- a/scripts/eval_matching/corpus/eval_release_c5192d47.json
+++ b/scripts/eval_matching/corpus/eval_release_c5192d47.json
@@ -1,134 +1,157 @@
 {
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "barcode": "9325583042089",
   "artist-credit": [
     {
       "artist": {
-        "sort-name": "Black Sabbath",
-        "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "type": "Group",
-        "name": "Black Sabbath",
         "country": "GB",
-        "disambiguation": "English heavy metal band"
+        "disambiguation": "English heavy metal band",
+        "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+        "name": "Black Sabbath",
+        "sort-name": "Black Sabbath",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
       "joinphrase": "",
       "name": "Black Sabbath"
     }
   ],
-  "text-representation": {
-    "language": "eng",
-    "script": "Latn"
+  "asin": null,
+  "barcode": "9325583042089",
+  "country": "AU",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": false,
+    "count": 1,
+    "darkened": false,
+    "front": true
   },
   "date": "2007",
+  "disambiguation": "",
+  "id": "c5192d47-f0e2-4f1b-81dc-fc61549d20e2",
   "label-info": [
     {
+      "catalog-number": "8122799924",
       "label": {
-        "label-code": 392,
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
         "disambiguation": "1958\u20132019; \u201cWB\u201d logo, with or without \u201crecords\u201d beneath or on banner across",
-        "name": "Warner Bros. Records",
-        "type": "Imprint",
         "id": "c595c289-47ce-4fba-b999-b87503e8cb71",
-        "sort-name": "Warner Bros. Records"
-      },
-      "catalog-number": "8122799924"
+        "label-code": 392,
+        "name": "Warner Bros. Records",
+        "sort-name": "Warner Bros. Records",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
     },
     {
+      "catalog-number": null,
       "label": {
-        "type": "Imprint",
         "disambiguation": "reissue label",
-        "name": "Rhino",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
+        "id": "c4f2cf49-b57c-4cc1-8061-f54400704ac4",
         "label-code": 2982,
+        "name": "Rhino",
         "sort-name": "Rhino",
-        "id": "c4f2cf49-b57c-4cc1-8061-f54400704ac4"
-      },
-      "catalog-number": null
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
     }
   ],
-  "title": "The Dio Years",
-  "asin": null,
   "media": [
     {
-      "position": 1,
-      "track-offset": 0,
-      "title": "",
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "996b1b68-b483-381c-bee0-94d268b8c613",
+      "position": 1,
+      "title": "",
+      "track-count": 16,
+      "track-offset": 0,
       "tracks": [
         {
-          "title": "Neon Knights",
-          "length": 232293,
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "English heavy metal band",
                 "country": "GB",
-                "name": "Black Sabbath",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "disambiguation": "English heavy metal band",
                 "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath"
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Black Sabbath",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Black Sabbath"
             }
           ],
+          "id": "d92d6f10-5462-4395-9f57-67d0fc3f36b5",
+          "length": 232293,
           "number": "1",
           "position": 1,
-          "id": "d92d6f10-5462-4395-9f57-67d0fc3f36b5",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1980-04-25",
-            "title": "Neon Knights",
-            "length": 232293,
+            "id": "0e8c9144-bd63-4cd6-9ed8-2d39690c0f87",
             "isrcs": [
               "GBUM70900395",
               "USRH12003566",
               "USWB10700217",
               "USWB10800510"
             ],
-            "video": false,
-            "id": "0e8c9144-bd63-4cd6-9ed8-2d39690c0f87",
+            "length": 232293,
+            "title": "Neon Knights",
+            "video": false
+          },
+          "title": "Neon Knights"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "0612d2f6-f0e8-4277-8ca0-c95767d02acb",
+          "length": 264493,
+          "number": "2",
+          "position": 2,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
                   "country": "GB",
                   "disambiguation": "English heavy metal band",
-                  "name": "Black Sabbath",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath"
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Black Sabbath"
               }
             ],
-            "disambiguation": ""
-          }
-        },
-        {
-          "position": 2,
-          "id": "0612d2f6-f0e8-4277-8ca0-c95767d02acb",
-          "recording": {
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1980-04-25",
             "id": "4325e6d2-8231-4ceb-ba22-3ff8bb5f5fa0",
             "isrcs": [
               "GBUM70900393",
@@ -138,283 +161,303 @@
             ],
             "length": 264493,
             "title": "Lady Evil",
-            "first-release-date": "1980-04-25"
-          },
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "GB",
-                "name": "Black Sabbath",
-                "disambiguation": "English heavy metal band",
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-              },
-              "joinphrase": "",
-              "name": "Black Sabbath"
-            }
-          ],
-          "title": "Lady Evil",
-          "length": 264493,
-          "number": "2"
-        },
-        {
-          "position": 3,
-          "id": "737d876d-98e5-4733-a600-a696bb225150",
-          "recording": {
-            "length": 417240,
-            "title": "Heaven and Hell",
-            "isrcs": [
-              "GBUM70900392",
-              "USRH12003569",
-              "USWB10700219",
-              "USWB10800513"
-            ],
-            "first-release-date": "1980-04-25",
-            "artist-credit": [
-              {
-                "name": "Black Sabbath",
-                "joinphrase": "",
-                "artist": {
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "name": "Black Sabbath",
-                  "type": "Group"
-                }
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "9ea011c9-d2ba-4e2a-adee-5ad2331f57e9"
-          },
-          "artist-credit": [
-            {
-              "name": "Black Sabbath",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "English heavy metal band",
-                "name": "Black Sabbath"
-              }
-            }
-          ],
-          "length": 418973,
-          "title": "Heaven and Hell",
-          "number": "3"
-        },
-        {
-          "number": "4",
-          "title": "Die Young",
-          "length": 284866,
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "disambiguation": "English heavy metal band",
-                "country": "GB",
-                "name": "Black Sabbath"
-              },
-              "name": "Black Sabbath",
-              "joinphrase": ""
-            }
-          ],
-          "recording": {
-            "title": "Die Young",
-            "length": 284866,
-            "isrcs": [
-              "GBUM70900391",
-              "USRH12003571",
-              "USWB10700220",
-              "USWB10800515"
-            ],
-            "first-release-date": "1980-04-25",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "disambiguation": "English heavy metal band"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "cbe61838-9184-4b59-bbde-862ca30682c5"
-          },
-          "id": "69cb9ba3-5de0-491e-a982-b601cbbe58b5",
-          "position": 4
-        },
-        {
-          "artist-credit": [
-            {
-              "name": "Black Sabbath",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "English heavy metal band",
-                "name": "Black Sabbath",
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-              }
-            }
-          ],
-          "title": "Lonely Is the Word",
-          "length": 351106,
-          "number": "5",
-          "id": "cd7fbbf0-1fab-4956-8700-5827d81bc931",
-          "position": 5,
-          "recording": {
-            "id": "fdcfcf7e-97ee-4262-8995-d439acc23cd8",
-            "video": false,
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath",
-                  "name": "Black Sabbath",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1980-04-25",
-            "isrcs": [
-              "GBUM70900394",
-              "USRH12003573",
-              "USWB10700221",
-              "USWB10800517"
-            ],
-            "title": "Lonely Is the Word",
-            "length": 350000
-          }
-        },
-        {
-          "recording": {
-            "isrcs": [
-              "GBUM70900389",
-              "USRH12003578",
-              "USWB10000515",
-              "USWB10700222"
-            ],
-            "title": "The Mob Rules",
-            "length": 195346,
-            "first-release-date": "1981-11-04",
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "disambiguation": "English heavy metal band",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-                },
-                "joinphrase": "",
-                "name": "Black Sabbath"
-              }
-            ],
-            "id": "9e2f0f8f-fc91-438e-9f1b-4a9dc3319d4e",
             "video": false
           },
-          "id": "e319fc3e-5ae0-4258-ad88-3c5dd0def9b3",
-          "position": 6,
-          "number": "6",
-          "length": 195986,
-          "title": "The Mob Rules",
+          "title": "Lady Evil"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
                 "country": "GB",
                 "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                 "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Black Sabbath"
             }
-          ]
+          ],
+          "id": "737d876d-98e5-4733-a600-a696bb225150",
+          "length": 418973,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1980-04-25",
+            "id": "9ea011c9-d2ba-4e2a-adee-5ad2331f57e9",
+            "isrcs": [
+              "GBUM70900392",
+              "USRH12003569",
+              "USWB10700219",
+              "USWB10800513"
+            ],
+            "length": 417240,
+            "title": "Heaven and Hell",
+            "video": false
+          },
+          "title": "Heaven and Hell"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "69cb9ba3-5de0-491e-a982-b601cbbe58b5",
+          "length": 284866,
+          "number": "4",
+          "position": 4,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1980-04-25",
+            "id": "cbe61838-9184-4b59-bbde-862ca30682c5",
+            "isrcs": [
+              "GBUM70900391",
+              "USRH12003571",
+              "USWB10700220",
+              "USWB10800515"
+            ],
+            "length": 284866,
+            "title": "Die Young",
+            "video": false
+          },
+          "title": "Die Young"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "cd7fbbf0-1fab-4956-8700-5827d81bc931",
+          "length": 351106,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1980-04-25",
+            "id": "fdcfcf7e-97ee-4262-8995-d439acc23cd8",
+            "isrcs": [
+              "GBUM70900394",
+              "USRH12003573",
+              "USWB10700221",
+              "USWB10800517"
+            ],
+            "length": 350000,
+            "title": "Lonely Is the Word",
+            "video": false
+          },
+          "title": "Lonely Is the Word"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "e319fc3e-5ae0-4258-ad88-3c5dd0def9b3",
+          "length": 195986,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1981-11-04",
-            "length": 222360,
-            "title": "Turn Up the Night",
+            "id": "9e2f0f8f-fc91-438e-9f1b-4a9dc3319d4e",
+            "isrcs": [
+              "GBUM70900389",
+              "USRH12003578",
+              "USWB10000515",
+              "USWB10700222"
+            ],
+            "length": 195346,
+            "title": "The Mob Rules",
+            "video": false
+          },
+          "title": "The Mob Rules"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "b3d4b94c-722c-483f-b992-fde821846de3",
+          "length": 222360,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1981-11-04",
+            "id": "2249f42f-b4a9-4fac-b1bd-0d1edcd9c886",
             "isrcs": [
               "GBUM70900381",
               "USRH12003574",
               "USWB10700223"
             ],
-            "id": "2249f42f-b4a9-4fac-b1bd-0d1edcd9c886",
-            "video": false,
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Black Sabbath",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-                },
-                "joinphrase": "",
-                "name": "Black Sabbath"
-              }
-            ]
+            "length": 222360,
+            "title": "Turn Up the Night",
+            "video": false
           },
-          "position": 7,
-          "id": "b3d4b94c-722c-483f-b992-fde821846de3",
-          "number": "7",
-          "title": "Turn Up the Night",
-          "length": 222360,
+          "title": "Turn Up the Night"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "English heavy metal band",
                 "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                 "name": "Black Sabbath",
-                "type": "Group"
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Black Sabbath"
             }
-          ]
-        },
-        {
+          ],
+          "id": "9ac4bea6-2a9a-48f3-9a01-0785287b0471",
+          "length": 274653,
+          "number": "8",
+          "position": 8,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1981-11-04",
+            "id": "9f34b1a2-e449-4cf4-a3b6-6c15bdfce548",
             "isrcs": [
               "GBUM70900382",
               "USRH12003575",
@@ -422,107 +465,19 @@
             ],
             "length": 273000,
             "title": "Voodoo",
-            "first-release-date": "1981-11-04",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "name": "Black Sabbath",
-                  "type": "Group"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "9f34b1a2-e449-4cf4-a3b6-6c15bdfce548"
+            "video": false
           },
-          "id": "9ac4bea6-2a9a-48f3-9a01-0785287b0471",
-          "position": 8,
-          "number": "8",
-          "length": 274653,
-          "title": "Voodoo",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Black Sabbath",
-              "artist": {
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "type": "Group",
-                "name": "Black Sabbath",
-                "country": "GB",
-                "disambiguation": "English heavy metal band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ]
+          "title": "Voodoo"
         },
         {
-          "id": "5a4f05e2-5a80-45a1-a629-de3a076bcc36",
-          "position": 9,
-          "recording": {
-            "video": false,
-            "id": "d38cea8d-1ce6-46a4-abdf-779dc5da8539",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Black Sabbath",
-                "artist": {
-                  "sort-name": "Black Sabbath",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "name": "Black Sabbath"
-                }
-              }
-            ],
-            "disambiguation": "",
-            "first-release-date": "1981-11-04",
-            "isrcs": [
-              "GBUM70900388",
-              "USRH12003581",
-              "USWB10700225"
-            ],
-            "title": "Falling off the Edge of the World",
-            "length": 303853
-          },
-          "length": 304960,
-          "title": "Falling off the Edge of the World",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Black Sabbath",
-              "artist": {
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "name": "Black Sabbath",
-                "country": "GB",
-                "disambiguation": "English heavy metal band"
-              }
-            }
-          ],
-          "number": "9"
-        },
-        {
-          "number": "10",
           "artist-credit": [
             {
               "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "name": "Black Sabbath",
                 "country": "GB",
                 "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
@@ -530,390 +485,435 @@
               "name": "Black Sabbath"
             }
           ],
-          "title": "After All (The Dead)",
-          "length": 342253,
+          "id": "5a4f05e2-5a80-45a1-a629-de3a076bcc36",
+          "length": 304960,
+          "number": "9",
+          "position": 9,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1981-11-04",
+            "id": "d38cea8d-1ce6-46a4-abdf-779dc5da8539",
+            "isrcs": [
+              "GBUM70900388",
+              "USRH12003581",
+              "USWB10700225"
+            ],
+            "length": 303853,
+            "title": "Falling off the Edge of the World",
+            "video": false
+          },
+          "title": "Falling off the Edge of the World"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "266decef-da96-43a5-86ad-251e6fc90a77",
+          "length": 342253,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1992-06-22",
+            "id": "e46093fb-a8e4-4d05-831d-2953a06f8523",
             "isrcs": [
               "USCA21003160",
               "USRE10700051"
             ],
             "length": 341626,
             "title": "After All (The Dead)",
-            "video": false,
-            "id": "e46093fb-a8e4-4d05-831d-2953a06f8523",
-            "artist-credit": [
-              {
-                "artist": {
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "disambiguation": "English heavy metal band",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": ""
+            "video": false
           },
-          "id": "266decef-da96-43a5-86ad-251e6fc90a77",
-          "position": 10
+          "title": "After All (The Dead)"
         },
         {
-          "number": "11",
-          "length": 242160,
-          "title": "TV Crimes",
           "artist-credit": [
             {
               "artist": {
-                "type": "Group",
-                "name": "Black Sabbath",
                 "country": "GB",
                 "disambiguation": "English heavy metal band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
                 "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Black Sabbath"
             }
           ],
-          "recording": {
-            "length": 242000,
-            "title": "TV Crimes",
-            "isrcs": [
-              "USCA21003161",
-              "USRE10700052"
-            ],
-            "first-release-date": "1992-06-01",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "English heavy metal band",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "type": "Group"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "fe2763b1-332f-4281-b785-c2fb032a9d5b"
-          },
           "id": "1acc5ce5-1aeb-4019-a4fe-9ce36195afac",
-          "position": 11
-        },
-        {
-          "number": "12",
-          "length": 313506,
-          "title": "I",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "name": "Black Sabbath",
-                "disambiguation": "English heavy metal band",
-                "type": "Group",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath"
-              },
-              "name": "Black Sabbath",
-              "joinphrase": ""
-            }
-          ],
+          "length": 242160,
+          "number": "11",
+          "position": 11,
           "recording": {
-            "id": "31ef8b7a-e849-49c5-bb6c-778d71497e3b",
-            "video": false,
-            "disambiguation": "",
             "artist-credit": [
               {
-                "name": "Black Sabbath",
-                "joinphrase": "",
                 "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
                   "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
                   "sort-name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "English heavy metal band",
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "type": "Group"
-                }
-              }
-            ],
-            "first-release-date": "1992-06-22",
-            "isrcs": [
-              "USCA21003167",
-              "USRE10700053"
-            ],
-            "length": 313000,
-            "title": "I"
-          },
-          "id": "107b4f1b-ba32-4b02-a9b2-383f87e10f59",
-          "position": 12
-        },
-        {
-          "recording": {
-            "first-release-date": "2007-03-30",
-            "title": "Children of the Sea (live)",
-            "length": 374013,
-            "isrcs": [
-              "USWB10700226"
-            ],
-            "video": false,
-            "id": "56c21ffe-3f9c-470f-852c-754070075d7b",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Black Sabbath",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
                   "type": "Group",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath"
-                },
-                "name": "Black Sabbath",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": ""
-          },
-          "position": 13,
-          "id": "38471643-b220-4ad4-868d-0893ed2497e1",
-          "number": "13",
-          "title": "Children of the Sea (live)",
-          "length": 374013,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Black Sabbath",
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "name": "Black Sabbath",
-                "disambiguation": "English heavy metal band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Black Sabbath",
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8"
-              }
-            }
-          ]
-        },
-        {
-          "number": "14",
-          "length": 361066,
-          "title": "The Devil Cried",
-          "artist-credit": [
-            {
-              "name": "Black Sabbath",
-              "joinphrase": "",
-              "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Black Sabbath",
-                "country": "GB",
-                "disambiguation": "English heavy metal band",
-                "type": "Group"
-              }
-            }
-          ],
-          "recording": {
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "artist": {
-                  "country": "GB",
-                  "name": "Black Sabbath",
-                  "disambiguation": "English heavy metal band",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Black Sabbath"
               }
             ],
-            "id": "94deece5-cc53-415f-a5ea-7ace353b1331",
-            "video": false,
-            "title": "The Devil Cried",
-            "length": 361066,
+            "disambiguation": "",
+            "first-release-date": "1992-06-01",
+            "id": "fe2763b1-332f-4281-b785-c2fb032a9d5b",
             "isrcs": [
-              "USRH10720699"
+              "USCA21003161",
+              "USRE10700052"
             ],
-            "first-release-date": "2007-03-13"
+            "length": 242000,
+            "title": "TV Crimes",
+            "video": false
           },
-          "position": 14,
-          "id": "7eefbe3a-cae0-4cb0-8446-ca9776a9fdbf"
+          "title": "TV Crimes"
         },
         {
-          "length": 340360,
-          "title": "Shadow of the Wind",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "GB",
                 "disambiguation": "English heavy metal band",
-                "name": "Black Sabbath",
-                "type": "Group",
                 "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath"
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Black Sabbath"
             }
           ],
-          "number": "15",
-          "id": "d5aee5fc-9a65-4152-8867-6d2e96f81ee8",
-          "position": 15,
+          "id": "107b4f1b-ba32-4b02-a9b2-383f87e10f59",
+          "length": 313506,
+          "number": "12",
+          "position": 12,
           "recording": {
-            "first-release-date": "2007-03-27",
-            "title": "Shadow of the Wind",
-            "length": 340360,
-            "isrcs": [
-              "USRH10720700"
-            ],
-            "video": false,
-            "id": "6659a234-056a-436f-93bd-8d7f9eb74277",
             "artist-credit": [
               {
-                "name": "Black Sabbath",
-                "joinphrase": "",
                 "artist": {
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "GB",
                   "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                   "name": "Black Sabbath",
-                  "type": "Group"
-                }
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
               }
             ],
-            "disambiguation": ""
-          }
+            "disambiguation": "",
+            "first-release-date": "1992-06-22",
+            "id": "31ef8b7a-e849-49c5-bb6c-778d71497e3b",
+            "isrcs": [
+              "USCA21003167",
+              "USRE10700053"
+            ],
+            "length": 313000,
+            "title": "I",
+            "video": false
+          },
+          "title": "I"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                "sort-name": "Black Sabbath",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "English heavy metal band",
                 "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
                 "name": "Black Sabbath",
-                "type": "Group"
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Black Sabbath",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Black Sabbath"
             }
           ],
-          "title": "Ear in the Wall",
+          "id": "38471643-b220-4ad4-868d-0893ed2497e1",
+          "length": 374013,
+          "number": "13",
+          "position": 13,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-03-30",
+            "id": "56c21ffe-3f9c-470f-852c-754070075d7b",
+            "isrcs": [
+              "USWB10700226"
+            ],
+            "length": 374013,
+            "title": "Children of the Sea (live)",
+            "video": false
+          },
+          "title": "Children of the Sea (live)"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "7eefbe3a-cae0-4cb0-8446-ca9776a9fdbf",
+          "length": 361066,
+          "number": "14",
+          "position": 14,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-03-13",
+            "id": "94deece5-cc53-415f-a5ea-7ace353b1331",
+            "isrcs": [
+              "USRH10720699"
+            ],
+            "length": 361066,
+            "title": "The Devil Cried",
+            "video": false
+          },
+          "title": "The Devil Cried"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "d5aee5fc-9a65-4152-8867-6d2e96f81ee8",
+          "length": 340360,
+          "number": "15",
+          "position": 15,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-03-27",
+            "id": "6659a234-056a-436f-93bd-8d7f9eb74277",
+            "isrcs": [
+              "USRH10720700"
+            ],
+            "length": 340360,
+            "title": "Shadow of the Wind",
+            "video": false
+          },
+          "title": "Shadow of the Wind"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English heavy metal band",
+                "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                "name": "Black Sabbath",
+                "sort-name": "Black Sabbath",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Black Sabbath"
+            }
+          ],
+          "id": "8e12b275-e5dc-412a-b069-c35d3ea7d4c1",
           "length": 244853,
           "number": "16",
           "position": 16,
-          "id": "8e12b275-e5dc-412a-b069-c35d3ea7d4c1",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English heavy metal band",
+                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+                  "name": "Black Sabbath",
+                  "sort-name": "Black Sabbath",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Black Sabbath"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2007-03-30",
-            "length": 244853,
-            "title": "Ear in the Wall",
+            "id": "dc8d14c0-51ae-4409-85c0-05ae27e60363",
             "isrcs": [
               "USRH10720701"
             ],
-            "video": false,
-            "id": "dc8d14c0-51ae-4409-85c0-05ae27e60363",
-            "artist-credit": [
-              {
-                "name": "Black Sabbath",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Black Sabbath",
-                  "country": "GB",
-                  "disambiguation": "English heavy metal band",
-                  "type": "Group",
-                  "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-                  "sort-name": "Black Sabbath"
-                }
-              }
-            ],
-            "disambiguation": ""
-          }
+            "length": 244853,
+            "title": "Ear in the Wall",
+            "video": false
+          },
+          "title": "Ear in the Wall"
         }
-      ],
-      "id": "996b1b68-b483-381c-bee0-94d268b8c613",
-      "track-count": 16
+      ]
     }
   ],
-  "status": "Official",
+  "packaging": "Jewel Case",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
   "quality": "normal",
-  "cover-art-archive": {
-    "artwork": true,
-    "count": 1,
-    "darkened": false,
-    "front": true,
-    "back": false
-  },
-  "country": "AU",
-  "disambiguation": "",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "release-events": [
     {
       "area": {
-        "type": null,
-        "name": "Australia",
         "disambiguation": "",
-        "type-id": null,
+        "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
         "iso-3166-1-codes": [
           "AU"
         ],
+        "name": "Australia",
         "sort-name": "Australia",
-        "id": "106e0bec-b638-3b37-b731-f53d507dc00e"
+        "type": null,
+        "type-id": null
       },
       "date": "2007"
     }
   ],
   "release-group": {
-    "title": "The Dio Years",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "first-release-date": "2007-03-30",
-    "primary-type": "Album",
-    "disambiguation": "",
-    "secondary-types": [
-      "Compilation"
-    ],
     "artist-credit": [
       {
         "artist": {
-          "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
-          "sort-name": "Black Sabbath",
           "country": "GB",
-          "name": "Black Sabbath",
           "disambiguation": "English heavy metal band",
+          "id": "5182c1d9-c7d2-4dad-afa0-ccfeada921a8",
+          "name": "Black Sabbath",
+          "sort-name": "Black Sabbath",
           "type": "Group",
           "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
         },
-        "name": "Black Sabbath",
-        "joinphrase": ""
+        "joinphrase": "",
+        "name": "Black Sabbath"
       }
     ],
+    "disambiguation": "",
+    "first-release-date": "2007-03-30",
+    "id": "ebe9bc5e-d5da-31c4-8e8a-8c5c54700b48",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
     "secondary-type-ids": [
       "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
     ],
-    "id": "ebe9bc5e-d5da-31c4-8e8a-8c5c54700b48"
+    "secondary-types": [
+      "Compilation"
+    ],
+    "title": "The Dio Years"
   },
-  "id": "c5192d47-f0e2-4f1b-81dc-fc61549d20e2",
-  "packaging": "Jewel Case"
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "The Dio Years"
 }

--- a/scripts/eval_matching/corpus/eval_release_cba282c5.json
+++ b/scripts/eval_matching/corpus/eval_release_cba282c5.json
@@ -1,600 +1,600 @@
 {
-  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
-  "cover-art-archive": {
-    "back": true,
-    "artwork": true,
-    "front": true,
-    "count": 17,
-    "darkened": false
-  },
-  "release-events": [
+  "artist-credit": [
     {
-      "area": {
-        "sort-name": "United States",
-        "type-id": null,
-        "id": "489ce91b-6658-3307-9877-795b68554c98",
-        "iso-3166-1-codes": [
-          "US"
-        ],
+      "artist": {
+        "country": "GB",
         "disambiguation": "",
-        "type": null,
-        "name": "United States"
+        "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+        "name": "Radiohead",
+        "sort-name": "Radiohead",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
-      "date": "2008-01-01"
+      "joinphrase": "",
+      "name": "Radiohead"
     }
   ],
-  "status": "Official",
-  "packaging": "Cardboard/Paper Sleeve",
-  "title": "In Rainbows",
+  "asin": "B000YXMMAE",
+  "barcode": "880882162221",
   "country": "US",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 17,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2008-01-01",
+  "disambiguation": "",
+  "id": "cba282c5-dd83-3157-afb6-9af6a5af7709",
   "label-info": [
     {
+      "catalog-number": "88088-21622-2",
       "label": {
-        "label-code": null,
-        "id": "2513d6c4-4622-4b4c-9ffa-a0067f29d717",
-        "type": "Distributor",
-        "name": "RED Distribution, LLC",
         "disambiguation": "a US division of Sony Music Entertainment",
-        "type-id": "53ab8dcc-9946-3b62-966e-7634d78e5034",
-        "sort-name": "RED Distribution, LLC"
-      },
-      "catalog-number": "88088-21622-2"
+        "id": "2513d6c4-4622-4b4c-9ffa-a0067f29d717",
+        "label-code": null,
+        "name": "RED Distribution, LLC",
+        "sort-name": "RED Distribution, LLC",
+        "type": "Distributor",
+        "type-id": "53ab8dcc-9946-3b62-966e-7634d78e5034"
+      }
     },
     {
       "catalog-number": "TBD0001",
       "label": {
-        "type": null,
-        "name": "TBD Records",
         "disambiguation": "",
         "id": "9b9655c8-30ec-4087-921d-87257e612d7b",
         "label-code": null,
+        "name": "TBD Records",
         "sort-name": "TBD Records",
+        "type": null,
         "type-id": null
       }
     }
   ],
-  "text-representation": {
-    "language": "eng",
-    "script": "Latn"
-  },
-  "release-group": {
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "primary-type": "Album",
-    "secondary-type-ids": [],
-    "title": "In Rainbows",
-    "secondary-types": [],
-    "id": "6e335887-60ba-38f0-95af-fae7774336bf",
-    "artist-credit": [
-      {
-        "artist": {
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "sort-name": "Radiohead",
-          "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-          "country": "GB",
-          "disambiguation": "",
-          "type": "Group",
-          "name": "Radiohead"
-        },
-        "name": "Radiohead",
-        "joinphrase": ""
-      }
-    ],
-    "first-release-date": "2007-10-10",
-    "disambiguation": ""
-  },
-  "date": "2008-01-01",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "barcode": "880882162221",
-  "id": "cba282c5-dd83-3157-afb6-9af6a5af7709",
-  "artist-credit": [
-    {
-      "joinphrase": "",
-      "name": "Radiohead",
-      "artist": {
-        "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-        "country": "GB",
-        "disambiguation": "",
-        "type": "Group",
-        "name": "Radiohead",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "sort-name": "Radiohead"
-      }
-    }
-  ],
-  "quality": "normal",
   "media": [
     {
-      "id": "a0081e6f-e923-38d7-9c16-2d9a2f74e0d8",
-      "track-offset": 0,
-      "title": "",
-      "position": 1,
       "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "a0081e6f-e923-38d7-9c16-2d9a2f74e0d8",
+      "position": 1,
+      "title": "",
       "track-count": 10,
+      "track-offset": 0,
       "tracks": [
         {
-          "recording": {
-            "title": "15 Step",
-            "first-release-date": "2007-10-10",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Radiohead",
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
-                },
-                "joinphrase": "",
-                "name": "Radiohead"
-              }
-            ],
-            "id": "faea2aa0-80a9-41be-9b1e-3b994f4f76ac",
-            "video": false,
-            "disambiguation": "",
-            "isrcs": [
-              "GBSTK0700001"
-            ],
-            "length": 238000
-          },
-          "number": "1",
-          "length": 238120,
-          "position": 1,
           "artist-credit": [
             {
-              "name": "Radiohead",
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
                 "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
                 "type": "Group",
-                "name": "Radiohead"
-              }
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
           "id": "6d55c8c9-998d-3a51-9385-c323404cd670",
+          "length": 238120,
+          "number": "1",
+          "position": 1,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "faea2aa0-80a9-41be-9b1e-3b994f4f76ac",
+            "isrcs": [
+              "GBSTK0700001"
+            ],
+            "length": 238000,
+            "title": "15 Step",
+            "video": false
+          },
           "title": "15 Step"
         },
         {
-          "recording": {
-            "length": 242293,
-            "isrcs": [
-              "GBSTK0700002"
-            ],
-            "video": false,
-            "disambiguation": "",
-            "title": "Bodysnatchers",
-            "id": "94a1d84a-66ce-4fc9-88a5-c46263c54d9a",
-            "first-release-date": "2007-10-10",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Radiohead",
-                "artist": {
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "",
-                  "country": "GB",
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
-                }
-              }
-            ]
-          },
-          "number": "2",
-          "length": 242293,
-          "position": 2,
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "",
                 "country": "GB",
-                "name": "Radiohead",
-                "type": "Group",
+                "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
                 "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Radiohead",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
           "id": "f02b4218-eb94-3615-9e34-62d8009b5de8",
+          "length": 242293,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "94a1d84a-66ce-4fc9-88a5-c46263c54d9a",
+            "isrcs": [
+              "GBSTK0700002"
+            ],
+            "length": 242293,
+            "title": "Bodysnatchers",
+            "video": false
+          },
           "title": "Bodysnatchers"
         },
         {
-          "title": "Nude",
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "",
                 "country": "GB",
-                "type": "Group",
-                "name": "Radiohead",
+                "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
                 "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Radiohead",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
           "id": "adeed8e5-1698-3374-8cd5-5337aded3438",
-          "position": 3,
-          "number": "3",
           "length": 255386,
+          "number": "3",
+          "position": 3,
           "recording": {
-            "title": "Nude",
-            "first-release-date": "2007-10-10",
             "artist-credit": [
               {
                 "artist": {
-                  "disambiguation": "",
                   "country": "GB",
-                  "type": "Group",
-                  "name": "Radiohead",
+                  "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
                   "sort-name": "Radiohead",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Radiohead",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "id": "f3bea96c-5ebf-4d37-990d-14f1bc281459",
-            "video": false,
             "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "f3bea96c-5ebf-4d37-990d-14f1bc281459",
             "isrcs": [
               "GBSTK0700003"
             ],
-            "length": 255386
-          }
+            "length": 255386,
+            "title": "Nude",
+            "video": false
+          },
+          "title": "Nude"
         },
         {
-          "position": 4,
-          "length": 318186,
-          "number": "4",
-          "recording": {
-            "id": "f74b48a6-5a60-4b5a-864d-3ecb7e983c31",
-            "first-release-date": "2007-10-10",
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "",
-                  "country": "GB",
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Radiohead"
-                },
-                "name": "Radiohead",
-                "joinphrase": ""
-              }
-            ],
-            "title": "Weird Fishes/Arpeggi",
-            "disambiguation": "",
-            "video": false,
-            "length": 318186,
-            "isrcs": [
-              "GBSTK0700004"
-            ]
-          },
-          "title": "Weird Fishes/Arpeggi",
-          "id": "70c028b2-da74-3c82-b196-ef6733c86bc6",
           "artist-credit": [
             {
               "artist": {
-                "type": "Group",
-                "name": "Radiohead",
-                "disambiguation": "",
                 "country": "GB",
+                "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Radiohead"
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Radiohead",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
-          ]
+          ],
+          "id": "70c028b2-da74-3c82-b196-ef6733c86bc6",
+          "length": 318186,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "f74b48a6-5a60-4b5a-864d-3ecb7e983c31",
+            "isrcs": [
+              "GBSTK0700004"
+            ],
+            "length": 318186,
+            "title": "Weird Fishes/Arpeggi",
+            "video": false
+          },
+          "title": "Weird Fishes/Arpeggi"
         },
         {
-          "number": "5",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "0ad56d90-cdda-30e4-9824-d70ef3b8b990",
           "length": 228746,
+          "number": "5",
           "position": 5,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "72c6b4d3-71a8-4c70-bf50-da11c0149089",
             "isrcs": [
               "GBSTK0700005"
             ],
             "length": 228746,
-            "artist-credit": [
-              {
-                "artist": {
-                  "country": "GB",
-                  "disambiguation": "",
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Radiohead",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2007-10-10",
-            "id": "72c6b4d3-71a8-4c70-bf50-da11c0149089",
             "title": "All I Need",
-            "disambiguation": "",
             "video": false
           },
-          "artist-credit": [
-            {
-              "artist": {
-                "type": "Group",
-                "name": "Radiohead",
-                "country": "GB",
-                "disambiguation": "",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "sort-name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "name": "Radiohead",
-              "joinphrase": ""
-            }
-          ],
-          "id": "0ad56d90-cdda-30e4-9824-d70ef3b8b990",
           "title": "All I Need"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
                 "sort-name": "Radiohead",
                 "type": "Group",
-                "name": "Radiohead",
-                "disambiguation": "",
-                "country": "GB",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Radiohead",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
           "id": "e1346fad-d8eb-3975-a346-05db10443baf",
-          "title": "Faust Arp",
+          "length": 129680,
+          "number": "6",
+          "position": 6,
           "recording": {
-            "length": 129680,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "ffac3cb1-a5e9-4f31-952d-45323f3640d5",
             "isrcs": [
               "GBSTK0700006"
             ],
-            "id": "ffac3cb1-a5e9-4f31-952d-45323f3640d5",
-            "first-release-date": "2007-10-10",
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "disambiguation": "",
-                  "country": "GB"
-                }
-              }
-            ],
+            "length": 129680,
             "title": "Faust Arp",
-            "disambiguation": "",
             "video": false
           },
-          "number": "6",
-          "length": 129680,
-          "position": 6
+          "title": "Faust Arp"
         },
         {
-          "title": "Reckoner",
-          "id": "218d567a-92e4-370e-ac72-8c77071a838a",
           "artist-credit": [
             {
-              "name": "Radiohead",
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "country": "GB",
                 "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
                 "type": "Group",
-                "name": "Radiohead"
-              }
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
+          "id": "218d567a-92e4-370e-ac72-8c77071a838a",
+          "length": 290213,
+          "number": "7",
+          "position": 7,
           "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "Reckoner",
-            "first-release-date": "2007-10-10",
             "artist-credit": [
               {
-                "name": "Radiohead",
-                "joinphrase": "",
                 "artist": {
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
                   "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "name": "Radiohead",
+                  "sort-name": "Radiohead",
                   "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Radiohead"
-                }
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
             "id": "d9b46ecb-5472-4dcd-8fa4-dd6723189e27",
             "isrcs": [
               "GBSTK0700007"
             ],
-            "length": 290213
+            "length": 290213,
+            "title": "Reckoner",
+            "video": false
           },
-          "position": 7,
-          "length": 290213,
-          "number": "7"
+          "title": "Reckoner"
         },
         {
-          "recording": {
-            "id": "29a9d792-151b-4dd4-99ae-25bc853d8895",
-            "artist-credit": [
-              {
-                "artist": {
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Radiohead",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2007-10-10",
-            "title": "House of Cards",
-            "disambiguation": "",
-            "video": false,
-            "length": 328293,
-            "isrcs": [
-              "GBSTK0700008"
-            ]
-          },
-          "position": 8,
-          "number": "8",
-          "length": 328293,
-          "title": "House of Cards",
           "artist-credit": [
             {
-              "name": "Radiohead",
-              "joinphrase": "",
               "artist": {
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "name": "Radiohead",
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
                 "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "id": "e2c56af5-5468-39df-be68-d06b703b0c74"
-        },
-        {
-          "position": 9,
-          "length": 248893,
-          "number": "9",
+          "id": "e2c56af5-5468-39df-be68-d06b703b0c74",
+          "length": 328293,
+          "number": "8",
+          "position": 8,
           "recording": {
-            "first-release-date": "2007-10-10",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
                   "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
                   "type": "Group",
-                  "name": "Radiohead"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "id": "31600df4-e6dd-48ca-9f6b-8804027d8d6e",
-            "title": "Jigsaw Falling Into Place",
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "2007-10-10",
+            "id": "29a9d792-151b-4dd4-99ae-25bc853d8895",
             "isrcs": [
-              "GBSTK0700009"
+              "GBSTK0700008"
             ],
-            "length": 248893
+            "length": 328293,
+            "title": "House of Cards",
+            "video": false
           },
-          "title": "Jigsaw Falling Into Place",
-          "id": "9b4c77fa-9e7a-3924-a71e-d69578e87c23",
+          "title": "House of Cards"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "country": "GB",
                 "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
                 "type": "Group",
-                "name": "Radiohead"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Radiohead",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
-          ]
-        },
-        {
+          ],
+          "id": "9b4c77fa-9e7a-3924-a71e-d69578e87c23",
+          "length": 248893,
+          "number": "9",
+          "position": 9,
           "recording": {
-            "disambiguation": "",
-            "video": false,
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
                   "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
                   "type": "Group",
-                  "name": "Radiohead"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Radiohead",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "31600df4-e6dd-48ca-9f6b-8804027d8d6e",
+            "isrcs": [
+              "GBSTK0700009"
+            ],
+            "length": 248893,
+            "title": "Jigsaw Falling Into Place",
+            "video": false
+          },
+          "title": "Jigsaw Falling Into Place"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "c0b111a4-1d2a-3cb9-b63f-c7912a04d74f",
+          "length": 281800,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2007-10-10",
             "id": "8648fe94-bbdc-44a1-9de8-c4ced7913dc2",
-            "title": "Videotape",
             "isrcs": [
               "GBSTK0700010"
             ],
-            "length": 281800
+            "length": 281800,
+            "title": "Videotape",
+            "video": false
           },
-          "position": 10,
-          "length": 281800,
-          "number": "10",
-          "title": "Videotape",
-          "id": "c0b111a4-1d2a-3cb9-b63f-c7912a04d74f",
-          "artist-credit": [
-            {
-              "name": "Radiohead",
-              "joinphrase": "",
-              "artist": {
-                "type": "Group",
-                "name": "Radiohead",
-                "disambiguation": "",
-                "country": "GB",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "sort-name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ]
+          "title": "Videotape"
         }
       ]
     }
   ],
-  "disambiguation": "",
-  "asin": "B000YXMMAE"
+  "packaging": "Cardboard/Paper Sleeve",
+  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "489ce91b-6658-3307-9877-795b68554c98",
+        "iso-3166-1-codes": [
+          "US"
+        ],
+        "name": "United States",
+        "sort-name": "United States",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2008-01-01"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "",
+          "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+          "name": "Radiohead",
+          "sort-name": "Radiohead",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Radiohead"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2007-10-10",
+    "id": "6e335887-60ba-38f0-95af-fae7774336bf",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "In Rainbows"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "In Rainbows"
 }

--- a/scripts/eval_matching/corpus/eval_release_e3334c4e.json
+++ b/scripts/eval_matching/corpus/eval_release_e3334c4e.json
@@ -1,339 +1,339 @@
 {
-  "release-group": {
-    "secondary-types": [],
-    "primary-type": "Album",
-    "first-release-date": "2000-10-09",
-    "id": "3822abb6-ca53-3ae1-a4ec-7718cb321e9b",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "artist-credit": [
-      {
-        "joinphrase": "",
-        "artist": {
-          "country": "CA",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "type": "Group",
-          "name": "Godspeed You! Black Emperor",
-          "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-          "sort-name": "Godspeed You! Black Emperor",
-          "disambiguation": ""
-        },
-        "name": "Godspeed You Black Emperor!"
-      }
-    ],
-    "secondary-type-ids": [],
-    "disambiguation": "",
-    "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!"
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "CA",
+        "disambiguation": "",
+        "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+        "name": "Godspeed You! Black Emperor",
+        "sort-name": "Godspeed You! Black Emperor",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Godspeed You Black Emperor!"
+    }
+  ],
+  "asin": "B00004ZD69",
+  "barcode": "666561001216",
+  "country": "AU",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 7,
+    "darkened": false,
+    "front": true
   },
+  "date": "2000-10-09",
+  "disambiguation": "",
   "id": "e3334c4e-9612-43a2-923b-27e33acbd705",
   "label-info": [
     {
       "catalog-number": "CST012",
       "label": {
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "name": "Constellation",
-        "type": "Original Production",
-        "label-code": null,
-        "id": "3496ee09-46bf-4bfd-92f1-38593e24d987",
         "disambiguation": "Montreal record label",
-        "sort-name": "Constellation"
+        "id": "3496ee09-46bf-4bfd-92f1-38593e24d987",
+        "label-code": null,
+        "name": "Constellation",
+        "sort-name": "Constellation",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
-  "quality": "normal",
-  "disambiguation": "",
-  "status": "Official",
-  "country": "AU",
-  "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
-  "date": "2000-10-09",
-  "cover-art-archive": {
-    "artwork": true,
-    "count": 7,
-    "darkened": false,
-    "back": true,
-    "front": true
-  },
-  "release-events": [
-    {
-      "area": {
-        "type-id": null,
-        "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
-        "name": "Australia",
-        "type": null,
-        "iso-3166-1-codes": [
-          "AU"
-        ],
-        "sort-name": "Australia",
-        "disambiguation": ""
-      },
-      "date": "2000-10-09"
-    },
-    {
-      "date": "2000-10-09",
-      "area": {
-        "type-id": null,
-        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
-        "type": null,
-        "name": "Canada",
-        "iso-3166-1-codes": [
-          "CA"
-        ],
-        "sort-name": "Canada",
-        "disambiguation": ""
-      }
-    },
-    {
-      "date": "2000-10-09",
-      "area": {
-        "disambiguation": "",
-        "sort-name": "United Kingdom",
-        "iso-3166-1-codes": [
-          "GB"
-        ],
-        "name": "United Kingdom",
-        "type": null,
-        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
-        "type-id": null
-      }
-    }
-  ],
-  "barcode": "666561001216",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "artist-credit": [
-    {
-      "joinphrase": "",
-      "name": "Godspeed You Black Emperor!",
-      "artist": {
-        "country": "CA",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-        "name": "Godspeed You! Black Emperor",
-        "type": "Group",
-        "sort-name": "Godspeed You! Black Emperor",
-        "disambiguation": ""
-      }
-    }
-  ],
-  "packaging": "Gatefold Cover",
   "media": [
     {
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
       "id": "0a422cdd-8519-3660-9407-a2e304bba86e",
+      "position": 1,
+      "title": "",
       "track-count": 2,
       "track-offset": 0,
-      "title": "",
-      "format": "12\" Vinyl",
-      "position": 1,
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
           "id": "e89f3b46-d0d8-3165-969a-94e4992fc5b4",
+          "length": 1352413,
+          "number": "A",
+          "position": 1,
           "recording": {
-            "disambiguation": "",
-            "title": "Storm",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
                   "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
                   "name": "Godspeed You! Black Emperor",
-                  "type": "Group",
-                  "country": "CA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "sort-name": "Godspeed You! Black Emperor",
-                  "disambiguation": ""
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Godspeed You Black Emperor!"
               }
             ],
-            "length": 1352413,
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "519e6d2f-c762-48b1-8798-8f0299e11cc7",
             "isrcs": [
               "USI4R0401862"
             ],
-            "video": false,
-            "id": "519e6d2f-c762-48b1-8798-8f0299e11cc7",
-            "first-release-date": "2000-10-09"
+            "length": 1352413,
+            "title": "Storm",
+            "video": false
           },
-          "title": "Storm (Lift Yr. Skinny Fists, Like Antennas to Heaven\u2026 / Gathering Storm / Il Pleut \u00c0 Mourir [+Clatters Like Worry] / \u201cWelcome to Barco AM/PM\u2026\u201d [L.A.X.; 5/14/00] / Cancer Towers on Holy Road Hi\u2010Way)",
-          "position": 1,
-          "number": "A",
-          "length": 1352413,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Godspeed You Black Emperor!",
-              "artist": {
-                "disambiguation": "",
-                "sort-name": "Godspeed You! Black Emperor",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "name": "Godspeed You! Black Emperor",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "CA"
-              }
-            }
-          ]
+          "title": "Storm (Lift Yr. Skinny Fists, Like Antennas to Heaven\u2026 / Gathering Storm / Il Pleut \u00c0 Mourir [+Clatters Like Worry] / \u201cWelcome to Barco AM/PM\u2026\u201d [L.A.X.; 5/14/00] / Cancer Towers on Holy Road Hi\u2010Way)"
         },
         {
-          "recording": {
-            "disambiguation": "",
-            "title": "Static",
-            "artist-credit": [
-              {
-                "name": "Godspeed You Black Emperor!",
-                "artist": {
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "type": "Group",
-                  "name": "Godspeed You! Black Emperor",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "CA",
-                  "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 1355946,
-            "video": false,
-            "isrcs": [
-              "USI4R0401863"
-            ],
-            "id": "30d53b2b-dbd5-4975-bbdf-48986b4bd089",
-            "first-release-date": "2000-10-09"
-          },
-          "id": "20f5f83f-ac61-32dd-a283-14e1a62526ca",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Godspeed You Black Emperor!",
               "artist": {
-                "disambiguation": "",
-                "sort-name": "Godspeed You! Black Emperor",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "type": "Group",
-                "name": "Godspeed You! Black Emperor",
                 "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
             }
           ],
+          "id": "20f5f83f-ac61-32dd-a283-14e1a62526ca",
           "length": 1355946,
           "number": "B",
           "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "30d53b2b-dbd5-4975-bbdf-48986b4bd089",
+            "isrcs": [
+              "USI4R0401863"
+            ],
+            "length": 1355946,
+            "title": "Static",
+            "video": false
+          },
           "title": "Static (Terrible Canyons of Static / Atomic Clock / Chart #3 / World Police and Friendly Fire / [\u2026+The Buildings They Are Sleeping Now])"
         }
       ]
     },
     {
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
       "id": "a4a189bc-c3be-3b2a-b256-4ec136b32025",
+      "position": 2,
+      "title": "",
       "track-count": 2,
       "track-offset": 0,
-      "position": 2,
-      "format": "12\" Vinyl",
-      "title": "",
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
       "tracks": [
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "name": "Godspeed You! Black Emperor",
-                "type": "Group",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
                 "country": "CA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
                 "sort-name": "Godspeed You! Black Emperor",
-                "disambiguation": ""
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Godspeed You Black Emperor!"
             }
           ],
+          "id": "0515b4e1-6806-3f7c-9dd7-3479edea9d62",
           "length": 1397746,
           "number": "C",
           "position": 1,
-          "title": "Sleep (Murray Ostril: \u201c\u2026 They Don\u2019t Sleep Anymore on the Beach\u2026\u201d / Monheim / Broken Windows, Locks of Love Pt. III. / 3rd Part)",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
             "id": "b8f1c93d-4273-4428-96cb-c38c6fb0d867",
-            "video": false,
             "isrcs": [
               "USI4R0401864"
             ],
-            "first-release-date": "2000-10-09",
-            "title": "Sleep",
-            "disambiguation": "",
             "length": 1397746,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Godspeed You Black Emperor!",
-                "artist": {
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "type": "Group",
-                  "name": "Godspeed You! Black Emperor",
-                  "country": "CA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "disambiguation": ""
-                }
-              }
-            ]
+            "title": "Sleep",
+            "video": false
           },
-          "id": "0515b4e1-6806-3f7c-9dd7-3479edea9d62"
+          "title": "Sleep (Murray Ostril: \u201c\u2026 They Don\u2019t Sleep Anymore on the Beach\u2026\u201d / Monheim / Broken Windows, Locks of Love Pt. III. / 3rd Part)"
         },
         {
-          "recording": {
-            "disambiguation": "",
-            "title": "Antennas to Heaven",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "name": "Godspeed You! Black Emperor",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "CA",
-                  "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor"
-                },
-                "name": "Godspeed You Black Emperor!",
-                "joinphrase": ""
-              }
-            ],
-            "length": 1137586,
-            "video": false,
-            "isrcs": [
-              "USI4R0401865"
-            ],
-            "id": "5fb00c2b-5bc9-420a-882a-cc024d137a08",
-            "first-release-date": "2000-10-09"
-          },
-          "id": "3dd71ba0-cdb4-3cd4-82c8-536f43c95b3c",
-          "number": "D",
-          "position": 2,
-          "title": "Antennas to Heaven (Moya Sings \u201cBaby\u2010O\u201d\u2026 / Edgyswingsetacid / [Glockenspiel Duet Recorded on a Campsite in Rhinebeck, N.Y.] / \u201cAttention\u2026 Mon Ami\u2026 Fa\u2010Lala\u2010Lala\u2010La\u2010La\u2026\u201d [55\u2010St.Laurent] / She Dreamt She Was a Bulldozer, She Dreamt She Was Alone in an Empty Field / Deathkamp Drone / [Antennas to Heaven\u2026])",
           "artist-credit": [
             {
               "artist": {
-                "type": "Group",
-                "name": "Godspeed You! Black Emperor",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
                 "country": "CA",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
                 "sort-name": "Godspeed You! Black Emperor",
-                "disambiguation": ""
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Godspeed You Black Emperor!",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
             }
           ],
-          "length": 1137586
+          "id": "3dd71ba0-cdb4-3cd4-82c8-536f43c95b3c",
+          "length": 1137586,
+          "number": "D",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "5fb00c2b-5bc9-420a-882a-cc024d137a08",
+            "isrcs": [
+              "USI4R0401865"
+            ],
+            "length": 1137586,
+            "title": "Antennas to Heaven",
+            "video": false
+          },
+          "title": "Antennas to Heaven (Moya Sings \u201cBaby\u2010O\u201d\u2026 / Edgyswingsetacid / [Glockenspiel Duet Recorded on a Campsite in Rhinebeck, N.Y.] / \u201cAttention\u2026 Mon Ami\u2026 Fa\u2010Lala\u2010Lala\u2010La\u2010La\u2026\u201d [55\u2010St.Laurent] / She Dreamt She Was a Bulldozer, She Dreamt She Was Alone in an Empty Field / Deathkamp Drone / [Antennas to Heaven\u2026])"
         }
       ]
     }
   ],
+  "packaging": "Gatefold Cover",
+  "packaging-id": "e724a489-a7e8-30a1-a17c-30dfd6831202",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
+        "iso-3166-1-codes": [
+          "AU"
+        ],
+        "name": "Australia",
+        "sort-name": "Australia",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2000-10-09"
+    },
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "71bbafaa-e825-3e15-8ca9-017dcad1748b",
+        "iso-3166-1-codes": [
+          "CA"
+        ],
+        "name": "Canada",
+        "sort-name": "Canada",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2000-10-09"
+    },
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+        "iso-3166-1-codes": [
+          "GB"
+        ],
+        "name": "United Kingdom",
+        "sort-name": "United Kingdom",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2000-10-09"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "CA",
+          "disambiguation": "",
+          "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+          "name": "Godspeed You! Black Emperor",
+          "sort-name": "Godspeed You! Black Emperor",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Godspeed You Black Emperor!"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2000-10-09",
+    "id": "3822abb6-ca53-3ae1-a4ec-7718cb321e9b",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
   "text-representation": {
     "language": "eng",
     "script": "Latn"
   },
-  "asin": "B00004ZD69",
   "title": "Lift Your Skinny Fists Like Antennas to Heaven!"
 }

--- a/scripts/eval_matching/corpus/eval_release_e9b0f69e.json
+++ b/scripts/eval_matching/corpus/eval_release_e9b0f69e.json
@@ -1,432 +1,414 @@
 {
-  "asin": "B000YIXBVI",
-  "release-group": {
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "first-release-date": "2007-10-10",
-    "title": "In Rainbows",
-    "id": "6e335887-60ba-38f0-95af-fae7774336bf",
-    "disambiguation": "",
-    "artist-credit": [
-      {
-        "joinphrase": "",
-        "artist": {
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "name": "Radiohead",
-          "type": "Group",
-          "country": "GB",
-          "sort-name": "Radiohead",
-          "disambiguation": "",
-          "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
-        },
-        "name": "Radiohead"
-      }
-    ],
-    "primary-type": "Album",
-    "secondary-type-ids": [],
-    "secondary-types": []
-  },
-  "status": "Official",
   "artist-credit": [
     {
-      "joinphrase": "",
       "artist": {
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "name": "Radiohead",
         "country": "GB",
-        "type": "Group",
         "disambiguation": "",
         "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-        "sort-name": "Radiohead"
+        "name": "Radiohead",
+        "sort-name": "Radiohead",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
+      "joinphrase": "",
       "name": "Radiohead"
     }
   ],
+  "asin": "B000YIXBVI",
+  "barcode": "634904032425",
+  "country": "XE",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 3,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2007-12-31",
+  "disambiguation": "",
   "id": "e9b0f69e-ee3d-36ed-8c12-f8ee65f87e45",
-  "release-events": [
+  "label-info": [
     {
-      "area": {
-        "type-id": null,
-        "name": "Europe",
-        "type": null,
-        "iso-3166-1-codes": [
-          "XE"
-        ],
-        "sort-name": "Europe",
-        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
-        "disambiguation": ""
-      },
-      "date": "2007-12-31"
+      "catalog-number": "XLCD 324",
+      "label": {
+        "disambiguation": "",
+        "id": "14221f01-8939-4ea0-b8f1-b5a21beae80a",
+        "label-code": 5667,
+        "name": "XL Recordings",
+        "sort-name": "XL Recordings",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
+      }
     },
     {
-      "date": "2007-12-31",
-      "area": {
-        "type": null,
+      "catalog-number": "XLCD324",
+      "label": {
         "disambiguation": "",
-        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
-        "iso-3166-1-codes": [
-          "GB"
-        ],
-        "sort-name": "United Kingdom",
-        "type-id": null,
-        "name": "United Kingdom"
+        "id": "14221f01-8939-4ea0-b8f1-b5a21beae80a",
+        "label-code": 5667,
+        "name": "XL Recordings",
+        "sort-name": "XL Recordings",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
-  "disambiguation": "",
   "media": [
     {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "33259638-3698-3a2c-98fd-745c4385bd74",
       "position": 1,
       "title": "",
       "track-count": 10,
+      "track-offset": 0,
       "tracks": [
         {
-          "number": "1",
           "artist-credit": [
             {
-              "name": "Radiohead",
-              "joinphrase": "",
               "artist": {
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
-                "sort-name": "Radiohead",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "recording": {
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "joinphrase": "",
-                "artist": {
-                  "country": "GB",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead"
-                }
-              }
-            ],
-            "first-release-date": "2007-10-10",
-            "video": false,
-            "length": 238000,
-            "title": "15 Step",
-            "isrcs": [
-              "GBSTK0700001"
-            ],
-            "id": "faea2aa0-80a9-41be-9b1e-3b994f4f76ac",
-            "disambiguation": ""
-          },
-          "position": 1,
-          "title": "15 Step",
           "id": "d55a0d72-0b5d-39d3-a20b-6bec305700c4",
-          "length": 238133
-        },
-        {
-          "length": 242293,
-          "position": 2,
-          "title": "Bodysnatchers",
+          "length": 238133,
+          "number": "1",
+          "position": 1,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
                   "country": "GB",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "disambiguation": "",
-                  "sort-name": "Radiohead"
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "first-release-date": "2007-10-10",
-            "video": false,
-            "length": 242293,
-            "isrcs": [
-              "GBSTK0700002"
-            ],
-            "id": "94a1d84a-66ce-4fc9-88a5-c46263c54d9a",
             "disambiguation": "",
-            "title": "Bodysnatchers"
+            "first-release-date": "2007-10-10",
+            "id": "faea2aa0-80a9-41be-9b1e-3b994f4f76ac",
+            "isrcs": [
+              "GBSTK0700001"
+            ],
+            "length": 238000,
+            "title": "15 Step",
+            "video": false
           },
-          "id": "812e3c5a-5473-3285-ab95-3bd1211d4a8d",
+          "title": "15 Step"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Radiohead",
                 "country": "GB",
-                "type": "Group",
                 "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "sort-name": "Radiohead"
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Radiohead"
             }
           ],
-          "number": "2"
+          "id": "812e3c5a-5473-3285-ab95-3bd1211d4a8d",
+          "length": 242293,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "94a1d84a-66ce-4fc9-88a5-c46263c54d9a",
+            "isrcs": [
+              "GBSTK0700002"
+            ],
+            "length": 242293,
+            "title": "Bodysnatchers",
+            "video": false
+          },
+          "title": "Bodysnatchers"
         },
         {
-          "number": "3",
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "sort-name": "Radiohead",
+                "country": "GB",
                 "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "country": "GB",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "title": "Nude",
+          "id": "fb993ae3-6539-3a17-a9c2-d9daf4ed4c8d",
+          "length": 255386,
+          "number": "3",
           "position": 3,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
-                  "type": "Group",
                   "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "video": false,
+            "disambiguation": "",
             "first-release-date": "2007-10-10",
-            "length": 255386,
-            "title": "Nude",
+            "id": "f3bea96c-5ebf-4d37-990d-14f1bc281459",
             "isrcs": [
               "GBSTK0700003"
             ],
-            "id": "f3bea96c-5ebf-4d37-990d-14f1bc281459",
-            "disambiguation": ""
+            "length": 255386,
+            "title": "Nude",
+            "video": false
           },
-          "id": "fb993ae3-6539-3a17-a9c2-d9daf4ed4c8d",
-          "length": 255386
+          "title": "Nude"
         },
         {
-          "number": "4",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Radiohead",
                 "country": "GB",
-                "type": "Group",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "disambiguation": "",
-                "sort-name": "Radiohead"
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Radiohead"
             }
           ],
-          "title": "Weird Fishes/Arpeggi",
+          "id": "9edcc268-7fca-3cf3-b38e-33ea3beac16d",
+          "length": 318186,
+          "number": "4",
+          "position": 4,
           "recording": {
             "artist-credit": [
               {
-                "name": "Radiohead",
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
-                  "sort-name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "disambiguation": "",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead"
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "2007-10-10",
-            "video": false,
-            "length": 318186,
+            "id": "f74b48a6-5a60-4b5a-864d-3ecb7e983c31",
             "isrcs": [
               "GBSTK0700004"
             ],
-            "id": "f74b48a6-5a60-4b5a-864d-3ecb7e983c31",
-            "disambiguation": "",
-            "title": "Weird Fishes/Arpeggi"
+            "length": 318186,
+            "title": "Weird Fishes/Arpeggi",
+            "video": false
           },
-          "position": 4,
-          "id": "9edcc268-7fca-3cf3-b38e-33ea3beac16d",
-          "length": 318186
+          "title": "Weird Fishes/Arpeggi"
         },
         {
-          "number": "5",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
-                "sort-name": "Radiohead",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Radiohead"
             }
           ],
+          "id": "ab8513cf-fad6-3b51-b369-307262308929",
+          "length": 228786,
+          "number": "5",
           "position": 5,
-          "title": "All I Need",
           "recording": {
-            "video": false,
-            "first-release-date": "2007-10-10",
-            "length": 228746,
-            "title": "All I Need",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "2007-10-10",
             "id": "72c6b4d3-71a8-4c70-bf50-da11c0149089",
             "isrcs": [
               "GBSTK0700005"
             ],
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "joinphrase": "",
-                "artist": {
-                  "name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "country": "GB",
-                  "type": "Group"
-                }
-              }
-            ]
+            "length": 228746,
+            "title": "All I Need",
+            "video": false
           },
-          "id": "ab8513cf-fad6-3b51-b369-307262308929",
-          "length": 228786
+          "title": "All I Need"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
-                "sort-name": "Radiohead",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Radiohead"
             }
           ],
-          "number": "6",
+          "id": "52c0c9ea-e417-3733-84d7-6aafa3681e43",
           "length": 129800,
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "country": "GB",
-                  "type": "Group",
-                  "disambiguation": "",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead"
-                },
-                "name": "Radiohead"
-              }
-            ],
-            "video": false,
-            "first-release-date": "2007-10-10",
-            "length": 129680,
-            "disambiguation": "",
-            "id": "ffac3cb1-a5e9-4f31-952d-45323f3640d5",
-            "isrcs": [
-              "GBSTK0700006"
-            ],
-            "title": "Faust Arp"
-          },
+          "number": "6",
           "position": 6,
-          "title": "Faust Arp",
-          "id": "52c0c9ea-e417-3733-84d7-6aafa3681e43"
-        },
-        {
-          "number": "7",
-          "artist-credit": [
-            {
-              "name": "Radiohead",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Radiohead",
-                "country": "GB",
-                "type": "Group",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
-                "sort-name": "Radiohead"
-              }
-            }
-          ],
-          "id": "296f92ac-22c4-3107-803e-2f5770d0a63e",
-          "title": "Reckoner",
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Radiohead",
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type": "Group",
-                  "country": "GB",
                   "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "video": false,
-            "first-release-date": "2007-10-10",
-            "length": 290213,
-            "isrcs": [
-              "GBSTK0700007"
-            ],
-            "id": "d9b46ecb-5472-4dcd-8fa4-dd6723189e27",
             "disambiguation": "",
-            "title": "Reckoner"
+            "first-release-date": "2007-10-10",
+            "id": "ffac3cb1-a5e9-4f31-952d-45323f3640d5",
+            "isrcs": [
+              "GBSTK0700006"
+            ],
+            "length": 129680,
+            "title": "Faust Arp",
+            "video": false
           },
-          "position": 7,
-          "length": 290373
+          "title": "Faust Arp"
         },
         {
-          "number": "8",
           "artist-credit": [
             {
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "sort-name": "Radiohead",
-                "country": "GB",
-                "type": "Group",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "296f92ac-22c4-3107-803e-2f5770d0a63e",
+          "length": 290373,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "d9b46ecb-5472-4dcd-8fa4-dd6723189e27",
+            "isrcs": [
+              "GBSTK0700007"
+            ],
+            "length": 290213,
+            "title": "Reckoner",
+            "video": false
+          },
+          "title": "Reckoner"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
@@ -434,181 +416,199 @@
             }
           ],
           "id": "6d2e4e90-7a74-3bac-8c82-48b2079565bf",
-          "title": "House of Cards",
+          "length": 328373,
+          "number": "8",
           "position": 8,
           "recording": {
             "artist-credit": [
               {
-                "name": "Radiohead",
                 "artist": {
                   "country": "GB",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
                   "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "title": "House of Cards",
-            "id": "29a9d792-151b-4dd4-99ae-25bc853d8895",
             "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "29a9d792-151b-4dd4-99ae-25bc853d8895",
             "isrcs": [
               "GBSTK0700008"
             ],
-            "video": false,
-            "first-release-date": "2007-10-10",
-            "length": 328293
+            "length": 328293,
+            "title": "House of Cards",
+            "video": false
           },
-          "length": 328373
+          "title": "House of Cards"
         },
         {
-          "number": "9",
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
-                "sort-name": "Radiohead",
                 "country": "GB",
-                "type": "Group"
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
           "id": "7621a646-3a29-3bc0-988e-f36be17b47a8",
+          "length": 249133,
+          "number": "9",
+          "position": 9,
           "recording": {
-            "title": "Jigsaw Falling Into Place",
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
             "disambiguation": "",
+            "first-release-date": "2007-10-10",
             "id": "31600df4-e6dd-48ca-9f6b-8804027d8d6e",
             "isrcs": [
               "GBSTK0700009"
             ],
-            "first-release-date": "2007-10-10",
-            "video": false,
             "length": 248893,
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "joinphrase": "",
-                "artist": {
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "country": "GB",
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ]
+            "title": "Jigsaw Falling Into Place",
+            "video": false
           },
-          "position": 9,
-          "title": "Jigsaw Falling Into Place",
-          "length": 249133
+          "title": "Jigsaw Falling Into Place"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "cc820072-aaa0-3c97-9385-bf8cb32b46d8",
+          "length": 282880,
+          "number": "10",
           "position": 10,
-          "title": "Videotape",
           "recording": {
             "artist-credit": [
               {
-                "name": "Radiohead",
-                "joinphrase": "",
                 "artist": {
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
                   "country": "GB",
-                  "type": "Group",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
             "id": "8648fe94-bbdc-44a1-9de8-c4ced7913dc2",
             "isrcs": [
               "GBSTK0700010"
             ],
-            "disambiguation": "",
+            "length": 281800,
             "title": "Videotape",
-            "video": false,
-            "first-release-date": "2007-10-10",
-            "length": 281800
+            "video": false
           },
-          "id": "cc820072-aaa0-3c97-9385-bf8cb32b46d8",
-          "length": 282880,
-          "number": "10",
-          "artist-credit": [
-            {
-              "name": "Radiohead",
-              "joinphrase": "",
-              "artist": {
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "sort-name": "Radiohead",
-                "country": "GB",
-                "type": "Group"
-              }
-            }
-          ]
+          "title": "Videotape"
         }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "track-offset": 0,
-      "format": "CD"
+      ]
     }
   ],
-  "title": "In Rainbows",
-  "date": "2007-12-31",
-  "label-info": [
+  "packaging": null,
+  "packaging-id": null,
+  "quality": "normal",
+  "release-events": [
     {
-      "catalog-number": "XLCD 324",
-      "label": {
+      "area": {
         "disambiguation": "",
-        "id": "14221f01-8939-4ea0-b8f1-b5a21beae80a",
-        "sort-name": "XL Recordings",
-        "type": "Original Production",
-        "name": "XL Recordings",
-        "label-code": 5667,
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
-      }
+        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+        "iso-3166-1-codes": [
+          "XE"
+        ],
+        "name": "Europe",
+        "sort-name": "Europe",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2007-12-31"
     },
     {
-      "catalog-number": "XLCD324",
-      "label": {
-        "name": "XL Recordings",
-        "label-code": 5667,
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "id": "14221f01-8939-4ea0-b8f1-b5a21beae80a",
+      "area": {
         "disambiguation": "",
-        "sort-name": "XL Recordings",
-        "type": "Original Production"
-      }
+        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+        "iso-3166-1-codes": [
+          "GB"
+        ],
+        "name": "United Kingdom",
+        "sort-name": "United Kingdom",
+        "type": null,
+        "type-id": null
+      },
+      "date": "2007-12-31"
     }
   ],
-  "cover-art-archive": {
-    "back": true,
-    "darkened": false,
-    "front": true,
-    "count": 3,
-    "artwork": true
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "",
+          "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+          "name": "Radiohead",
+          "sort-name": "Radiohead",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Radiohead"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2007-10-10",
+    "id": "6e335887-60ba-38f0-95af-fae7774336bf",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "In Rainbows"
   },
-  "packaging-id": null,
-  "country": "XE",
+  "status": "Official",
   "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "quality": "normal",
-  "barcode": "634904032425",
   "text-representation": {
     "language": "eng",
     "script": "Latn"
   },
-  "packaging": null
+  "title": "In Rainbows"
 }

--- a/scripts/eval_matching/corpus/eval_release_ea92a194.json
+++ b/scripts/eval_matching/corpus/eval_release_ea92a194.json
@@ -1,1509 +1,1509 @@
 {
-  "cover-art-archive": {
-    "back": true,
-    "darkened": false,
-    "count": 23,
-    "artwork": true,
-    "front": true
-  },
-  "release-events": [
-    {
-      "area": {
-        "sort-name": "United Kingdom",
-        "disambiguation": "",
-        "iso-3166-1-codes": [
-          "GB"
-        ],
-        "type": null,
-        "name": "United Kingdom",
-        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
-        "type-id": null
-      },
-      "date": "2007-12-03"
-    }
-  ],
-  "country": "GB",
-  "packaging-id": "d60b6157-79fe-3913-ab8b-23b32de8690d",
-  "date": "2007-12-03",
-  "asin": null,
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "title": "In Rainbows",
-  "barcode": null,
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "packaging": "Book",
   "artist-credit": [
     {
-      "joinphrase": "",
       "artist": {
-        "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-        "type": "Group",
-        "name": "Radiohead",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
         "country": "GB",
+        "disambiguation": "",
+        "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+        "name": "Radiohead",
         "sort-name": "Radiohead",
-        "disambiguation": ""
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
+      "joinphrase": "",
       "name": "Radiohead"
+    }
+  ],
+  "asin": null,
+  "barcode": null,
+  "country": "GB",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 23,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2007-12-03",
+  "disambiguation": "discbox",
+  "id": "ea92a194-2d60-35c7-9d56-0e1dba20cd45",
+  "label-info": [
+    {
+      "catalog-number": "CDS_X_X001",
+      "label": {
+        "disambiguation": "",
+        "id": "22434a7f-88eb-4e30-b33a-6920aad57525",
+        "label-code": null,
+        "name": "_Xurbia_Xendless Limited",
+        "sort-name": "_Xurbia_Xendless Limited",
+        "type": null,
+        "type-id": null
+      }
+    },
+    {
+      "catalog-number": "CD_X_X001",
+      "label": {
+        "disambiguation": "",
+        "id": "22434a7f-88eb-4e30-b33a-6920aad57525",
+        "label-code": null,
+        "name": "_Xurbia_Xendless Limited",
+        "sort-name": "_Xurbia_Xendless Limited",
+        "type": null,
+        "type-id": null
+      }
+    },
+    {
+      "catalog-number": "_X_X001",
+      "label": {
+        "disambiguation": "",
+        "id": "22434a7f-88eb-4e30-b33a-6920aad57525",
+        "label-code": null,
+        "name": "_Xurbia_Xendless Limited",
+        "sort-name": "_Xurbia_Xendless Limited",
+        "type": null,
+        "type-id": null
+      }
     }
   ],
   "media": [
     {
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+      "id": "9a116a07-fe15-3090-8003-6b509e8b1eb0",
+      "position": 1,
+      "title": "",
+      "track-count": 6,
+      "track-offset": 0,
       "tracks": [
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
                 "sort-name": "Radiohead",
                 "type": "Group",
-                "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "country": "GB",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Radiohead"
             }
           ],
+          "id": "137e9dc2-139a-34a0-bf60-3bc6f5155718",
           "length": 238000,
           "number": "A1",
-          "title": "15 Step",
           "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2007-10-10",
             "id": "faea2aa0-80a9-41be-9b1e-3b994f4f76ac",
-            "video": false,
             "isrcs": [
               "GBSTK0700001"
             ],
             "length": 238000,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Radiohead",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
-                }
-              }
-            ],
             "title": "15 Step",
-            "disambiguation": ""
+            "video": false
           },
-          "id": "137e9dc2-139a-34a0-bf60-3bc6f5155718"
+          "title": "15 Step"
         },
         {
-          "position": 2,
-          "title": "Bodysnatchers",
-          "number": "A2",
-          "length": 242000,
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "name": "Radiohead",
-                "type": "Group",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "GB",
                 "disambiguation": "",
-                "sort-name": "Radiohead"
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
           "id": "1f3aeced-e98b-3c96-b1de-f58d2c9d8fbc",
+          "length": 242000,
+          "number": "A2",
+          "position": 2,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Radiohead",
                 "artist": {
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "disambiguation": "",
-                  "sort-name": "Radiohead"
-                }
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "length": 242293,
             "disambiguation": "",
-            "title": "Bodysnatchers",
             "first-release-date": "2007-10-10",
+            "id": "94a1d84a-66ce-4fc9-88a5-c46263c54d9a",
             "isrcs": [
               "GBSTK0700002"
             ],
-            "video": false,
-            "id": "94a1d84a-66ce-4fc9-88a5-c46263c54d9a"
-          }
+            "length": 242293,
+            "title": "Bodysnatchers",
+            "video": false
+          },
+          "title": "Bodysnatchers"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
           "id": "8edbf633-a7a6-3d93-bfce-191169b76a62",
+          "length": 255000,
+          "number": "A3",
+          "position": 3,
           "recording": {
-            "disambiguation": "",
-            "title": "Nude",
             "artist-credit": [
               {
-                "name": "Radiohead",
                 "artist": {
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "name": "Radiohead",
+                  "sort-name": "Radiohead",
                   "type": "Group",
-                  "disambiguation": "",
-                  "sort-name": "Radiohead"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "length": 255386,
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "f3bea96c-5ebf-4d37-990d-14f1bc281459",
             "isrcs": [
               "GBSTK0700003"
             ],
-            "video": false,
-            "id": "f3bea96c-5ebf-4d37-990d-14f1bc281459",
-            "first-release-date": "2007-10-10"
+            "length": 255386,
+            "title": "Nude",
+            "video": false
           },
-          "title": "Nude",
-          "position": 3,
-          "number": "A3",
-          "length": 255000,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Radiohead",
-              "artist": {
-                "sort-name": "Radiohead",
-                "disambiguation": "",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead"
-              }
-            }
-          ]
+          "title": "Nude"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "55b81d64-243f-3ade-b873-a7d4eca84da6",
+          "length": 318000,
+          "number": "B1",
+          "position": 4,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "length": 318186,
             "disambiguation": "",
-            "title": "Weird Fishes/Arpeggi",
             "first-release-date": "2007-10-10",
-            "video": false,
+            "id": "f74b48a6-5a60-4b5a-864d-3ecb7e983c31",
             "isrcs": [
               "GBSTK0700004"
             ],
-            "id": "f74b48a6-5a60-4b5a-864d-3ecb7e983c31"
+            "length": 318186,
+            "title": "Weird Fishes/Arpeggi",
+            "video": false
           },
-          "id": "55b81d64-243f-3ade-b873-a7d4eca84da6",
-          "number": "B1",
-          "title": "Weird Fishes/Arpeggi",
-          "position": 4,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Radiohead",
-              "artist": {
-                "disambiguation": "",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB"
-              }
-            }
-          ],
-          "length": 318000
+          "title": "Weird Fishes/Arpeggi"
         },
         {
-          "number": "B2",
-          "title": "All I Need",
-          "position": 5,
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Radiohead",
               "artist": {
-                "sort-name": "Radiohead",
+                "country": "GB",
                 "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
                 "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB"
-              }
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
+          "id": "e2e5eccb-a9ad-3fef-8687-16e8a35d7cd7",
           "length": 229000,
+          "number": "B2",
+          "position": 5,
           "recording": {
-            "length": 228746,
             "artist-credit": [
               {
-                "name": "Radiohead",
                 "artist": {
+                  "country": "GB",
                   "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "name": "Radiohead",
-                  "type": "Group",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB"
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "title": "All I Need",
             "disambiguation": "",
             "first-release-date": "2007-10-10",
             "id": "72c6b4d3-71a8-4c70-bf50-da11c0149089",
-            "video": false,
             "isrcs": [
               "GBSTK0700005"
-            ]
+            ],
+            "length": 228746,
+            "title": "All I Need",
+            "video": false
           },
-          "id": "e2e5eccb-a9ad-3fef-8687-16e8a35d7cd7"
+          "title": "All I Need"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "5f360045-b0d2-331c-8d83-87ec0c88862b",
+          "length": 130000,
+          "number": "B3",
+          "position": 6,
           "recording": {
-            "disambiguation": "",
-            "title": "Faust Arp",
             "artist-credit": [
               {
-                "name": "Radiohead",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "GB",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "disambiguation": "",
-                  "sort-name": "Radiohead"
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "length": 129680,
-            "video": false,
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "ffac3cb1-a5e9-4f31-952d-45323f3640d5",
             "isrcs": [
               "GBSTK0700006"
             ],
-            "id": "ffac3cb1-a5e9-4f31-952d-45323f3640d5",
-            "first-release-date": "2007-10-10"
+            "length": 129680,
+            "title": "Faust Arp",
+            "video": false
           },
-          "id": "5f360045-b0d2-331c-8d83-87ec0c88862b",
-          "number": "B3",
-          "position": 6,
-          "title": "Faust Arp",
-          "artist-credit": [
-            {
-              "name": "Radiohead",
-              "artist": {
-                "type": "Group",
-                "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "country": "GB",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Radiohead",
-                "disambiguation": ""
-              },
-              "joinphrase": ""
-            }
-          ],
-          "length": 130000
+          "title": "Faust Arp"
         }
-      ],
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
-      "format": "12\" Vinyl",
-      "title": "",
-      "position": 1,
-      "track-offset": 0,
-      "track-count": 6,
-      "id": "9a116a07-fe15-3090-8003-6b509e8b1eb0"
+      ]
     },
     {
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+      "id": "d4804188-ad8d-3f2d-9ac9-76e4613e3330",
+      "position": 2,
+      "title": "",
+      "track-count": 4,
+      "track-offset": 0,
       "tracks": [
         {
-          "number": "C1",
-          "position": 1,
-          "title": "Reckoner",
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
                 "sort-name": "Radiohead",
                 "type": "Group",
-                "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "country": "GB",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
+          "id": "d84d7c3e-5f95-3d3f-93f5-304a3f48d3d0",
           "length": 290000,
+          "number": "C1",
+          "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "2007-10-10",
             "id": "d9b46ecb-5472-4dcd-8fa4-dd6723189e27",
             "isrcs": [
               "GBSTK0700007"
             ],
-            "video": false,
             "length": 290213,
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Radiohead",
-                  "disambiguation": "",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type": "Group",
-                  "name": "Radiohead"
-                },
-                "name": "Radiohead",
-                "joinphrase": ""
-              }
-            ],
             "title": "Reckoner",
-            "disambiguation": ""
+            "video": false
           },
-          "id": "d84d7c3e-5f95-3d3f-93f5-304a3f48d3d0"
+          "title": "Reckoner"
         },
         {
-          "id": "3574a15d-7c3d-3c3f-a03c-57cde0f2507a",
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB"
-                },
-                "name": "Radiohead"
-              }
-            ],
-            "length": 328293,
-            "disambiguation": "",
-            "title": "House of Cards",
-            "first-release-date": "2007-10-10",
-            "isrcs": [
-              "GBSTK0700008"
-            ],
-            "video": false,
-            "id": "29a9d792-151b-4dd4-99ae-25bc853d8895"
-          },
-          "title": "House of Cards",
-          "position": 2,
-          "number": "C2",
-          "length": 328000,
           "artist-credit": [
             {
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
-                "sort-name": "Radiohead",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
                 "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Radiohead",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
-          ]
-        },
-        {
-          "id": "44bbe905-7926-3afa-bdfc-e4e55be03b24",
+          ],
+          "id": "3574a15d-7c3d-3c3f-a03c-57cde0f2507a",
+          "length": 328000,
+          "number": "C2",
+          "position": 2,
           "recording": {
-            "title": "Jigsaw Falling Into Place",
-            "disambiguation": "",
-            "length": 248893,
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Radiohead",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "GB",
+                  "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type": "Group",
                   "name": "Radiohead",
                   "sort-name": "Radiohead",
-                  "disambiguation": ""
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "29a9d792-151b-4dd4-99ae-25bc853d8895",
+            "isrcs": [
+              "GBSTK0700008"
+            ],
+            "length": 328293,
+            "title": "House of Cards",
+            "video": false
+          },
+          "title": "House of Cards"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "44bbe905-7926-3afa-bdfc-e4e55be03b24",
+          "length": 249000,
+          "number": "D1",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
             "id": "31600df4-e6dd-48ca-9f6b-8804027d8d6e",
             "isrcs": [
               "GBSTK0700009"
             ],
-            "video": false,
-            "first-release-date": "2007-10-10"
+            "length": 248893,
+            "title": "Jigsaw Falling Into Place",
+            "video": false
           },
-          "position": 3,
-          "title": "Jigsaw Falling Into Place",
-          "number": "D1",
-          "length": 249000,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "type": "Group",
-                "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "sort-name": "Radiohead",
-                "disambiguation": ""
-              },
-              "name": "Radiohead"
-            }
-          ]
+          "title": "Jigsaw Falling Into Place"
         },
         {
-          "position": 4,
-          "title": "Videotape",
-          "number": "D2",
-          "length": 282000,
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
                 "sort-name": "Radiohead",
-                "disambiguation": ""
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
           "id": "d8fc6797-32ba-38e0-8533-0af616f5fe92",
+          "length": 282000,
+          "number": "D2",
+          "position": 4,
           "recording": {
-            "disambiguation": "",
-            "title": "Videotape",
             "artist-credit": [
               {
-                "name": "Radiohead",
                 "artist": {
-                  "sort-name": "Radiohead",
+                  "country": "GB",
                   "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "name": "Radiohead",
+                  "sort-name": "Radiohead",
                   "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "length": 281800,
-            "video": false,
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "8648fe94-bbdc-44a1-9de8-c4ced7913dc2",
             "isrcs": [
               "GBSTK0700010"
             ],
-            "id": "8648fe94-bbdc-44a1-9de8-c4ced7913dc2",
-            "first-release-date": "2007-10-10"
-          }
+            "length": 281800,
+            "title": "Videotape",
+            "video": false
+          },
+          "title": "Videotape"
         }
-      ],
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
-      "title": "",
-      "format": "12\" Vinyl",
-      "position": 2,
-      "track-offset": 0,
-      "track-count": 4,
-      "id": "d4804188-ad8d-3f2d-9ac9-76e4613e3330"
+      ]
     },
     {
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "5b59757e-f5a2-3c66-8bea-0968f8288315",
-      "track-count": 10,
       "position": 3,
       "title": "",
-      "format": "CD",
+      "track-count": 10,
       "track-offset": 0,
       "tracks": [
         {
-          "id": "863cdc4d-a6db-3348-a998-1a4f1dd7805c",
-          "recording": {
-            "isrcs": [
-              "GBSTK0700001"
-            ],
-            "video": false,
-            "id": "faea2aa0-80a9-41be-9b1e-3b994f4f76ac",
-            "first-release-date": "2007-10-10",
-            "disambiguation": "",
-            "title": "15 Step",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Radiohead",
-                  "disambiguation": ""
-                },
-                "name": "Radiohead"
-              }
-            ],
-            "length": 238000
-          },
-          "length": 238120,
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "sort-name": "Radiohead",
+                "country": "GB",
                 "disambiguation": "",
-                "name": "Radiohead",
-                "type": "Group",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB"
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Radiohead"
             }
           ],
-          "title": "15 Step",
+          "id": "863cdc4d-a6db-3348-a998-1a4f1dd7805c",
+          "length": 238120,
+          "number": "1",
           "position": 1,
-          "number": "1"
-        },
-        {
-          "id": "caf3008f-931e-3ade-8c06-cd8175b52f78",
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "disambiguation": "",
-                  "sort-name": "Radiohead"
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "length": 242293,
             "disambiguation": "",
-            "title": "Bodysnatchers",
             "first-release-date": "2007-10-10",
+            "id": "faea2aa0-80a9-41be-9b1e-3b994f4f76ac",
+            "isrcs": [
+              "GBSTK0700001"
+            ],
+            "length": 238000,
+            "title": "15 Step",
+            "video": false
+          },
+          "title": "15 Step"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "caf3008f-931e-3ade-8c06-cd8175b52f78",
+          "length": 242293,
+          "number": "2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "94a1d84a-66ce-4fc9-88a5-c46263c54d9a",
             "isrcs": [
               "GBSTK0700002"
             ],
-            "video": false,
-            "id": "94a1d84a-66ce-4fc9-88a5-c46263c54d9a"
+            "length": 242293,
+            "title": "Bodysnatchers",
+            "video": false
           },
-          "length": 242293,
-          "artist-credit": [
-            {
-              "name": "Radiohead",
-              "artist": {
-                "disambiguation": "",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "name": "Radiohead",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "position": 2,
-          "title": "Bodysnatchers",
-          "number": "2"
+          "title": "Bodysnatchers"
         },
         {
-          "position": 3,
-          "title": "Nude",
-          "number": "3",
-          "length": 255386,
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "GB",
                 "disambiguation": "",
-                "sort-name": "Radiohead"
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Radiohead"
             }
           ],
           "id": "5bf91792-6f09-33e2-97f5-ceac92522a4d",
+          "length": 255386,
+          "number": "3",
+          "position": 3,
           "recording": {
-            "length": 255386,
             "artist-credit": [
               {
                 "artist": {
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type": "Group",
-                  "name": "Radiohead",
                   "disambiguation": "",
-                  "sort-name": "Radiohead"
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Radiohead",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "title": "Nude",
             "disambiguation": "",
             "first-release-date": "2007-10-10",
             "id": "f3bea96c-5ebf-4d37-990d-14f1bc281459",
             "isrcs": [
               "GBSTK0700003"
             ],
+            "length": 255386,
+            "title": "Nude",
             "video": false
-          }
+          },
+          "title": "Nude"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "0fea63bc-cf8e-3ede-b3f9-3a93ddaf00f3",
+          "length": 318186,
+          "number": "4",
+          "position": 4,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
                   "sort-name": "Radiohead",
-                  "disambiguation": ""
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "length": 318186,
             "disambiguation": "",
-            "title": "Weird Fishes/Arpeggi",
             "first-release-date": "2007-10-10",
+            "id": "f74b48a6-5a60-4b5a-864d-3ecb7e983c31",
             "isrcs": [
               "GBSTK0700004"
             ],
-            "video": false,
-            "id": "f74b48a6-5a60-4b5a-864d-3ecb7e983c31"
+            "length": 318186,
+            "title": "Weird Fishes/Arpeggi",
+            "video": false
           },
-          "id": "0fea63bc-cf8e-3ede-b3f9-3a93ddaf00f3",
-          "artist-credit": [
-            {
-              "name": "Radiohead",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "name": "Radiohead",
-                "type": "Group",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
-                "sort-name": "Radiohead"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "length": 318186,
-          "number": "4",
-          "title": "Weird Fishes/Arpeggi",
-          "position": 4
+          "title": "Weird Fishes/Arpeggi"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "dd615567-4ecb-30df-a6f5-06d9c40e0c94",
+          "length": 228746,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "disambiguation": "",
-            "title": "All I Need",
             "artist-credit": [
               {
                 "artist": {
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "type": "Group",
+                  "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
                   "sort-name": "Radiohead",
-                  "disambiguation": ""
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Radiohead",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
-            "length": 228746,
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "72c6b4d3-71a8-4c70-bf50-da11c0149089",
             "isrcs": [
               "GBSTK0700005"
             ],
-            "video": false,
-            "id": "72c6b4d3-71a8-4c70-bf50-da11c0149089",
-            "first-release-date": "2007-10-10"
+            "length": 228746,
+            "title": "All I Need",
+            "video": false
           },
-          "id": "dd615567-4ecb-30df-a6f5-06d9c40e0c94",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Radiohead",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "type": "Group",
-                "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
-                "sort-name": "Radiohead"
-              }
-            }
-          ],
-          "length": 228746,
-          "number": "5",
-          "title": "All I Need",
-          "position": 5
+          "title": "All I Need"
         },
         {
-          "length": 129680,
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Radiohead",
               "artist": {
+                "country": "GB",
                 "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
                 "sort-name": "Radiohead",
                 "type": "Group",
-                "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "country": "GB",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "position": 6,
-          "title": "Faust Arp",
-          "number": "6",
           "id": "6fbecb8a-bbbc-3d50-a2a7-62dcad2c5090",
+          "length": 129680,
+          "number": "6",
+          "position": 6,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
             "id": "ffac3cb1-a5e9-4f31-952d-45323f3640d5",
             "isrcs": [
               "GBSTK0700006"
             ],
-            "video": false,
-            "first-release-date": "2007-10-10",
-            "title": "Faust Arp",
-            "disambiguation": "",
             "length": 129680,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Radiohead",
-                  "disambiguation": "",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Radiohead"
-              }
-            ]
-          }
+            "title": "Faust Arp",
+            "video": false
+          },
+          "title": "Faust Arp"
         },
         {
-          "recording": {
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB"
-                },
-                "name": "Radiohead",
-                "joinphrase": ""
-              }
-            ],
-            "length": 290213,
-            "disambiguation": "",
-            "title": "Reckoner",
-            "first-release-date": "2007-10-10",
-            "video": false,
-            "isrcs": [
-              "GBSTK0700007"
-            ],
-            "id": "d9b46ecb-5472-4dcd-8fa4-dd6723189e27"
-          },
-          "id": "ebab42c4-8fa0-36f7-8a59-d367eab30b49",
-          "number": "7",
-          "position": 7,
-          "title": "Reckoner",
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "GB",
-                "name": "Radiohead",
-                "type": "Group",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "sort-name": "Radiohead",
-                "disambiguation": ""
-              },
-              "name": "Radiohead",
-              "joinphrase": ""
-            }
-          ],
-          "length": 290213
-        },
-        {
-          "id": "7f4faf2e-abde-364c-9757-9c7119ce6121",
-          "recording": {
-            "isrcs": [
-              "GBSTK0700008"
-            ],
-            "video": false,
-            "id": "29a9d792-151b-4dd4-99ae-25bc853d8895",
-            "first-release-date": "2007-10-10",
-            "disambiguation": "",
-            "title": "House of Cards",
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 328293
-          },
-          "length": 328293,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Radiohead",
-              "artist": {
-                "sort-name": "Radiohead",
                 "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
                 "type": "Group",
-                "country": "GB",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "position": 8,
-          "title": "House of Cards",
-          "number": "8"
+          "id": "ebab42c4-8fa0-36f7-8a59-d367eab30b49",
+          "length": 290213,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "d9b46ecb-5472-4dcd-8fa4-dd6723189e27",
+            "isrcs": [
+              "GBSTK0700007"
+            ],
+            "length": 290213,
+            "title": "Reckoner",
+            "video": false
+          },
+          "title": "Reckoner"
         },
         {
-          "id": "20ae2491-4f17-3924-a8fe-61ae87506792",
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "7f4faf2e-abde-364c-9757-9c7119ce6121",
+          "length": 328293,
+          "number": "8",
+          "position": 8,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "29a9d792-151b-4dd4-99ae-25bc853d8895",
+            "isrcs": [
+              "GBSTK0700008"
+            ],
+            "length": 328293,
+            "title": "House of Cards",
+            "video": false
+          },
+          "title": "House of Cards"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "20ae2491-4f17-3924-a8fe-61ae87506792",
+          "length": 248893,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
             "id": "31600df4-e6dd-48ca-9f6b-8804027d8d6e",
             "isrcs": [
               "GBSTK0700009"
             ],
-            "video": false,
-            "first-release-date": "2007-10-10",
-            "title": "Jigsaw Falling Into Place",
-            "disambiguation": "",
             "length": 248893,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Radiohead",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
-                }
-              }
-            ]
+            "title": "Jigsaw Falling Into Place",
+            "video": false
           },
-          "title": "Jigsaw Falling Into Place",
-          "position": 9,
-          "number": "9",
-          "length": 248893,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Radiohead",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "type": "Group",
-                "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "disambiguation": "",
-                "sort-name": "Radiohead"
-              }
-            }
-          ]
+          "title": "Jigsaw Falling Into Place"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Radiohead",
               "artist": {
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead",
                 "country": "GB",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "disambiguation": "",
-                "sort-name": "Radiohead"
-              }
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
+          "id": "1fa24edb-eb63-3788-a75a-d52efca0ce7b",
           "length": 281800,
           "number": "10",
           "position": 10,
-          "title": "Videotape",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-10-10",
+            "id": "8648fe94-bbdc-44a1-9de8-c4ced7913dc2",
             "isrcs": [
               "GBSTK0700010"
             ],
-            "video": false,
-            "id": "8648fe94-bbdc-44a1-9de8-c4ced7913dc2",
-            "first-release-date": "2007-10-10",
-            "disambiguation": "",
+            "length": 281800,
             "title": "Videotape",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Radiohead",
-                "artist": {
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Radiohead",
-                  "disambiguation": ""
-                }
-              }
-            ],
-            "length": 281800
+            "video": false
           },
-          "id": "1fa24edb-eb63-3788-a75a-d52efca0ce7b"
+          "title": "Videotape"
         }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31"
+      ]
     },
     {
+      "format": "Enhanced CD",
+      "format-id": "8a08dc62-1aa2-34de-a904-fa467c53052c",
       "id": "14dea14c-5c50-3b33-87d6-1fe71cde783a",
+      "position": 4,
+      "title": "Disk 2",
       "track-count": 8,
       "track-offset": 0,
-      "position": 4,
-      "format": "Enhanced CD",
-      "title": "Disk 2",
-      "format-id": "8a08dc62-1aa2-34de-a904-fa467c53052c",
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "7c83a748-e1a0-3ef7-bfec-c2d5479a40fe",
+          "length": 63960,
+          "number": "1",
+          "position": 1,
           "recording": {
-            "title": "MK 1",
-            "disambiguation": "",
-            "length": 64000,
             "artist-credit": [
               {
-                "name": "Radiohead",
                 "artist": {
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Radiohead",
+                  "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
                   "sort-name": "Radiohead",
-                  "disambiguation": ""
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Radiohead"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "2007-12-03",
             "id": "e8d91bc2-9f74-487b-8b6b-a1ddfce55d28",
             "isrcs": [
               "GBSTK0700011"
             ],
-            "video": false,
-            "first-release-date": "2007-12-03"
+            "length": 64000,
+            "title": "MK 1",
+            "video": false
           },
-          "id": "7c83a748-e1a0-3ef7-bfec-c2d5479a40fe",
-          "number": "1",
-          "position": 1,
-          "title": "MK 1",
-          "artist-credit": [
-            {
-              "artist": {
-                "type": "Group",
-                "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "sort-name": "Radiohead",
-                "disambiguation": ""
-              },
-              "name": "Radiohead",
-              "joinphrase": ""
-            }
-          ],
-          "length": 63960
+          "title": "MK 1"
         },
         {
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "name": "Radiohead",
-                "type": "Group",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "country": "GB",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "disambiguation": "",
-                "sort-name": "Radiohead"
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
+          "id": "7b820ed9-2a83-3fa1-af44-cca64c347c8c",
           "length": 299120,
           "number": "2",
           "position": 2,
-          "title": "Down Is the New Up",
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Radiohead",
                 "artist": {
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "sort-name": "Radiohead",
-                  "disambiguation": ""
-                }
-              }
-            ],
-            "length": 299000,
-            "disambiguation": "",
-            "title": "Down Is the New Up",
-            "first-release-date": "2007-12-03",
-            "isrcs": [
-              "GBSTK0700012"
-            ],
-            "video": false,
-            "id": "7b9e1b47-b1bd-4d82-951e-cb98692a7467"
-          },
-          "id": "7b820ed9-2a83-3fa1-af44-cca64c347c8c"
-        },
-        {
-          "id": "8a6e5eb3-0abc-36fc-b669-f73b545e6137",
-          "recording": {
-            "length": 228000,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Radiohead",
                   "disambiguation": "",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB",
-                  "type": "Group",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                   "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "title": "Go Slowly",
+            "disambiguation": "",
+            "first-release-date": "2007-12-03",
+            "id": "7b9e1b47-b1bd-4d82-951e-cb98692a7467",
+            "isrcs": [
+              "GBSTK0700012"
+            ],
+            "length": 299000,
+            "title": "Down Is the New Up",
+            "video": false
+          },
+          "title": "Down Is the New Up"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "8a6e5eb3-0abc-36fc-b669-f73b545e6137",
+          "length": 228200,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
             "disambiguation": "",
             "first-release-date": "2007-12-03",
             "id": "dd11af7e-46b0-4f53-996b-b00945d8f9a2",
             "isrcs": [
               "GBSTK0700013"
             ],
+            "length": 228000,
+            "title": "Go Slowly",
             "video": false
           },
-          "length": 228200,
-          "artist-credit": [
-            {
-              "name": "Radiohead",
-              "artist": {
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "disambiguation": "",
-                "sort-name": "Radiohead"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "title": "Go Slowly",
-          "position": 3,
-          "number": "3"
+          "title": "Go Slowly"
         },
         {
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "sort-name": "Radiohead",
+                "country": "GB",
                 "disambiguation": "",
                 "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "name": "Radiohead",
+                "sort-name": "Radiohead",
                 "type": "Group",
-                "country": "GB",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
-            }
-          ],
-          "length": 53026,
-          "number": "4",
-          "title": "MK 2",
-          "position": 4,
-          "recording": {
-            "first-release-date": "2007-12-03",
-            "isrcs": [
-              "GBSTK0700014"
-            ],
-            "video": false,
-            "id": "caaa855a-1b2f-4458-b441-151ff0e9f741",
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "artist": {
-                  "type": "Group",
-                  "name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "",
-                  "sort-name": "Radiohead"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 53000,
-            "disambiguation": "",
-            "title": "MK 2"
-          },
-          "id": "8bf13adf-dd14-37bf-ace0-a920d3ee287e"
-        },
-        {
-          "number": "5",
-          "position": 5,
-          "title": "Last Flowers",
-          "artist-credit": [
-            {
               "joinphrase": "",
-              "name": "Radiohead",
-              "artist": {
-                "disambiguation": "",
-                "sort-name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB"
-              }
-            }
-          ],
-          "length": 266480,
-          "recording": {
-            "first-release-date": "2007-12-03",
-            "isrcs": [
-              "GBSTK0700015"
-            ],
-            "video": false,
-            "id": "dbab4de5-7f70-44c6-8047-b4c03e4a8d7e",
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Radiohead",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 267000,
-            "disambiguation": "",
-            "title": "Last Flowers"
-          },
-          "id": "6b976eb3-bd54-3470-ac26-e011850806ef"
-        },
-        {
-          "recording": {
-            "disambiguation": "",
-            "title": "Up on the Ladder",
-            "artist-credit": [
-              {
-                "name": "Radiohead",
-                "artist": {
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "disambiguation": "",
-                  "sort-name": "Radiohead"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "length": 257000,
-            "isrcs": [
-              "GBSTK0700016"
-            ],
-            "video": false,
-            "id": "1bb739a3-5004-4f18-bb39-4d2053f66256",
-            "first-release-date": "2007-12-03"
-          },
-          "id": "1984442e-ce2f-37d1-b533-7d1d5cbe289c",
-          "number": "6",
-          "title": "Up on the Ladder",
-          "position": 6,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Radiohead",
-                "disambiguation": "",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead",
-                "country": "GB",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
               "name": "Radiohead"
             }
           ],
-          "length": 257146
-        },
-        {
+          "id": "8bf13adf-dd14-37bf-ace0-a920d3ee287e",
+          "length": 53026,
+          "number": "4",
+          "position": 4,
           "recording": {
-            "disambiguation": "",
-            "title": "Bangers + Mash",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Radiohead",
-                  "disambiguation": "",
                   "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Radiohead",
-                  "type": "Group",
-                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
-                },
-                "name": "Radiohead",
-                "joinphrase": ""
-              }
-            ],
-            "length": 200000,
-            "isrcs": [
-              "GBSTK0700017"
-            ],
-            "video": false,
-            "id": "873d9d72-6d19-4dc4-bd91-695d6ebed037",
-            "first-release-date": "2007-12-03"
-          },
-          "id": "f73dd6d3-9853-318f-809b-9ae979a4cdf3",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Radiohead",
-                "disambiguation": "",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                "type": "Group",
-                "name": "Radiohead",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB"
-              },
-              "name": "Radiohead",
-              "joinphrase": ""
-            }
-          ],
-          "length": 199693,
-          "number": "7",
-          "position": 7,
-          "title": "Bangers + Mash"
-        },
-        {
-          "recording": {
-            "first-release-date": "2007-12-03",
-            "video": false,
-            "isrcs": [
-              "GBSTK0700018"
-            ],
-            "id": "9dd6fffb-14cc-43f3-993a-d83a39608ce8",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "type": "Group",
-                  "name": "Radiohead",
+                  "disambiguation": "",
                   "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-                  "country": "GB",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "",
-                  "sort-name": "Radiohead"
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Radiohead"
               }
             ],
-            "length": 246000,
             "disambiguation": "",
-            "title": "4 Minute Warning"
+            "first-release-date": "2007-12-03",
+            "id": "caaa855a-1b2f-4458-b441-151ff0e9f741",
+            "isrcs": [
+              "GBSTK0700014"
+            ],
+            "length": 53000,
+            "title": "MK 2",
+            "video": false
           },
-          "id": "0c983ee3-79e4-36a0-b2ee-8181159d36c6",
-          "number": "8",
-          "position": 8,
-          "title": "4 Minute Warning",
+          "title": "MK 2"
+        },
+        {
           "artist-credit": [
             {
-              "name": "Radiohead",
               "artist": {
-                "disambiguation": "",
-                "sort-name": "Radiohead",
                 "country": "GB",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
                 "name": "Radiohead",
-                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711"
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Radiohead"
             }
           ],
-          "length": 246266
+          "id": "6b976eb3-bd54-3470-ac26-e011850806ef",
+          "length": 266480,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-12-03",
+            "id": "dbab4de5-7f70-44c6-8047-b4c03e4a8d7e",
+            "isrcs": [
+              "GBSTK0700015"
+            ],
+            "length": 267000,
+            "title": "Last Flowers",
+            "video": false
+          },
+          "title": "Last Flowers"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "1984442e-ce2f-37d1-b533-7d1d5cbe289c",
+          "length": 257146,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-12-03",
+            "id": "1bb739a3-5004-4f18-bb39-4d2053f66256",
+            "isrcs": [
+              "GBSTK0700016"
+            ],
+            "length": 257000,
+            "title": "Up on the Ladder",
+            "video": false
+          },
+          "title": "Up on the Ladder"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "f73dd6d3-9853-318f-809b-9ae979a4cdf3",
+          "length": 199693,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-12-03",
+            "id": "873d9d72-6d19-4dc4-bd91-695d6ebed037",
+            "isrcs": [
+              "GBSTK0700017"
+            ],
+            "length": 200000,
+            "title": "Bangers + Mash",
+            "video": false
+          },
+          "title": "Bangers + Mash"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "",
+                "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                "name": "Radiohead",
+                "sort-name": "Radiohead",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Radiohead"
+            }
+          ],
+          "id": "0c983ee3-79e4-36a0-b2ee-8181159d36c6",
+          "length": 246266,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "",
+                  "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+                  "name": "Radiohead",
+                  "sort-name": "Radiohead",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Radiohead"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2007-12-03",
+            "id": "9dd6fffb-14cc-43f3-993a-d83a39608ce8",
+            "isrcs": [
+              "GBSTK0700018"
+            ],
+            "length": 246000,
+            "title": "4 Minute Warning",
+            "video": false
+          },
+          "title": "4 Minute Warning"
         }
       ]
     }
   ],
-  "release-group": {
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "artist-credit": [
-      {
-        "name": "Radiohead",
-        "artist": {
-          "country": "GB",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "type": "Group",
-          "name": "Radiohead",
-          "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
-          "disambiguation": "",
-          "sort-name": "Radiohead"
-        },
-        "joinphrase": ""
-      }
-    ],
-    "secondary-type-ids": [],
-    "disambiguation": "",
-    "title": "In Rainbows",
-    "secondary-types": [],
-    "primary-type": "Album",
-    "first-release-date": "2007-10-10",
-    "id": "6e335887-60ba-38f0-95af-fae7774336bf"
-  },
-  "id": "ea92a194-2d60-35c7-9d56-0e1dba20cd45",
-  "label-info": [
+  "packaging": "Book",
+  "packaging-id": "d60b6157-79fe-3913-ab8b-23b32de8690d",
+  "quality": "normal",
+  "release-events": [
     {
-      "catalog-number": "CDS_X_X001",
-      "label": {
-        "id": "22434a7f-88eb-4e30-b33a-6920aad57525",
-        "name": "_Xurbia_Xendless Limited",
-        "type": null,
-        "label-code": null,
-        "type-id": null,
+      "area": {
         "disambiguation": "",
-        "sort-name": "_Xurbia_Xendless Limited"
-      }
-    },
-    {
-      "catalog-number": "CD_X_X001",
-      "label": {
-        "type-id": null,
+        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+        "iso-3166-1-codes": [
+          "GB"
+        ],
+        "name": "United Kingdom",
+        "sort-name": "United Kingdom",
         "type": null,
-        "name": "_Xurbia_Xendless Limited",
-        "label-code": null,
-        "id": "22434a7f-88eb-4e30-b33a-6920aad57525",
-        "sort-name": "_Xurbia_Xendless Limited",
-        "disambiguation": ""
-      }
-    },
-    {
-      "label": {
-        "id": "22434a7f-88eb-4e30-b33a-6920aad57525",
-        "label-code": null,
-        "type": null,
-        "name": "_Xurbia_Xendless Limited",
-        "type-id": null,
-        "sort-name": "_Xurbia_Xendless Limited",
-        "disambiguation": ""
+        "type-id": null
       },
-      "catalog-number": "_X_X001"
+      "date": "2007-12-03"
     }
   ],
-  "quality": "normal",
-  "disambiguation": "discbox",
-  "status": "Official"
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "",
+          "id": "a74b1b7f-71a5-4011-9441-d0b5e4122711",
+          "name": "Radiohead",
+          "sort-name": "Radiohead",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Radiohead"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2007-10-10",
+    "id": "6e335887-60ba-38f0-95af-fae7774336bf",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "In Rainbows"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "In Rainbows"
 }

--- a/scripts/eval_matching/corpus/eval_release_eccae410.json
+++ b/scripts/eval_matching/corpus/eval_release_eccae410.json
@@ -1,696 +1,696 @@
 {
-  "release-group": {
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "artist-credit": [
-      {
-        "artist": {
-          "country": "US",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "name": "Nirvana",
-          "type": "Group",
-          "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-          "sort-name": "Nirvana",
-          "disambiguation": "1980s\u20131990s US grunge band"
-        },
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "US",
+        "disambiguation": "1980s\u20131990s US grunge band",
+        "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
         "name": "Nirvana",
-        "joinphrase": ""
-      }
-    ],
-    "secondary-type-ids": [],
-    "disambiguation": "",
-    "title": "Nevermind",
-    "secondary-types": [],
-    "primary-type": "Album",
-    "first-release-date": "1991-09-24",
-    "id": "1b022e01-4da6-387b-8658-8678046e4cef"
+        "sort-name": "Nirvana",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Nirvana"
+    }
+  ],
+  "asin": null,
+  "barcode": "720642442524",
+  "country": "AU",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 4,
+    "darkened": false,
+    "front": true
   },
+  "date": "1991-09-24",
+  "disambiguation": "",
   "id": "eccae410-7577-4daa-b602-92d305828331",
   "label-info": [
     {
       "catalog-number": "DGCD-24425",
       "label": {
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "id": "68803e28-86fe-4a95-985f-8e493795ab31",
-        "type": "Original Production",
-        "name": "DGC Records",
-        "label-code": 6406,
         "disambiguation": "",
-        "sort-name": "DGC Records"
+        "id": "68803e28-86fe-4a95-985f-8e493795ab31",
+        "label-code": 6406,
+        "name": "DGC Records",
+        "sort-name": "DGC Records",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     },
     {
       "catalog-number": null,
       "label": {
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
+        "disambiguation": "",
         "id": "38dc88de-7720-4100-9d5b-3cdc41b0c474",
         "label-code": 8323,
-        "type": "Original Production",
         "name": "Sub Pop Records",
         "sort-name": "Sub Pop Records",
-        "disambiguation": ""
-      }
-    }
-  ],
-  "quality": "normal",
-  "disambiguation": "",
-  "status": "Official",
-  "country": "AU",
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "date": "1991-09-24",
-  "cover-art-archive": {
-    "artwork": true,
-    "count": 4,
-    "darkened": false,
-    "back": true,
-    "front": true
-  },
-  "release-events": [
-    {
-      "date": "1991-09-24",
-      "area": {
-        "type-id": null,
-        "type": null,
-        "name": "Australia",
-        "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
-        "iso-3166-1-codes": [
-          "AU"
-        ],
-        "sort-name": "Australia",
-        "disambiguation": ""
-      }
-    }
-  ],
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "barcode": "720642442524",
-  "packaging": "Jewel Case",
-  "artist-credit": [
-    {
-      "joinphrase": "",
-      "name": "Nirvana",
-      "artist": {
-        "sort-name": "Nirvana",
-        "disambiguation": "1980s\u20131990s US grunge band",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "country": "US",
-        "type": "Group",
-        "name": "Nirvana",
-        "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
   "media": [
     {
-      "track-count": 12,
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "38c57f12-ab7a-3f9d-9b93-14768c7886d2",
+      "position": 1,
+      "title": "",
+      "track-count": 12,
+      "track-offset": 0,
       "tracks": [
         {
-          "length": 301626,
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Nirvana",
               "artist": {
-                "type": "Group",
-                "name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana"
-              }
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
-          "position": 1,
-          "title": "Smells Like Teen Spirit",
-          "number": "1",
           "id": "5d7bddb6-c250-4f65-a56d-037ece60da03",
+          "length": 301626,
+          "number": "1",
+          "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1991-09-10",
+            "id": "5fb524f1-8cc8-4c04-a921-e34c0a911ea7",
             "isrcs": [
               "USGF19942501"
             ],
-            "video": false,
-            "id": "5fb524f1-8cc8-4c04-a921-e34c0a911ea7",
-            "artist-credit": [
-              {
-                "name": "Nirvana",
-                "artist": {
-                  "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Nirvana",
-                  "type": "Group",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band"
-                },
-                "joinphrase": ""
-              }
-            ],
             "length": 301133,
-            "disambiguation": "",
-            "title": "Smells Like Teen Spirit"
-          }
+            "title": "Smells Like Teen Spirit",
+            "video": false
+          },
+          "title": "Smells Like Teen Spirit"
         },
         {
-          "number": "2",
-          "position": 2,
-          "title": "In Bloom",
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Nirvana",
+                "country": "US",
                 "disambiguation": "1980s\u20131990s US grunge band",
                 "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type": "Group",
                 "name": "Nirvana",
-                "country": "US",
+                "sort-name": "Nirvana",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Nirvana",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
+          "id": "371f0ebc-de2a-4e54-8e81-b41dd4c1fbfa",
           "length": 255066,
+          "number": "2",
+          "position": 2,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "Nevermind version",
+            "first-release-date": "1991-09-24",
             "id": "593e9317-a327-4a31-b796-416c62dcf49d",
             "isrcs": [
               "USGF19942502"
             ],
-            "video": false,
-            "first-release-date": "1991-09-24",
-            "title": "In Bloom",
-            "disambiguation": "Nevermind version",
             "length": 254973,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Nirvana",
-                "artist": {
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "sort-name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "name": "Nirvana",
-                  "type": "Group"
-                }
-              }
-            ]
+            "title": "In Bloom",
+            "video": false
           },
-          "id": "371f0ebc-de2a-4e54-8e81-b41dd4c1fbfa"
+          "title": "In Bloom"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
           "id": "b75dd14d-42cf-4006-a65b-d45eb9f877e1",
+          "length": 219000,
+          "number": "3",
+          "position": 3,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "original studio mix",
             "first-release-date": "1991-09-24",
             "id": "70ac6733-068f-4613-b06b-bea17cfbcc30",
             "isrcs": [
               "USGF19942503"
             ],
-            "video": false,
             "length": 219026,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Nirvana",
-                "artist": {
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "type": "Group",
-                  "name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-                }
-              }
-            ],
             "title": "Come as You Are",
-            "disambiguation": "original studio mix"
+            "video": false
           },
-          "position": 3,
-          "title": "Come as You Are",
-          "number": "3",
-          "length": 219000,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Nirvana",
-              "artist": {
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana",
-                "type": "Group",
-                "name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US"
-              }
-            }
-          ]
+          "title": "Come as You Are"
         },
         {
-          "recording": {
-            "disambiguation": "",
-            "title": "Breed",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Nirvana",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type": "Group",
-                  "name": "Nirvana",
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band"
-                }
-              }
-            ],
-            "length": 183840,
-            "isrcs": [
-              "USGF19942504"
-            ],
-            "video": false,
-            "id": "0cf9f95f-70e7-4f2e-8075-5d8ba38dd4a3",
-            "first-release-date": "1991-09-24"
-          },
-          "id": "4cf810d0-f718-4cd7-8d19-d3f213768b55",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Nirvana",
               "artist": {
                 "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type": "Group",
-                "name": "Nirvana",
                 "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana"
-              }
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
+          "id": "4cf810d0-f718-4cd7-8d19-d3f213768b55",
           "length": 183906,
           "number": "4",
           "position": 4,
-          "title": "Breed"
-        },
-        {
-          "id": "6bb5ad41-7434-4867-b274-c53b2b30ef60",
           "recording": {
-            "isrcs": [
-              "USGF19942505"
-            ],
-            "video": false,
-            "id": "3fac712c-4196-4865-8c1a-94231a7da309",
-            "first-release-date": "1991-09-24",
-            "disambiguation": "",
-            "title": "Lithium",
             "artist-credit": [
               {
                 "artist": {
-                  "type": "Group",
-                  "name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band"
-                },
-                "name": "Nirvana",
-                "joinphrase": ""
-              }
-            ],
-            "length": 257000
-          },
-          "length": 257066,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "name": "Nirvana",
-                "type": "Group",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band"
-              },
-              "name": "Nirvana"
-            }
-          ],
-          "title": "Lithium",
-          "position": 5,
-          "number": "5"
-        },
-        {
-          "id": "2c892d11-3fd0-4e5c-8836-3d77d0eb4e76",
-          "recording": {
-            "length": 177000,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
                   "disambiguation": "1980s\u20131990s US grunge band",
-                  "sort-name": "Nirvana",
-                  "name": "Nirvana",
-                  "type": "Group",
                   "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "country": "US",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Nirvana"
               }
             ],
-            "title": "Polly",
             "disambiguation": "",
             "first-release-date": "1991-09-24",
-            "id": "d088ed9e-1921-4568-ae75-fba8b15ed206",
-            "video": false,
+            "id": "0cf9f95f-70e7-4f2e-8075-5d8ba38dd4a3",
             "isrcs": [
-              "USGF19942506"
-            ]
+              "USGF19942504"
+            ],
+            "length": 183840,
+            "title": "Breed",
+            "video": false
           },
-          "title": "Polly",
-          "position": 6,
-          "number": "6",
-          "length": 175000,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "name": "Nirvana",
-                "type": "Group",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana"
-              },
-              "name": "Nirvana"
-            }
-          ]
+          "title": "Breed"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "6bb5ad41-7434-4867-b274-c53b2b30ef60",
+          "length": 257066,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "title": "Territorial Pissings",
-            "disambiguation": "",
-            "length": 143000,
             "artist-credit": [
               {
                 "artist": {
-                  "type": "Group",
-                  "name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "US",
                   "disambiguation": "1980s\u20131990s US grunge band",
-                  "sort-name": "Nirvana"
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Nirvana",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1991-09-24",
+            "id": "3fac712c-4196-4865-8c1a-94231a7da309",
+            "isrcs": [
+              "USGF19942505"
+            ],
+            "length": 257000,
+            "title": "Lithium",
+            "video": false
+          },
+          "title": "Lithium"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "2c892d11-3fd0-4e5c-8836-3d77d0eb4e76",
+          "length": 175000,
+          "number": "6",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1991-09-24",
+            "id": "d088ed9e-1921-4568-ae75-fba8b15ed206",
+            "isrcs": [
+              "USGF19942506"
+            ],
+            "length": 177000,
+            "title": "Polly",
+            "video": false
+          },
+          "title": "Polly"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "294c78bf-a7ce-4c35-a4f4-998ddfb1f5db",
+          "length": 140800,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1991-09-24",
             "id": "dbaa10b1-d46a-4960-8b50-4e2d80c8113c",
             "isrcs": [
               "USGF19942507"
             ],
-            "video": false,
-            "first-release-date": "1991-09-24"
+            "length": 143000,
+            "title": "Territorial Pissings",
+            "video": false
           },
-          "id": "294c78bf-a7ce-4c35-a4f4-998ddfb1f5db",
+          "title": "Territorial Pissings"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
                 "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type": "Group",
                 "name": "Nirvana",
                 "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Nirvana",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
-          "length": 140800,
-          "number": "7",
-          "title": "Territorial Pissings",
-          "position": 7
-        },
-        {
           "id": "c2dcee25-2709-4d40-9402-dd7d53512047",
+          "length": 223760,
+          "number": "8",
+          "position": 8,
           "recording": {
-            "length": 223880,
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "sort-name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
                   "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                   "name": "Nirvana",
-                  "type": "Group"
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Nirvana"
               }
             ],
-            "title": "Drain You",
             "disambiguation": "",
             "first-release-date": "1991-09-10",
             "id": "11cc49bd-f531-4cdd-9b59-e1f59b06c1d7",
             "isrcs": [
               "USGF19942508"
             ],
+            "length": 223880,
+            "title": "Drain You",
             "video": false
           },
-          "title": "Drain You",
-          "position": 8,
-          "number": "8",
-          "length": 223760,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana",
-                "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-              },
-              "name": "Nirvana"
-            }
-          ]
+          "title": "Drain You"
         },
         {
-          "title": "Lounge Act",
-          "position": 9,
-          "number": "9",
-          "length": 157066,
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "sort-name": "Nirvana",
                 "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Nirvana",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
           "id": "bdd9fac9-737f-4fa3-9c64-0601e7d280a1",
+          "length": 157066,
+          "number": "9",
+          "position": 9,
           "recording": {
-            "isrcs": [
-              "USGF19942509"
-            ],
-            "video": false,
-            "id": "aef0677b-93b4-4c66-be74-10120d0e6f5a",
-            "first-release-date": "1991-09-24",
-            "disambiguation": "",
-            "title": "Lounge Act",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band",
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "disambiguation": "1980s\u20131990s US grunge band",
                   "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
                   "type": "Group",
-                  "name": "Nirvana"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Nirvana",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
-            "length": 156800
-          }
+            "disambiguation": "",
+            "first-release-date": "1991-09-24",
+            "id": "aef0677b-93b4-4c66-be74-10120d0e6f5a",
+            "isrcs": [
+              "USGF19942509"
+            ],
+            "length": 156800,
+            "title": "Lounge Act",
+            "video": false
+          },
+          "title": "Lounge Act"
         },
         {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type": "Group",
-                "name": "Nirvana",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
                 "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Nirvana"
             }
           ],
+          "id": "d3f3ddca-cad0-4a5d-80e5-3b7e8e2b120b",
           "length": 212506,
           "number": "10",
           "position": 10,
-          "title": "Stay Away",
           "recording": {
-            "length": 212466,
             "artist-credit": [
               {
-                "name": "Nirvana",
                 "artist": {
-                  "sort-name": "Nirvana",
+                  "country": "US",
                   "disambiguation": "1980s\u20131990s US grunge band",
                   "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                   "name": "Nirvana",
+                  "sort-name": "Nirvana",
                   "type": "Group",
-                  "country": "US",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
-            "title": "Stay Away",
             "disambiguation": "",
             "first-release-date": "1991-09-24",
             "id": "8bf26383-8b9b-4252-9cb3-0efa4d3f47f1",
             "isrcs": [
               "USGF19942510"
             ],
+            "length": 212466,
+            "title": "Stay Away",
             "video": false
           },
-          "id": "d3f3ddca-cad0-4a5d-80e5-3b7e8e2b120b"
+          "title": "Stay Away"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type": "Group",
-                "name": "Nirvana",
                 "country": "US",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
                 "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Nirvana",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
+          "id": "d31a7c6f-e940-4c54-82d2-605e3ce272f8",
           "length": 196400,
           "number": "11",
           "position": 11,
-          "title": "On a Plain",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1991-09-24",
+            "id": "ea61d42b-9a76-47fd-bcf7-df911640c309",
             "isrcs": [
               "USGF19942511"
             ],
-            "video": false,
-            "id": "ea61d42b-9a76-47fd-bcf7-df911640c309",
+            "length": 196373,
+            "title": "On a Plain",
+            "video": false
+          },
+          "title": "On a Plain"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "72faaa73-ab82-4cc5-8125-39acb355323d",
+          "length": 230293,
+          "number": "12",
+          "position": 12,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type": "Group",
-                  "name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                   "country": "US",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "disambiguation": "1980s\u20131990s US grunge band",
-                  "sort-name": "Nirvana"
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Nirvana",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
-            "length": 196373,
             "disambiguation": "",
-            "title": "On a Plain"
-          },
-          "id": "d31a7c6f-e940-4c54-82d2-605e3ce272f8"
-        },
-        {
-          "number": "12",
-          "title": "Something in the Way",
-          "position": 12,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Nirvana",
-              "artist": {
-                "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "name": "Nirvana",
-                "type": "Group"
-              }
-            }
-          ],
-          "length": 230293,
-          "recording": {
+            "first-release-date": "1991-09-24",
             "id": "3589823f-b494-4b2d-aab3-c2e500f81175",
-            "video": false,
             "isrcs": [
               "USGF19942512"
             ],
-            "first-release-date": "1991-09-24",
-            "title": "Something in the Way",
-            "disambiguation": "",
             "length": 232000,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type": "Group",
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "sort-name": "Nirvana"
-                },
-                "name": "Nirvana"
-              }
-            ]
+            "title": "Something in the Way",
+            "video": false
           },
-          "id": "72faaa73-ab82-4cc5-8125-39acb355323d"
+          "title": "Something in the Way"
         }
-      ],
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "title": "",
-      "format": "CD",
-      "position": 1,
-      "track-offset": 0
+      ]
     }
   ],
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
+  "packaging": "Jewel Case",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "106e0bec-b638-3b37-b731-f53d507dc00e",
+        "iso-3166-1-codes": [
+          "AU"
+        ],
+        "name": "Australia",
+        "sort-name": "Australia",
+        "type": null,
+        "type-id": null
+      },
+      "date": "1991-09-24"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "1980s\u20131990s US grunge band",
+          "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+          "name": "Nirvana",
+          "sort-name": "Nirvana",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Nirvana"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1991-09-24",
+    "id": "1b022e01-4da6-387b-8658-8678046e4cef",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Nevermind"
   },
-  "asin": null,
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
   "title": "Nevermind"
 }

--- a/scripts/eval_matching/corpus/eval_release_ee99a91b.json
+++ b/scripts/eval_matching/corpus/eval_release_ee99a91b.json
@@ -1,156 +1,245 @@
 {
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "GB",
+        "disambiguation": "UK rock group",
+        "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+        "name": "Queen",
+        "sort-name": "Queen",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Queen"
+    }
+  ],
+  "asin": null,
+  "barcode": "4607147861714",
   "country": "RU",
-  "packaging": "Digipak",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 10,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2008",
+  "disambiguation": "",
+  "id": "ee99a91b-e1c2-405b-9c83-99378667f09f",
+  "label-info": [
+    {
+      "catalog-number": "13816-1/2",
+      "label": {
+        "disambiguation": "fake label pretending to be the real thing",
+        "id": "95777b9f-0cf4-4328-b4c9-da1402bcbc5c",
+        "label-code": null,
+        "name": "Hollywood Records",
+        "sort-name": "Hollywood Records",
+        "type": "Bootleg Production",
+        "type-id": "fdac9b96-359b-3488-9322-ad99c2473636"
+      }
+    },
+    {
+      "catalog-number": "13816-1/2",
+      "label": {
+        "disambiguation": "Russian bootleg production",
+        "id": "46adc01f-fb5d-4ec2-874b-d6c8c9ba4010",
+        "label-code": null,
+        "name": "Star Mark",
+        "sort-name": "Star Mark",
+        "type": "Bootleg Production",
+        "type-id": "fdac9b96-359b-3488-9322-ad99c2473636"
+      }
+    }
+  ],
   "media": [
     {
-      "position": 1,
-      "title": "",
+      "format": "CD",
       "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "1a21bb5a-01b4-35d6-8e62-e3f33047adc2",
+      "position": 1,
+      "title": "",
+      "track-count": 22,
       "track-offset": 0,
       "tracks": [
         {
-          "number": "1",
           "artist-credit": [
             {
               "artist": {
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
                 "country": "GB",
-                "type": "Group",
-                "disambiguation": "UK rock group"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
-          "position": 1,
-          "title": "We Will Rock You",
-          "length": 124000,
-          "id": "0ce56ff6-917d-4c75-9fc2-8999a8808bfb",
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "type": "Group"
-                }
-              }
-            ],
-            "first-release-date": "2008",
-            "disambiguation": "",
-            "length": 124000,
-            "id": "9fa00ada-b61c-4c23-966c-a5c97427b8cc",
-            "title": "We Will Rock You",
-            "isrcs": [],
-            "video": false
-          }
-        },
-        {
-          "id": "c352b116-29d8-4720-8614-abb78cdf9fbf",
-          "length": 360000,
-          "title": "Bohemian Rhapsody",
-          "position": 2,
-          "recording": {
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "type": "Group"
-                },
-                "name": "Queen",
-                "joinphrase": ""
-              }
-            ],
-            "title": "Bohemian Rhapsody",
-            "video": false,
-            "isrcs": [],
-            "length": 360000,
-            "id": "04601910-e48d-4b21-ae01-ae2b6423470f",
-            "disambiguation": ""
-          },
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
-          "number": "2"
-        },
-        {
-          "number": "3",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
                 "disambiguation": "UK rock group",
-                "type": "Group",
-                "country": "GB",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
                 "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
           ],
-          "position": 3,
-          "title": "Killer Queen",
-          "id": "fe275497-8089-4291-9d8e-85a336397def",
-          "length": 184000,
+          "id": "0ce56ff6-917d-4c75-9fc2-8999a8808bfb",
+          "length": 124000,
+          "number": "1",
+          "position": 1,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
-            "first-release-date": "2008",
             "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "9fa00ada-b61c-4c23-966c-a5c97427b8cc",
             "isrcs": [],
-            "video": false,
-            "title": "Killer Queen",
-            "id": "a4752f1c-05a9-4ffe-a6c3-a124d733173d",
-            "length": 184000
-          }
+            "length": 124000,
+            "title": "We Will Rock You",
+            "video": false
+          },
+          "title": "We Will Rock You"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "c352b116-29d8-4720-8614-abb78cdf9fbf",
+          "length": 360000,
+          "number": "2",
+          "position": 2,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "04601910-e48d-4b21-ae01-ae2b6423470f",
+            "isrcs": [],
+            "length": 360000,
+            "title": "Bohemian Rhapsody",
+            "video": false
+          },
+          "title": "Bohemian Rhapsody"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "fe275497-8089-4291-9d8e-85a336397def",
+          "length": 184000,
+          "number": "3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "a4752f1c-05a9-4ffe-a6c3-a124d733173d",
+            "isrcs": [],
+            "length": 184000,
+            "title": "Killer Queen",
+            "video": false
+          },
+          "title": "Killer Queen"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "766c8f34-c73c-45be-96f9-048c6a126439",
+          "length": 185000,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1978-10-13",
             "id": "135214af-6058-4705-9f17-18d396f36191",
-            "length": 182000,
             "isrcs": [
               "GBCEE0100116",
               "GBCEE9300008",
@@ -158,1778 +247,1689 @@
               "GBCEG9800004",
               "GBUM71029608"
             ],
-            "video": false,
+            "length": 182000,
             "title": "Bicycle Race",
-            "disambiguation": "",
-            "first-release-date": "1978-10-13",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
-                },
-                "name": "Queen",
-                "joinphrase": ""
-              }
-            ]
+            "video": false
           },
-          "id": "766c8f34-c73c-45be-96f9-048c6a126439",
-          "length": 185000,
-          "position": 4,
-          "title": "Bicycle Race",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "disambiguation": "UK rock group",
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen"
-              }
-            }
-          ],
-          "number": "4"
+          "title": "Bicycle Race"
         },
         {
-          "number": "5",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "disambiguation": "UK rock group",
                 "country": "GB",
-                "type": "Group",
+                "disambiguation": "UK rock group",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
                 "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
           ],
-          "title": "Don\u2019t Stop Me Now",
-          "position": 5,
-          "length": 213000,
           "id": "295fe4c1-2346-4fa6-994b-be1a1a4c4ca5",
+          "length": 213000,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "disambiguation": "",
-            "length": 213000,
-            "id": "6eb80e0c-96bc-4575-9a86-3e098c4addcf",
-            "title": "Don\u2019t Stop Me Now",
-            "isrcs": [],
-            "video": false,
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
+                  "country": "GB",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
                   "type": "Group",
-                  "country": "GB"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
-            "first-release-date": "2008"
-          }
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "6eb80e0c-96bc-4575-9a86-3e098c4addcf",
+            "isrcs": [],
+            "length": 213000,
+            "title": "Don\u2019t Stop Me Now",
+            "video": false
+          },
+          "title": "Don\u2019t Stop Me Now"
         },
         {
-          "number": "6",
           "artist-credit": [
             {
-              "name": "Queen",
               "artist": {
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
                 "type": "Group",
-                "disambiguation": "UK rock group"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "title": "We Are the Champions",
-          "position": 6,
           "id": "8916e471-5cfc-449c-a57e-2bbee901115b",
           "length": 183000,
+          "number": "6",
+          "position": 6,
           "recording": {
-            "isrcs": [],
-            "video": false,
-            "title": "We Are the Champions",
-            "id": "0c9c80d5-b5ab-4fcc-909b-e0e5cc530891",
-            "length": 183000,
-            "disambiguation": "",
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "UK rock group",
                   "country": "GB",
-                  "type": "Group"
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
-            ]
-          }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "0c9c80d5-b5ab-4fcc-909b-e0e5cc530891",
+            "isrcs": [],
+            "length": 183000,
+            "title": "We Are the Champions",
+            "video": false
+          },
+          "title": "We Are the Champions"
         },
         {
-          "number": "7",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
+                "country": "GB",
+                "disambiguation": "UK rock group",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
                 "sort-name": "Queen",
                 "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
           ],
+          "id": "95e1dfa1-fcbf-434e-978b-74bd307d30fd",
+          "length": 250000,
+          "number": "7",
+          "position": 7,
           "recording": {
-            "title": "Friends Will Be Friends",
-            "video": false,
-            "isrcs": [],
-            "length": 250000,
-            "id": "79ba92a8-47e8-461a-aca1-fec44e3fd659",
-            "disambiguation": "",
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "name": "Queen",
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
-            ]
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "79ba92a8-47e8-461a-aca1-fec44e3fd659",
+            "isrcs": [],
+            "length": 250000,
+            "title": "Friends Will Be Friends",
+            "video": false
           },
-          "title": "Friends Will Be Friends",
-          "position": 7,
-          "id": "95e1dfa1-fcbf-434e-978b-74bd307d30fd",
-          "length": 250000
+          "title": "Friends Will Be Friends"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "disambiguation": "UK rock group",
-                "type": "Group",
                 "country": "GB",
+                "disambiguation": "UK rock group",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
                 "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Queen",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
+          "id": "d77ced57-357c-4b23-baaf-6c71443e2614",
+          "length": 194000,
           "number": "8",
+          "position": 8,
           "recording": {
             "artist-credit": [
               {
-                "name": "Queen",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
                   "sort-name": "Queen",
                   "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "UK rock group"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
-            "first-release-date": "2008",
             "disambiguation": "",
-            "title": "Jealousy",
+            "first-release-date": "2008",
+            "id": "f2fba4d1-a0d9-42fd-8126-0142e54b682c",
             "isrcs": [],
-            "video": false,
             "length": 194000,
-            "id": "f2fba4d1-a0d9-42fd-8126-0142e54b682c"
+            "title": "Jealousy",
+            "video": false
           },
-          "length": 194000,
-          "id": "d77ced57-357c-4b23-baaf-6c71443e2614",
-          "title": "Jealousy",
-          "position": 8
+          "title": "Jealousy"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "1ca5d732-57f4-4f69-8b1d-4683caca2ea1",
           "length": 299000,
-          "title": "Somebody to Love",
+          "number": "9",
           "position": 9,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
                   "country": "GB",
-                  "sort-name": "Queen",
+                  "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen"
-                }
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
-            "first-release-date": "2008",
             "disambiguation": "",
-            "video": false,
-            "isrcs": [],
-            "title": "Somebody to Love",
+            "first-release-date": "2008",
             "id": "9a28391b-4e11-4dc4-b3aa-242505d7eb4e",
-            "length": 299000
+            "isrcs": [],
+            "length": 299000,
+            "title": "Somebody to Love",
+            "video": false
           },
+          "title": "Somebody to Love"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
+                "country": "GB",
                 "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
                 "type": "Group",
-                "country": "GB"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Queen",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "number": "9"
-        },
-        {
-          "recording": {
-            "artist-credit": [
-              {
-                "name": "Queen",
-                "artist": {
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "type": "Group",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2008",
-            "disambiguation": "",
-            "video": false,
-            "isrcs": [],
-            "title": "I Want to Break Free",
-            "id": "ee50ce38-d833-4d23-ac27-b8f4fbb89ab1",
-            "length": 260000
-          },
-          "position": 10,
-          "title": "I Want to Break Free",
           "id": "30874a11-a5cb-4809-9e29-7e857c689249",
           "length": 260000,
           "number": "10",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
+          "position": 10,
           "recording": {
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Queen",
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "type": "Group"
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
-            "id": "6dee7a94-aa5d-4de8-a118-b8ff616504bc",
-            "length": 174000,
-            "video": false,
-            "isrcs": [],
-            "title": "You\u2019re My Best Friend",
-            "disambiguation": ""
-          },
-          "length": 174000,
-          "id": "f06cafea-fbb4-4234-a468-3f06368f83bc",
-          "position": 11,
-          "title": "You\u2019re My Best Friend",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "disambiguation": "UK rock group",
-                "country": "GB",
-                "type": "Group",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "number": "11"
-        },
-        {
-          "number": "12",
-          "artist-credit": [
-            {
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
-          "position": 12,
-          "title": "Play the Game",
-          "length": 215000,
-          "id": "2dcc9e93-21e9-4108-9760-0724aeec7a48",
-          "recording": {
-            "title": "Play the Game",
-            "isrcs": [],
-            "video": false,
-            "length": 215000,
-            "id": "654c4bf0-fc16-42ac-a87f-08ed8efdf475",
             "disambiguation": "",
             "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "country": "GB",
-                  "type": "Group",
-                  "disambiguation": "UK rock group",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                }
-              }
-            ]
-          }
+            "id": "ee50ce38-d833-4d23-ac27-b8f4fbb89ab1",
+            "isrcs": [],
+            "length": 260000,
+            "title": "I Want to Break Free",
+            "video": false
+          },
+          "title": "I Want to Break Free"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "f06cafea-fbb4-4234-a468-3f06368f83bc",
+          "length": 174000,
+          "number": "11",
+          "position": 11,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "6dee7a94-aa5d-4de8-a118-b8ff616504bc",
+            "isrcs": [],
+            "length": 174000,
+            "title": "You\u2019re My Best Friend",
+            "video": false
+          },
+          "title": "You\u2019re My Best Friend"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "2dcc9e93-21e9-4108-9760-0724aeec7a48",
+          "length": 215000,
+          "number": "12",
+          "position": 12,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "654c4bf0-fc16-42ac-a87f-08ed8efdf475",
+            "isrcs": [],
+            "length": 215000,
+            "title": "Play the Game",
+            "video": false
+          },
+          "title": "Play the Game"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "d31271ba-601b-4832-942a-f855b88250b1",
           "length": 230000,
-          "title": "Save Me",
+          "number": "13",
           "position": 13,
           "recording": {
-            "disambiguation": "",
-            "length": 230000,
-            "id": "81f61c4f-6c55-409c-9759-fe5248091058",
-            "title": "Save Me",
-            "isrcs": [],
-            "video": false,
             "artist-credit": [
               {
-                "name": "Queen",
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
-            "first-release-date": "2008"
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "81f61c4f-6c55-409c-9759-fe5248091058",
+            "isrcs": [],
+            "length": 230000,
+            "title": "Save Me",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group"
-              }
-            }
-          ],
-          "number": "13"
+          "title": "Save Me"
         },
         {
           "artist-credit": [
             {
               "artist": {
                 "country": "GB",
-                "type": "Group",
                 "disambiguation": "UK rock group",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Queen",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "number": "14",
           "id": "9250bc30-07eb-44f1-af49-6d5fba352b4d",
           "length": 218000,
+          "number": "14",
           "position": 14,
-          "title": "Love of My Life",
           "recording": {
-            "first-release-date": "2008",
             "artist-credit": [
               {
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Queen",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
-            "video": false,
-            "isrcs": [],
-            "title": "Love of My Life",
-            "id": "4bf314cc-f205-4ce1-87b5-ec2b880cf3c1",
-            "length": 218000,
-            "disambiguation": ""
-          }
-        },
-        {
-          "recording": {
-            "isrcs": [],
-            "video": false,
-            "title": "Good Old\u2010Fashioned Lover Boy",
-            "id": "dfe90f24-fc12-4241-8db2-1b4f3d3d1477",
-            "length": 177000,
             "disambiguation": "",
             "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "UK rock group"
-                }
-              }
-            ]
+            "id": "4bf314cc-f205-4ce1-87b5-ec2b880cf3c1",
+            "isrcs": [],
+            "length": 218000,
+            "title": "Love of My Life",
+            "video": false
           },
-          "length": 177000,
-          "id": "9880e800-ba80-4126-a1d8-f5560c486424",
-          "title": "Good Old\u2010Fashioned Lover Boy",
-          "position": 15,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "country": "GB",
-                "type": "Group",
-                "disambiguation": "UK rock group"
-              }
-            }
-          ],
-          "number": "15"
+          "title": "Love of My Life"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "9880e800-ba80-4126-a1d8-f5560c486424",
+          "length": 177000,
+          "number": "15",
+          "position": 15,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "dfe90f24-fc12-4241-8db2-1b4f3d3d1477",
+            "isrcs": [],
+            "length": 177000,
+            "title": "Good Old\u2010Fashioned Lover Boy",
+            "video": false
+          },
+          "title": "Good Old\u2010Fashioned Lover Boy"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "a07ec0e8-801e-496d-9f80-ebed9b59fc0d",
           "length": 149000,
-          "title": "In Only Seven Days",
+          "number": "16",
           "position": 16,
           "recording": {
             "artist-credit": [
               {
-                "name": "Queen",
                 "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
+                  "country": "GB",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
                   "type": "Group",
-                  "country": "GB"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
-            "first-release-date": "2008",
             "disambiguation": "",
-            "title": "In Only Seven Days",
-            "video": false,
+            "first-release-date": "2008",
+            "id": "7acfe0cf-6eba-4b1b-b587-7aedcaeeceef",
             "isrcs": [],
             "length": 149000,
-            "id": "7acfe0cf-6eba-4b1b-b587-7aedcaeeceef"
+            "title": "In Only Seven Days",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "disambiguation": "UK rock group",
-                "type": "Group",
-                "country": "GB",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen"
-              }
-            }
-          ],
-          "number": "16"
+          "title": "In Only Seven Days"
         },
         {
-          "number": "17",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Queen",
               "artist": {
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
-              }
-            }
-          ],
-          "recording": {
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
-                  "country": "GB",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen"
-                },
-                "name": "Queen"
-              }
-            ],
-            "length": 277000,
-            "id": "69b7bb6d-e2dc-42b0-bdfb-5fb8cca493d6",
-            "title": "Spread Your Wings",
-            "isrcs": [],
-            "video": false,
-            "disambiguation": ""
-          },
-          "title": "Spread Your Wings",
-          "position": 17,
-          "id": "41e14e23-dc3c-4709-95cf-f0b2a443bc6d",
-          "length": 277000
-        },
-        {
-          "recording": {
-            "title": "Hammer to Fall",
-            "video": false,
-            "isrcs": [],
-            "length": 218000,
-            "id": "dbd95857-6730-49bd-9941-e940900e3ee2",
-            "disambiguation": "",
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "type": "Group"
-                }
-              }
-            ]
-          },
-          "id": "f99e3515-227e-4c76-a215-631725c00dd5",
-          "length": 218000,
-          "title": "Hammer to Fall",
-          "position": 18,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "name": "Queen",
                 "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group"
-              }
-            }
-          ],
-          "number": "18"
-        },
-        {
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
           ],
-          "number": "19",
+          "id": "41e14e23-dc3c-4709-95cf-f0b2a443bc6d",
+          "length": 277000,
+          "number": "17",
+          "position": 17,
           "recording": {
-            "title": "Is This the World We Created",
-            "video": false,
-            "isrcs": [],
-            "length": 135000,
-            "id": "952e905d-701c-4a2c-85d9-ea04cac29222",
-            "disambiguation": "",
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
                   "country": "GB",
+                  "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
                   "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen"
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
-            ]
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "69b7bb6d-e2dc-42b0-bdfb-5fb8cca493d6",
+            "isrcs": [],
+            "length": 277000,
+            "title": "Spread Your Wings",
+            "video": false
           },
-          "length": 135000,
+          "title": "Spread Your Wings"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "f99e3515-227e-4c76-a215-631725c00dd5",
+          "length": 218000,
+          "number": "18",
+          "position": 18,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "dbd95857-6730-49bd-9941-e940900e3ee2",
+            "isrcs": [],
+            "length": 218000,
+            "title": "Hammer to Fall",
+            "video": false
+          },
+          "title": "Hammer to Fall"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "dea25190-b109-4ba8-9d5a-1c530fbb1012",
+          "length": 135000,
+          "number": "19",
           "position": 19,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "952e905d-701c-4a2c-85d9-ea04cac29222",
+            "isrcs": [],
+            "length": 135000,
+            "title": "Is This the World We Created",
+            "video": false
+          },
           "title": "Is This the World We Created"
         },
         {
-          "recording": {
-            "title": "It\u2019s a Hard Life",
-            "video": false,
-            "isrcs": [],
-            "length": 251000,
-            "id": "c0fc74da-14c9-42cf-87be-9e42e341a78c",
-            "disambiguation": "",
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "name": "Queen",
-                "artist": {
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "country": "GB",
-                  "type": "Group",
-                  "disambiguation": "UK rock group"
-                },
-                "joinphrase": ""
-              }
-            ]
-          },
-          "title": "It\u2019s a Hard Life",
-          "position": 20,
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "2a3046e8-1c46-45b0-859e-d2ff7baf4d46",
           "length": 251000,
           "number": "20",
-          "artist-credit": [
-            {
-              "artist": {
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "UK rock group",
-                "country": "GB",
-                "type": "Group"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "number": "21",
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "disambiguation": "UK rock group",
-                "type": "Group",
-                "country": "GB"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
+          "position": 20,
           "recording": {
-            "disambiguation": "",
-            "length": 279000,
-            "id": "b1f90225-3e78-4340-a397-96f32e5d0354",
-            "title": "Scandal",
-            "isrcs": [],
-            "video": false,
             "artist-credit": [
               {
                 "artist": {
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
                   "country": "GB",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen"
-                },
-                "name": "Queen",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2008"
-          },
-          "title": "Scandal",
-          "position": 21,
-          "id": "9ae0d47b-8885-48ac-ad9d-0db86e76f6d4",
-          "length": 279000
-        },
-        {
-          "number": "22",
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "recording": {
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
                   "type": "Group",
-                  "country": "GB"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
-            "video": false,
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "c0fc74da-14c9-42cf-87be-9e42e341a78c",
             "isrcs": [],
-            "title": "My Melancholy Blues",
-            "id": "02f375b9-4846-4e5c-a119-f65f72cd57c5",
-            "length": 210000,
-            "disambiguation": ""
+            "length": 251000,
+            "title": "It\u2019s a Hard Life",
+            "video": false
           },
-          "position": 22,
-          "title": "My Melancholy Blues",
+          "title": "It\u2019s a Hard Life"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "9ae0d47b-8885-48ac-ad9d-0db86e76f6d4",
+          "length": 279000,
+          "number": "21",
+          "position": 21,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "b1f90225-3e78-4340-a397-96f32e5d0354",
+            "isrcs": [],
+            "length": 279000,
+            "title": "Scandal",
+            "video": false
+          },
+          "title": "Scandal"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "c92d6438-8de7-424c-9950-9ed4a4fbd495",
           "length": 210000,
-          "id": "c92d6438-8de7-424c-9950-9ed4a4fbd495"
+          "number": "22",
+          "position": 22,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "02f375b9-4846-4e5c-a119-f65f72cd57c5",
+            "isrcs": [],
+            "length": 210000,
+            "title": "My Melancholy Blues",
+            "video": false
+          },
+          "title": "My Melancholy Blues"
         }
-      ],
-      "track-count": 22,
-      "format": "CD"
+      ]
     },
     {
-      "track-count": 17,
       "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
+      "id": "a41acaa5-332d-32f8-89a2-c17475c5e56e",
+      "position": 2,
+      "title": "",
+      "track-count": 17,
+      "track-offset": 0,
       "tracks": [
         {
-          "number": "1",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "UK rock group",
                 "country": "GB",
-                "type": "Group"
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
           ],
-          "recording": {
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "UK rock group"
-                },
-                "name": "Queen",
-                "joinphrase": ""
-              }
-            ],
-            "video": false,
-            "isrcs": [],
-            "title": "I Was Born to Love You",
-            "id": "943637c4-a085-4b51-9871-0e5462a98bca",
-            "length": 292000,
-            "disambiguation": ""
-          },
-          "position": 1,
-          "title": "I Was Born to Love You",
+          "id": "e6ec3435-e80c-444b-812d-4b1bf0567a76",
           "length": 292000,
-          "id": "e6ec3435-e80c-444b-812d-4b1bf0567a76"
-        },
-        {
-          "position": 2,
-          "title": "A Kind of Magic",
-          "length": 264000,
-          "id": "09c0ab33-0595-49b6-b95c-0dc889b6cf4e",
+          "number": "1",
+          "position": 1,
           "recording": {
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
-            "id": "939acaf2-0226-441c-9554-57f4e91eb644",
-            "length": 264000,
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "943637c4-a085-4b51-9871-0e5462a98bca",
             "isrcs": [],
-            "video": false,
-            "title": "A Kind of Magic",
-            "disambiguation": ""
+            "length": 292000,
+            "title": "I Was Born to Love You",
+            "video": false
           },
-          "number": "2",
+          "title": "I Was Born to Love You"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "UK rock group",
                 "country": "GB",
-                "type": "Group"
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
-          ]
-        },
-        {
-          "number": "3",
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-              },
-              "joinphrase": ""
-            }
           ],
-          "position": 3,
-          "title": "The Miracle",
-          "length": 296000,
-          "id": "1cbf36de-718b-42cd-8fac-a1ee8c96aee6",
+          "id": "09c0ab33-0595-49b6-b95c-0dc889b6cf4e",
+          "length": 264000,
+          "number": "2",
+          "position": 2,
           "recording": {
-            "length": 296000,
-            "id": "182b504d-a65e-4d15-8a16-fbc580ca83a4",
-            "title": "The Miracle",
-            "video": false,
-            "isrcs": [],
-            "disambiguation": "",
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
-            ]
-          }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "939acaf2-0226-441c-9554-57f4e91eb644",
+            "isrcs": [],
+            "length": 264000,
+            "title": "A Kind of Magic",
+            "video": false
+          },
+          "title": "A Kind of Magic"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "1cbf36de-718b-42cd-8fac-a1ee8c96aee6",
+          "length": 296000,
+          "number": "3",
+          "position": 3,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
+                  "country": "GB",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
                   "type": "Group",
-                  "country": "GB"
-                }
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
-            "first-release-date": "2008",
             "disambiguation": "",
-            "title": "Under Pressure",
-            "video": false,
+            "first-release-date": "2008",
+            "id": "182b504d-a65e-4d15-8a16-fbc580ca83a4",
+            "isrcs": [],
+            "length": 296000,
+            "title": "The Miracle",
+            "video": false
+          },
+          "title": "The Miracle"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "ec41b2b6-dc4a-4346-b85b-cd031aa29dae",
+          "length": 238000,
+          "number": "4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "a1cfd525-d133-4c22-8b1c-e34d888491ef",
             "isrcs": [],
             "length": 238000,
-            "id": "a1cfd525-d133-4c22-8b1c-e34d888491ef"
+            "title": "Under Pressure",
+            "video": false
           },
-          "position": 4,
-          "title": "Under Pressure",
-          "length": 238000,
-          "id": "ec41b2b6-dc4a-4346-b85b-cd031aa29dae",
-          "number": "4",
+          "title": "Under Pressure"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "name": "Queen",
                 "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
-          ]
+          ],
+          "id": "e528244f-f9f6-4f94-b200-f7822c19b380",
+          "length": 345000,
+          "number": "5",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "d2e9ade2-1c51-4801-83fd-c4b98e7580b7",
+            "isrcs": [],
+            "length": 345000,
+            "title": "Radio Ga Ga",
+            "video": false
+          },
+          "title": "Radio Ga Ga"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
                 "type": "Group",
-                "disambiguation": "UK rock group"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Queen",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "number": "5",
-          "length": 345000,
-          "id": "e528244f-f9f6-4f94-b200-f7822c19b380",
-          "position": 5,
-          "title": "Radio Ga Ga",
-          "recording": {
-            "length": 345000,
-            "id": "d2e9ade2-1c51-4801-83fd-c4b98e7580b7",
-            "title": "Radio Ga Ga",
-            "video": false,
-            "isrcs": [],
-            "disambiguation": "",
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "country": "GB",
-                  "type": "Group",
-                  "disambiguation": "UK rock group",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
-                },
-                "name": "Queen"
-              }
-            ]
-          }
-        },
-        {
-          "length": 232000,
           "id": "ca3051d0-958c-4add-b030-0bc45591e4fa",
-          "title": "The Invisible Man",
+          "length": 232000,
+          "number": "6",
           "position": 6,
           "recording": {
-            "disambiguation": "",
-            "isrcs": [],
-            "video": false,
-            "title": "The Invisible Man",
-            "id": "8120df13-2c31-4cc0-8e15-215d4e20cd7e",
-            "length": 232000,
             "artist-credit": [
               {
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                },
-                "name": "Queen",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "2008"
-          },
-          "artist-credit": [
-            {
-              "artist": {
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "country": "GB",
-                "type": "Group",
-                "disambiguation": "UK rock group"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
-          "number": "6"
-        },
-        {
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "artist": {
-                "country": "GB",
-                "type": "Group",
-                "disambiguation": "UK rock group",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "number": "7",
-          "length": 218000,
-          "id": "5d1b1397-d247-4cfc-8431-1f4643d6be40",
-          "position": 7,
-          "title": "Another One Bites the Dust",
-          "recording": {
-            "disambiguation": "",
-            "length": 218000,
-            "id": "06f570a1-66b4-4964-8c63-1d48d0f03eaa",
-            "title": "Another One Bites the Dust",
-            "isrcs": [],
-            "video": false,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "country": "GB",
                   "type": "Group",
-                  "disambiguation": "UK rock group",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
-            "first-release-date": "2008"
-          }
-        },
-        {
-          "number": "8",
-          "artist-credit": [
-            {
-              "artist": {
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "country": "GB",
-                "type": "Group",
-                "disambiguation": "UK rock group"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "type": "Group"
-                },
-                "name": "Queen"
-              }
-            ],
+            "disambiguation": "",
             "first-release-date": "2008",
-            "disambiguation": "",
-            "id": "08f64ab3-e3d6-44e9-8b6b-1c320fb66bd5",
-            "length": 251000,
-            "video": false,
+            "id": "8120df13-2c31-4cc0-8e15-215d4e20cd7e",
             "isrcs": [],
-            "title": "Breakthru"
+            "length": 232000,
+            "title": "The Invisible Man",
+            "video": false
           },
-          "position": 8,
-          "title": "Breakthru",
-          "id": "d3114cb9-5523-4dc5-a741-996533709de2",
-          "length": 251000
+          "title": "The Invisible Man"
         },
         {
           "artist-credit": [
             {
-              "name": "Queen",
               "artist": {
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
                 "type": "Group",
-                "disambiguation": "UK rock group"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "number": "9",
+          "id": "5d1b1397-d247-4cfc-8431-1f4643d6be40",
+          "length": 218000,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "06f570a1-66b4-4964-8c63-1d48d0f03eaa",
+            "isrcs": [],
+            "length": 218000,
+            "title": "Another One Bites the Dust",
+            "video": false
+          },
+          "title": "Another One Bites the Dust"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "d3114cb9-5523-4dc5-a741-996533709de2",
+          "length": 251000,
+          "number": "8",
+          "position": 8,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "08f64ab3-e3d6-44e9-8b6b-1c320fb66bd5",
+            "isrcs": [],
+            "length": 251000,
+            "title": "Breakthru",
+            "video": false
+          },
+          "title": "Breakthru"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "f2477355-7cbd-4282-970c-2033e729279b",
           "length": 299000,
-          "title": "Who Wants to Live Forever",
+          "number": "9",
           "position": 9,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
-            "first-release-date": "2008",
             "disambiguation": "",
-            "isrcs": [],
-            "video": false,
-            "title": "Who Wants to Live Forever",
+            "first-release-date": "2008",
             "id": "a9e8ea05-d865-4ce3-a399-ac0176f190e1",
-            "length": 299000
-          }
-        },
-        {
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "number": "10",
-          "length": 243000,
-          "id": "2f394b6e-7fbb-4736-8293-5c6648177923",
-          "position": 10,
-          "title": "I Want It All",
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "country": "GB",
-                  "type": "Group",
-                  "disambiguation": "UK rock group"
-                }
-              }
-            ],
-            "first-release-date": "2008",
-            "disambiguation": "",
-            "title": "I Want It All",
             "isrcs": [],
-            "video": false,
-            "length": 243000,
-            "id": "5b3549a2-cd45-4841-b74f-a605724514a4"
-          }
-        },
-        {
-          "recording": {
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                }
-              }
-            ],
-            "isrcs": [],
-            "video": false,
-            "title": "One Vision",
-            "id": "cdf275d3-9721-42b6-85af-d29b1abc8a47",
-            "length": 244000,
-            "disambiguation": ""
+            "length": 299000,
+            "title": "Who Wants to Live Forever",
+            "video": false
           },
-          "position": 11,
-          "title": "One Vision",
-          "length": 244000,
-          "id": "c6d0fe39-811e-43f2-b2d6-81ada609f268",
-          "number": "11",
+          "title": "Who Wants to Live Forever"
+        },
+        {
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "name": "Queen",
                 "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
-          ]
-        },
-        {
+          ],
+          "id": "2f394b6e-7fbb-4736-8293-5c6648177923",
+          "length": 243000,
+          "number": "10",
+          "position": 10,
           "recording": {
-            "id": "9654b7d7-936d-42e9-bb6a-ca9d587adab7",
-            "length": 275000,
-            "isrcs": [],
-            "video": false,
-            "title": "Headlong",
-            "disambiguation": "",
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Queen",
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "type": "Group"
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
-            ]
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "5b3549a2-cd45-4841-b74f-a605724514a4",
+            "isrcs": [],
+            "length": 243000,
+            "title": "I Want It All",
+            "video": false
           },
+          "title": "I Want It All"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "c6d0fe39-811e-43f2-b2d6-81ada609f268",
+          "length": 244000,
+          "number": "11",
+          "position": 11,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "cdf275d3-9721-42b6-85af-d29b1abc8a47",
+            "isrcs": [],
+            "length": 244000,
+            "title": "One Vision",
+            "video": false
+          },
+          "title": "One Vision"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "a786b792-8fd2-4d5e-b239-c2aa8ec134b2",
           "length": 275000,
+          "number": "12",
           "position": 12,
-          "title": "Headlong",
-          "artist-credit": [
-            {
-              "artist": {
-                "disambiguation": "UK rock group",
-                "type": "Group",
-                "country": "GB",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ],
-          "number": "12"
-        },
-        {
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "UK rock group",
-                "country": "GB",
-                "type": "Group"
-              }
-            }
-          ],
-          "number": "13",
-          "length": 329000,
-          "id": "37871dd0-3e5b-410b-8088-6c33c22ab0b6",
-          "title": "Made in Heaven",
-          "position": 13,
           "recording": {
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
-            "length": 329000,
-            "id": "4dd4afcd-62e6-44b9-90ed-e65b572f2634",
-            "title": "Made in Heaven",
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "9654b7d7-936d-42e9-bb6a-ca9d587adab7",
             "isrcs": [],
-            "video": false,
-            "disambiguation": ""
-          }
+            "length": 275000,
+            "title": "Headlong",
+            "video": false
+          },
+          "title": "Headlong"
         },
         {
-          "number": "14",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
                 "country": "GB",
-                "type": "Group",
                 "disambiguation": "UK rock group",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Queen"
             }
           ],
+          "id": "37871dd0-3e5b-410b-8088-6c33c22ab0b6",
+          "length": 329000,
+          "number": "13",
+          "position": 13,
           "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
                   "country": "GB",
-                  "sort-name": "Queen",
+                  "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen"
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Queen",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
-            "first-release-date": "2008",
             "disambiguation": "",
-            "id": "8d322243-e949-4f04-a86a-dc86ebc315ea",
-            "length": 389000,
+            "first-release-date": "2008",
+            "id": "4dd4afcd-62e6-44b9-90ed-e65b572f2634",
             "isrcs": [],
-            "video": false,
-            "title": "Innuendo"
+            "length": 329000,
+            "title": "Made in Heaven",
+            "video": false
           },
-          "title": "Innuendo",
-          "position": 14,
-          "length": 389000,
-          "id": "d36ac905-ba59-422e-a566-2cad26cf6634"
+          "title": "Made in Heaven"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "d36ac905-ba59-422e-a566-2cad26cf6634",
+          "length": 389000,
+          "number": "14",
+          "position": 14,
           "recording": {
-            "video": false,
-            "isrcs": [],
-            "title": "You Don\u2019t Fool Me",
-            "id": "90017201-7210-4ecc-ad33-8efab762d0a6",
-            "length": 326000,
-            "disambiguation": "",
-            "first-release-date": "2008",
             "artist-credit": [
               {
-                "name": "Queen",
                 "artist": {
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
                   "country": "GB",
+                  "disambiguation": "UK rock group",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
                   "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
-            ]
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "8d322243-e949-4f04-a86a-dc86ebc315ea",
+            "isrcs": [],
+            "length": 389000,
+            "title": "Innuendo",
+            "video": false
           },
-          "position": 15,
-          "title": "You Don\u2019t Fool Me",
+          "title": "Innuendo"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "d0703bdc-2574-42ff-b522-79e353dbf6ba",
           "length": 326000,
           "number": "15",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group"
-              },
-              "name": "Queen",
-              "joinphrase": ""
-            }
-          ]
-        },
-        {
-          "recording": {
-            "id": "461ee134-e4ad-4dfa-85d3-efb9f82aab3c",
-            "length": 249000,
-            "isrcs": [],
-            "video": false,
-            "title": "I\u2019m Going Slightly Mad",
-            "disambiguation": "",
-            "first-release-date": "2008",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Queen",
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
-                  "country": "GB"
-                },
-                "name": "Queen",
-                "joinphrase": ""
-              }
-            ]
-          },
-          "title": "I\u2019m Going Slightly Mad",
-          "position": 16,
-          "id": "63f29b68-2701-416d-b51a-dca67042832c",
-          "length": 249000,
-          "number": "16",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-              }
-            }
-          ]
-        },
-        {
-          "length": 263000,
-          "id": "40e051db-b361-4b7f-8d8a-2c4d0977001a",
-          "position": 17,
-          "title": "The Show Must Go On",
+          "position": 15,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
                 "artist": {
                   "country": "GB",
-                  "type": "Group",
                   "disambiguation": "UK rock group",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
+                "joinphrase": "",
                 "name": "Queen"
               }
             ],
-            "first-release-date": "2008",
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "2008",
+            "id": "90017201-7210-4ecc-ad33-8efab762d0a6",
             "isrcs": [],
-            "title": "The Show Must Go On",
-            "id": "4878c739-df55-488e-b400-e57992d4cf3c",
-            "length": 263000
+            "length": 326000,
+            "title": "You Don\u2019t Fool Me",
+            "video": false
           },
+          "title": "You Don\u2019t Fool Me"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "type": "Group",
                 "country": "GB",
                 "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Queen",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "number": "17"
+          "id": "63f29b68-2701-416d-b51a-dca67042832c",
+          "length": 249000,
+          "number": "16",
+          "position": 16,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "461ee134-e4ad-4dfa-85d3-efb9f82aab3c",
+            "isrcs": [],
+            "length": 249000,
+            "title": "I\u2019m Going Slightly Mad",
+            "video": false
+          },
+          "title": "I\u2019m Going Slightly Mad"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "40e051db-b361-4b7f-8d8a-2c4d0977001a",
+          "length": 263000,
+          "number": "17",
+          "position": 17,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2008",
+            "id": "4878c739-df55-488e-b400-e57992d4cf3c",
+            "isrcs": [],
+            "length": 263000,
+            "title": "The Show Must Go On",
+            "video": false
+          },
+          "title": "The Show Must Go On"
         }
-      ],
-      "track-offset": 0,
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "id": "a41acaa5-332d-32f8-89a2-c17475c5e56e",
-      "position": 2,
-      "title": ""
+      ]
     }
   ],
-  "barcode": "4607147861714",
-  "asin": null,
+  "packaging": "Digipak",
   "packaging-id": "8f931351-d2e2-310f-afc6-37b89ddba246",
-  "disambiguation": "",
-  "status": "Bootleg",
+  "quality": "normal",
   "release-events": [
     {
-      "date": "2008",
       "area": {
-        "type-id": null,
-        "name": "Russia",
+        "disambiguation": "",
         "id": "1f1fc3a4-9500-39b8-9f10-f0a465557eef",
         "iso-3166-1-codes": [
           "RU"
         ],
-        "disambiguation": "",
+        "name": "Russia",
         "sort-name": "Russia",
-        "type": null
-      }
-    }
-  ],
-  "cover-art-archive": {
-    "front": true,
-    "darkened": false,
-    "count": 10,
-    "back": true,
-    "artwork": true
-  },
-  "title": "Greatest Hits",
-  "artist-credit": [
-    {
-      "artist": {
-        "disambiguation": "UK rock group",
-        "type": "Group",
-        "country": "GB",
-        "sort-name": "Queen",
-        "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "name": "Queen"
+        "type": null,
+        "type-id": null
       },
-      "name": "Queen",
-      "joinphrase": ""
+      "date": "2008"
     }
   ],
   "release-group": {
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
     "artist-credit": [
       {
-        "name": "Queen",
         "artist": {
-          "type": "Group",
           "country": "GB",
           "disambiguation": "UK rock group",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "name": "Queen",
           "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-          "sort-name": "Queen"
+          "name": "Queen",
+          "sort-name": "Queen",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
         },
-        "joinphrase": ""
+        "joinphrase": "",
+        "name": "Queen"
       }
     ],
+    "disambiguation": "",
     "first-release-date": "2008",
+    "id": "b6d1f1a6-fc62-49bc-8426-dcfd8a95de91",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
     "secondary-type-ids": [
       "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
     ],
-    "disambiguation": "",
     "secondary-types": [
       "Compilation"
     ],
-    "title": "Greatest Hits",
-    "primary-type": "Album",
-    "id": "b6d1f1a6-fc62-49bc-8426-dcfd8a95de91"
+    "title": "Greatest Hits"
   },
+  "status": "Bootleg",
   "status-id": "1156806e-d06a-38bd-83f0-cf2284a808b9",
   "text-representation": {
     "language": "eng",
     "script": "Latn"
   },
-  "id": "ee99a91b-e1c2-405b-9c83-99378667f09f",
-  "quality": "normal",
-  "label-info": [
-    {
-      "label": {
-        "sort-name": "Hollywood Records",
-        "id": "95777b9f-0cf4-4328-b4c9-da1402bcbc5c",
-        "type-id": "fdac9b96-359b-3488-9322-ad99c2473636",
-        "name": "Hollywood Records",
-        "label-code": null,
-        "disambiguation": "fake label pretending to be the real thing",
-        "type": "Bootleg Production"
-      },
-      "catalog-number": "13816-1/2"
-    },
-    {
-      "catalog-number": "13816-1/2",
-      "label": {
-        "type": "Bootleg Production",
-        "disambiguation": "Russian bootleg production",
-        "label-code": null,
-        "type-id": "fdac9b96-359b-3488-9322-ad99c2473636",
-        "name": "Star Mark",
-        "id": "46adc01f-fb5d-4ec2-874b-d6c8c9ba4010",
-        "sort-name": "Star Mark"
-      }
-    }
-  ],
-  "date": "2008"
+  "title": "Greatest Hits"
 }

--- a/scripts/eval_matching/corpus/eval_release_f390ab14.json
+++ b/scripts/eval_matching/corpus/eval_release_f390ab14.json
@@ -1,416 +1,416 @@
 {
-  "disambiguation": "",
-  "quality": "normal",
-  "status": "Official",
-  "release-group": {
-    "id": "d5cb0b10-ddeb-4879-b343-5af4e01712e3",
-    "secondary-types": [],
-    "primary-type": "Album",
-    "first-release-date": "1978",
-    "disambiguation": "",
-    "title": "Symphony No 5",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "artist-credit": [
-      {
-        "joinphrase": "; ",
-        "name": "Beethoven",
-        "artist": {
-          "disambiguation": "German composer",
-          "sort-name": "Beethoven, Ludwig van",
-          "country": "DE",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-          "type": "Person",
-          "name": "Ludwig van Beethoven"
-        }
-      },
-      {
-        "artist": {
-          "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
-          "name": "Berliner Philharmoniker",
-          "type": "Orchestra",
-          "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-          "country": "DE",
-          "disambiguation": "",
-          "sort-name": "Berliner Philharmoniker"
-        },
-        "name": "Berlin Philharmonic Orchestra",
-        "joinphrase": ", "
-      },
-      {
-        "joinphrase": "",
-        "name": "Herbert von Karajan",
-        "artist": {
-          "sort-name": "Karajan, Herbert von",
-          "disambiguation": "conductor",
-          "type": "Person",
-          "name": "Herbert von Karajan",
-          "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "country": "AT"
-        }
-      }
-    ],
-    "secondary-type-ids": []
-  },
-  "label-info": [
-    {
-      "label": {
-        "name": "Deutsche Grammophon",
-        "type": "Imprint",
-        "label-code": 173,
-        "id": "5a584032-dcef-41bb-9f8b-19540116fb1c",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "disambiguation": "",
-        "sort-name": "Deutsche Grammophon"
-      },
-      "catalog-number": "2542 105"
-    },
-    {
-      "label": {
-        "disambiguation": "",
-        "sort-name": "Deutsche Grammophon Accolade",
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "id": "3b7e8081-0d76-4164-b79e-b8f0f239026e",
-        "name": "Deutsche Grammophon Accolade",
-        "type": "Imprint",
-        "label-code": null
-      },
-      "catalog-number": "2542 105"
-    }
-  ],
-  "id": "f390ab14-095d-42aa-ade3-fbbafe093f9d",
-  "text-representation": {
-    "language": "eng",
-    "script": "Latn"
-  },
-  "asin": null,
-  "title": "Symphony no. 5",
-  "packaging": "Cardboard/Paper Sleeve",
   "artist-credit": [
     {
-      "name": "Beethoven",
       "artist": {
-        "sort-name": "Beethoven, Ludwig van",
-        "disambiguation": "German composer",
-        "type": "Person",
-        "name": "Ludwig van Beethoven",
-        "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "country": "DE"
-      },
-      "joinphrase": "; "
-    },
-    {
-      "name": "Berlin Philharmonic Orchestra",
-      "artist": {
-        "type": "Orchestra",
-        "name": "Berliner Philharmoniker",
-        "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
         "country": "DE",
-        "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-        "disambiguation": "",
-        "sort-name": "Berliner Philharmoniker"
+        "disambiguation": "German composer",
+        "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+        "name": "Ludwig van Beethoven",
+        "sort-name": "Beethoven, Ludwig van",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
       },
-      "joinphrase": ", "
+      "joinphrase": "; ",
+      "name": "Beethoven"
     },
     {
-      "joinphrase": "",
       "artist": {
-        "type": "Person",
-        "name": "Herbert von Karajan",
-        "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "country": "AT",
-        "sort-name": "Karajan, Herbert von",
-        "disambiguation": "conductor"
+        "country": "DE",
+        "disambiguation": "",
+        "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
+        "name": "Berliner Philharmoniker",
+        "sort-name": "Berliner Philharmoniker",
+        "type": "Orchestra",
+        "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
       },
+      "joinphrase": ", ",
+      "name": "Berlin Philharmonic Orchestra"
+    },
+    {
+      "artist": {
+        "country": "AT",
+        "disambiguation": "conductor",
+        "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
+        "name": "Herbert von Karajan",
+        "sort-name": "Karajan, Herbert von",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+      },
+      "joinphrase": "",
       "name": "Herbert von Karajan"
     }
   ],
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "asin": null,
   "barcode": "",
+  "country": "GB",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 2,
+    "darkened": false,
+    "front": true
+  },
+  "date": "1978",
+  "disambiguation": "",
+  "id": "f390ab14-095d-42aa-ade3-fbbafe093f9d",
+  "label-info": [
+    {
+      "catalog-number": "2542 105",
+      "label": {
+        "disambiguation": "",
+        "id": "5a584032-dcef-41bb-9f8b-19540116fb1c",
+        "label-code": 173,
+        "name": "Deutsche Grammophon",
+        "sort-name": "Deutsche Grammophon",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    },
+    {
+      "catalog-number": "2542 105",
+      "label": {
+        "disambiguation": "",
+        "id": "3b7e8081-0d76-4164-b79e-b8f0f239026e",
+        "label-code": null,
+        "name": "Deutsche Grammophon Accolade",
+        "sort-name": "Deutsche Grammophon Accolade",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    }
+  ],
   "media": [
     {
-      "track-count": 4,
-      "id": "a7d0790f-29cf-3d0a-8e10-62d493f041f2",
+      "format": "12\" Vinyl",
       "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+      "id": "a7d0790f-29cf-3d0a-8e10-62d493f041f2",
+      "position": 1,
+      "title": "",
+      "track-count": 4,
+      "track-offset": 0,
       "tracks": [
         {
-          "recording": {
-            "id": "ff3ad1c2-38c5-4fb3-b3ce-f24295f2ed89",
-            "video": false,
-            "isrcs": [
-              "DEF056201641"
-            ],
-            "first-release-date": "1962",
-            "title": "Symphony no. 5 in C minor, op. 67: I. Allegro con brio",
-            "disambiguation": "",
-            "length": 438000,
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
-                  "name": "Berliner Philharmoniker",
-                  "type": "Orchestra",
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "country": "DE",
-                  "disambiguation": "",
-                  "sort-name": "Berliner Philharmoniker"
-                },
-                "name": "Berliner Philharmoniker",
-                "joinphrase": ", "
-              },
-              {
-                "name": "Herbert von Karajan",
-                "artist": {
-                  "sort-name": "Karajan, Herbert von",
-                  "disambiguation": "conductor",
-                  "type": "Person",
-                  "name": "Herbert von Karajan",
-                  "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
-                  "country": "AT",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                },
-                "joinphrase": ""
-              }
-            ]
-          },
-          "id": "baa14410-7cd1-4fa4-8d3a-98d80b829181",
           "artist-credit": [
             {
-              "name": "Ludwig van Beethoven",
               "artist": {
-                "sort-name": "Beethoven, Ludwig van",
-                "disambiguation": "German composer",
                 "country": "DE",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
+                "disambiguation": "German composer",
                 "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+                "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
                 "type": "Person",
-                "name": "Ludwig van Beethoven"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Ludwig van Beethoven"
             }
           ],
+          "id": "baa14410-7cd1-4fa4-8d3a-98d80b829181",
           "length": 427000,
           "number": "A1",
           "position": 1,
-          "title": "Symphony no. 5 in C minor, op. 67: I. Allegro con brio"
-        },
-        {
           "recording": {
-            "disambiguation": "",
-            "title": "Symphony no. 5 in C minor, op. 67: II. Andante con moto",
             "artist-credit": [
               {
-                "name": "Berliner Philharmoniker",
                 "artist": {
+                  "country": "DE",
                   "disambiguation": "",
-                  "sort-name": "Berliner Philharmoniker",
-                  "name": "Berliner Philharmoniker",
-                  "type": "Orchestra",
                   "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "country": "DE"
+                  "name": "Berliner Philharmoniker",
+                  "sort-name": "Berliner Philharmoniker",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
                 },
-                "joinphrase": ", "
+                "joinphrase": ", ",
+                "name": "Berliner Philharmoniker"
               },
               {
-                "joinphrase": "",
                 "artist": {
-                  "disambiguation": "conductor",
-                  "sort-name": "Karajan, Herbert von",
-                  "name": "Herbert von Karajan",
-                  "type": "Person",
-                  "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
                   "country": "AT",
+                  "disambiguation": "conductor",
+                  "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
+                  "name": "Herbert von Karajan",
+                  "sort-name": "Karajan, Herbert von",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
                 },
+                "joinphrase": "",
                 "name": "Herbert von Karajan"
               }
             ],
-            "length": 604000,
+            "disambiguation": "",
+            "first-release-date": "1962",
+            "id": "ff3ad1c2-38c5-4fb3-b3ce-f24295f2ed89",
+            "isrcs": [
+              "DEF056201641"
+            ],
+            "length": 438000,
+            "title": "Symphony no. 5 in C minor, op. 67: I. Allegro con brio",
+            "video": false
+          },
+          "title": "Symphony no. 5 in C minor, op. 67: I. Allegro con brio"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "DE",
+                "disambiguation": "German composer",
+                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+                "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "Ludwig van Beethoven"
+            }
+          ],
+          "id": "25a47559-bdf0-416a-aa66-af6440e99a9f",
+          "length": 592000,
+          "number": "A2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "DE",
+                  "disambiguation": "",
+                  "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
+                  "name": "Berliner Philharmoniker",
+                  "sort-name": "Berliner Philharmoniker",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "Berliner Philharmoniker"
+              },
+              {
+                "artist": {
+                  "country": "AT",
+                  "disambiguation": "conductor",
+                  "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
+                  "name": "Herbert von Karajan",
+                  "sort-name": "Karajan, Herbert von",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Herbert von Karajan"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1962",
+            "id": "ad2d76cb-54e2-4b52-ac93-822d71e7d39e",
             "isrcs": [
               "DEF056201642"
             ],
-            "video": false,
-            "id": "ad2d76cb-54e2-4b52-ac93-822d71e7d39e",
-            "first-release-date": "1962"
+            "length": 604000,
+            "title": "Symphony no. 5 in C minor, op. 67: II. Andante con moto",
+            "video": false
           },
-          "id": "25a47559-bdf0-416a-aa66-af6440e99a9f",
-          "number": "A2",
-          "position": 2,
-          "title": "Symphony no. 5 in C minor, op. 67: II. Andante con moto",
-          "artist-credit": [
-            {
-              "name": "Ludwig van Beethoven",
-              "artist": {
-                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-                "type": "Person",
-                "name": "Ludwig van Beethoven",
-                "country": "DE",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "disambiguation": "German composer",
-                "sort-name": "Beethoven, Ludwig van"
-              },
-              "joinphrase": ""
-            }
-          ],
-          "length": 592000
+          "title": "Symphony no. 5 in C minor, op. 67: II. Andante con moto"
         },
         {
-          "position": 3,
-          "title": "Symphony no. 5 in C minor, op. 67: III. Scherzo. Allegro",
-          "number": "B1",
-          "length": 282000,
           "artist-credit": [
             {
               "artist": {
+                "country": "DE",
                 "disambiguation": "German composer",
-                "sort-name": "Beethoven, Ludwig van",
                 "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
                 "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
                 "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "country": "DE"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "Ludwig van Beethoven",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Ludwig van Beethoven"
             }
           ],
           "id": "7040122d-37dc-4d3d-86b7-678c40f6f538",
+          "length": 282000,
+          "number": "B1",
+          "position": 3,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "DE",
+                  "disambiguation": "",
+                  "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
+                  "name": "Berliner Philharmoniker",
+                  "sort-name": "Berliner Philharmoniker",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "Berliner Philharmoniker"
+              },
+              {
+                "artist": {
+                  "country": "AT",
+                  "disambiguation": "conductor",
+                  "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
+                  "name": "Herbert von Karajan",
+                  "sort-name": "Karajan, Herbert von",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Herbert von Karajan"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1962",
             "id": "f008e4a0-8472-4afd-9bd7-a264d98d7611",
             "isrcs": [
               "DEF056201643"
             ],
-            "video": false,
-            "first-release-date": "1962",
-            "title": "Symphony no. 5 in C minor, op. 67: III. Scherzo. Allegro",
-            "disambiguation": "",
             "length": 294000,
-            "artist-credit": [
-              {
-                "name": "Berliner Philharmoniker",
-                "artist": {
-                  "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
-                  "type": "Orchestra",
-                  "name": "Berliner Philharmoniker",
-                  "country": "DE",
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "sort-name": "Berliner Philharmoniker",
-                  "disambiguation": ""
-                },
-                "joinphrase": ", "
-              },
-              {
-                "name": "Herbert von Karajan",
-                "artist": {
-                  "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
-                  "name": "Herbert von Karajan",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "AT",
-                  "disambiguation": "conductor",
-                  "sort-name": "Karajan, Herbert von"
-                },
-                "joinphrase": ""
-              }
-            ]
-          }
+            "title": "Symphony no. 5 in C minor, op. 67: III. Scherzo. Allegro",
+            "video": false
+          },
+          "title": "Symphony no. 5 in C minor, op. 67: III. Scherzo. Allegro"
         },
         {
-          "id": "4155ac10-e01f-49df-a0b7-4349d4108626",
-          "recording": {
-            "first-release-date": "1962",
-            "isrcs": [
-              "DEF056201644"
-            ],
-            "video": false,
-            "id": "8e67c3a2-76aa-47b8-a78a-13887156bdd5",
-            "artist-credit": [
-              {
-                "joinphrase": ", ",
-                "name": "Berliner Philharmoniker",
-                "artist": {
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "country": "DE",
-                  "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
-                  "name": "Berliner Philharmoniker",
-                  "type": "Orchestra",
-                  "sort-name": "Berliner Philharmoniker",
-                  "disambiguation": ""
-                }
-              },
-              {
-                "joinphrase": "",
-                "name": "Herbert von Karajan",
-                "artist": {
-                  "sort-name": "Karajan, Herbert von",
-                  "disambiguation": "conductor",
-                  "type": "Person",
-                  "name": "Herbert von Karajan",
-                  "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "country": "AT"
-                }
-              }
-            ],
-            "length": 545400,
-            "disambiguation": "",
-            "title": "Symphony no. 5 in C minor, op. 67: IV. Allegro"
-          },
-          "length": 537000,
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "country": "DE",
+                "disambiguation": "German composer",
                 "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
                 "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
                 "type": "Person",
-                "disambiguation": "German composer",
-                "sort-name": "Beethoven, Ludwig van"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
+              "joinphrase": "",
               "name": "Ludwig van Beethoven"
             }
           ],
+          "id": "4155ac10-e01f-49df-a0b7-4349d4108626",
+          "length": 537000,
+          "number": "B2",
           "position": 4,
-          "title": "Symphony no. 5 in C minor, op. 67: IV. Allegro",
-          "number": "B2"
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "DE",
+                  "disambiguation": "",
+                  "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
+                  "name": "Berliner Philharmoniker",
+                  "sort-name": "Berliner Philharmoniker",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "Berliner Philharmoniker"
+              },
+              {
+                "artist": {
+                  "country": "AT",
+                  "disambiguation": "conductor",
+                  "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
+                  "name": "Herbert von Karajan",
+                  "sort-name": "Karajan, Herbert von",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "Herbert von Karajan"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1962",
+            "id": "8e67c3a2-76aa-47b8-a78a-13887156bdd5",
+            "isrcs": [
+              "DEF056201644"
+            ],
+            "length": 545400,
+            "title": "Symphony no. 5 in C minor, op. 67: IV. Allegro",
+            "video": false
+          },
+          "title": "Symphony no. 5 in C minor, op. 67: IV. Allegro"
         }
-      ],
-      "track-offset": 0,
-      "title": "",
-      "format": "12\" Vinyl",
-      "position": 1
+      ]
     }
   ],
-  "cover-art-archive": {
-    "front": true,
-    "count": 2,
-    "artwork": true,
-    "back": true,
-    "darkened": false
-  },
+  "packaging": "Cardboard/Paper Sleeve",
+  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+  "quality": "normal",
   "release-events": [
     {
       "area": {
         "disambiguation": "",
-        "sort-name": "United Kingdom",
+        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
         "iso-3166-1-codes": [
           "GB"
         ],
-        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
-        "type": null,
         "name": "United Kingdom",
+        "sort-name": "United Kingdom",
+        "type": null,
         "type-id": null
       },
       "date": "1978"
     }
   ],
-  "country": "GB",
-  "date": "1978",
-  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f"
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "DE",
+          "disambiguation": "German composer",
+          "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+          "name": "Ludwig van Beethoven",
+          "sort-name": "Beethoven, Ludwig van",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "; ",
+        "name": "Beethoven"
+      },
+      {
+        "artist": {
+          "country": "DE",
+          "disambiguation": "",
+          "id": "dea28aa9-1086-4ffa-8739-0ccc759de1ce",
+          "name": "Berliner Philharmoniker",
+          "sort-name": "Berliner Philharmoniker",
+          "type": "Orchestra",
+          "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+        },
+        "joinphrase": ", ",
+        "name": "Berlin Philharmonic Orchestra"
+      },
+      {
+        "artist": {
+          "country": "AT",
+          "disambiguation": "conductor",
+          "id": "d2ced2f1-6b58-47cf-ae87-5943e2ab6d99",
+          "name": "Herbert von Karajan",
+          "sort-name": "Karajan, Herbert von",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "",
+        "name": "Herbert von Karajan"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1978",
+    "id": "d5cb0b10-ddeb-4879-b343-5af4e01712e3",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Symphony No 5"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Symphony no. 5"
 }

--- a/scripts/eval_matching/corpus/eval_release_f394e886.json
+++ b/scripts/eval_matching/corpus/eval_release_f394e886.json
@@ -1,541 +1,93 @@
 {
-  "cover-art-archive": {
-    "back": false,
-    "front": false,
-    "artwork": false,
-    "count": 0,
-    "darkened": false
-  },
-  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
-  "release-events": [
-    {
-      "date": "1977",
-      "area": null
-    }
-  ],
-  "title": "Conducts Beethoven-Symphony No. 5; Symphony No. 4",
-  "packaging": "Cardboard/Paper Sleeve",
-  "status": "Official",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "release-group": {
-    "secondary-type-ids": [],
-    "primary-type": "Album",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "disambiguation": "",
-    "secondary-types": [],
-    "title": "Conducts Beethoven-Symphony No. 5; Symphony No. 4",
-    "artist-credit": [
-      {
-        "artist": {
-          "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-          "country": "DE",
-          "disambiguation": "German composer",
-          "type": "Person",
-          "name": "Ludwig van Beethoven",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "sort-name": "Beethoven, Ludwig van"
-        },
-        "name": "Beethoven",
-        "joinphrase": "; "
-      },
-      {
-        "artist": {
-          "disambiguation": "",
-          "country": "US",
-          "name": "The Cleveland Orchestra",
-          "type": "Orchestra",
-          "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-          "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-          "sort-name": "Cleveland Orchestra, The"
-        },
-        "name": "Cleveland Orchestra",
-        "joinphrase": ", "
-      },
-      {
-        "joinphrase": "",
-        "name": "George Szell",
-        "artist": {
-          "sort-name": "Szell, George",
-          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-          "type": "Person",
-          "name": "George Szell",
-          "country": "US",
-          "disambiguation": "conductor, pianist, composer",
-          "id": "642116e0-69e6-48a8-a19d-f272cb5b7756"
-        }
-      }
-    ],
-    "first-release-date": "1977",
-    "id": "b7f65937-646e-4039-a182-fb54cb4d5039"
-  },
-  "label-info": [
-    {
-      "label": {
-        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded",
-        "sort-name": "Columbia Odyssey",
-        "label-code": null,
-        "id": "0088c4d5-d998-4830-b0c4-1f8b7d14128a",
-        "disambiguation": "sub-label of CBS-owned Columbia, dove in logo",
-        "type": "Imprint",
-        "name": "Columbia Odyssey"
-      },
-      "catalog-number": "Y 34600 XSB 76887"
-    }
-  ],
-  "country": null,
-  "date": "1977",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "barcode": "",
-  "quality": "normal",
-  "id": "f394e886-5485-4b66-9b7c-ca45b4734b6e",
   "artist-credit": [
     {
       "artist": {
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "sort-name": "Beethoven, Ludwig van",
+        "country": "DE",
+        "disambiguation": "German composer",
         "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
         "name": "Ludwig van Beethoven",
+        "sort-name": "Beethoven, Ludwig van",
         "type": "Person",
-        "disambiguation": "German composer",
-        "country": "DE"
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
       },
       "joinphrase": "; ",
       "name": "Beethoven"
     },
     {
-      "name": "Cleveland Orchestra",
-      "joinphrase": ", ",
       "artist": {
-        "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-        "sort-name": "Cleveland Orchestra, The",
         "country": "US",
         "disambiguation": "",
+        "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
         "name": "The Cleveland Orchestra",
+        "sort-name": "Cleveland Orchestra, The",
         "type": "Orchestra",
-        "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa"
-      }
+        "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+      },
+      "joinphrase": ", ",
+      "name": "Cleveland Orchestra"
     },
     {
-      "joinphrase": "",
-      "name": "George Szell",
       "artist": {
-        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-        "sort-name": "Szell, George",
         "country": "US",
         "disambiguation": "conductor, pianist, composer",
-        "type": "Person",
+        "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
         "name": "George Szell",
-        "id": "642116e0-69e6-48a8-a19d-f272cb5b7756"
-      }
+        "sort-name": "Szell, George",
+        "type": "Person",
+        "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+      },
+      "joinphrase": "",
+      "name": "George Szell"
     }
   ],
   "asin": null,
+  "barcode": "",
+  "country": null,
+  "cover-art-archive": {
+    "artwork": false,
+    "back": false,
+    "count": 0,
+    "darkened": false,
+    "front": false
+  },
+  "date": "1977",
+  "disambiguation": "",
+  "id": "f394e886-5485-4b66-9b7c-ca45b4734b6e",
+  "label-info": [
+    {
+      "catalog-number": "Y 34600 XSB 76887",
+      "label": {
+        "disambiguation": "sub-label of CBS-owned Columbia, dove in logo",
+        "id": "0088c4d5-d998-4830-b0c4-1f8b7d14128a",
+        "label-code": null,
+        "name": "Columbia Odyssey",
+        "sort-name": "Columbia Odyssey",
+        "type": "Imprint",
+        "type-id": "b6285b2a-3514-3d43-80df-fcf528824ded"
+      }
+    }
+  ],
   "media": [
     {
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
+      "id": "50a8ed69-ce0e-3428-8853-4b243d846c48",
+      "position": 1,
+      "title": "",
       "track-count": 7,
+      "track-offset": 0,
       "tracks": [
         {
-          "position": 1,
-          "number": "A1",
-          "length": 601000,
-          "recording": {
-            "title": "Symphony no. 4 in B-flat major, op. 60: I. Adagio \u2014 Allegro vivace",
-            "first-release-date": "1977",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "sort-name": "Cleveland Orchestra, The",
-                  "country": "US",
-                  "disambiguation": "",
-                  "type": "Orchestra",
-                  "name": "The Cleveland Orchestra",
-                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa"
-                },
-                "joinphrase": ", ",
-                "name": "Cleveland Orchestra"
-              },
-              {
-                "name": "George Szell",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Szell, George",
-                  "disambiguation": "conductor, pianist, composer",
-                  "country": "US",
-                  "type": "Person",
-                  "name": "George Szell",
-                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756"
-                }
-              }
-            ],
-            "id": "048e8ffe-cbc2-4b87-bcfe-6cf696934a36",
-            "video": false,
-            "disambiguation": "",
-            "isrcs": [
-              "USSM16300971"
-            ],
-            "length": 601413
-          },
-          "title": "Symphony No. 4 in B-flat major, Op. 60: I - Adagio; Allegro Vivace",
           "artist-credit": [
             {
               "artist": {
+                "country": "DE",
+                "disambiguation": "German composer",
                 "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-                "type": "Person",
                 "name": "Ludwig van Beethoven",
-                "disambiguation": "German composer",
-                "country": "DE",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Beethoven, Ludwig van"
-              },
-              "joinphrase": "; ",
-              "name": "Beethoven"
-            },
-            {
-              "joinphrase": ", ",
-              "name": "Cleveland Orchestra",
-              "artist": {
-                "sort-name": "Cleveland Orchestra, The",
-                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                "name": "The Cleveland Orchestra",
-                "type": "Orchestra",
-                "disambiguation": "",
-                "country": "US"
-              }
-            },
-            {
-              "artist": {
-                "sort-name": "Szell, George",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                "name": "George Szell",
-                "type": "Person",
-                "disambiguation": "conductor, pianist, composer",
-                "country": "US"
-              },
-              "joinphrase": "",
-              "name": "George Szell"
-            }
-          ],
-          "id": "a9bade69-b70f-4012-9cc4-56107d93aab1"
-        },
-        {
-          "position": 2,
-          "number": "A2",
-          "length": 585000,
-          "recording": {
-            "title": "Symphony no. 4 in B-flat major, op. 60: II. Adagio",
-            "id": "1f628c28-bd54-4901-998b-1a4a4a41a319",
-            "first-release-date": "1977",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                  "disambiguation": "",
-                  "country": "US",
-                  "name": "The Cleveland Orchestra",
-                  "type": "Orchestra",
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "sort-name": "Cleveland Orchestra, The"
-                },
-                "joinphrase": ", ",
-                "name": "Cleveland Orchestra"
-              },
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Szell, George",
-                  "country": "US",
-                  "disambiguation": "conductor, pianist, composer",
-                  "name": "George Szell",
-                  "type": "Person",
-                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756"
-                },
-                "joinphrase": "",
-                "name": "George Szell"
-              }
-            ],
-            "video": false,
-            "disambiguation": "",
-            "length": 588226,
-            "isrcs": [
-              "USSM16300972"
-            ]
-          },
-          "title": "Symphony No. 4 in B-flat major, Op. 60: II - Adagio",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
                 "sort-name": "Beethoven, Ludwig van",
-                "country": "DE",
-                "disambiguation": "German composer",
                 "type": "Person",
-                "name": "Ludwig van Beethoven",
-                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9"
-              },
-              "joinphrase": "; ",
-              "name": "Beethoven"
-            },
-            {
-              "joinphrase": ", ",
-              "name": "Cleveland Orchestra",
-              "artist": {
-                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                "sort-name": "Cleveland Orchestra, The",
-                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                "country": "US",
-                "disambiguation": "",
-                "type": "Orchestra",
-                "name": "The Cleveland Orchestra"
-              }
-            },
-            {
-              "joinphrase": "",
-              "name": "George Szell",
-              "artist": {
-                "type": "Person",
-                "name": "George Szell",
-                "country": "US",
-                "disambiguation": "conductor, pianist, composer",
-                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                "sort-name": "Szell, George",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
-            }
-          ],
-          "id": "a9fae011-3a6d-4600-8a22-503f6aab5360"
-        },
-        {
-          "id": "1f574119-e0d0-4a88-82fd-3c8591f97087",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Beethoven, Ludwig van",
-                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-                "country": "DE",
-                "disambiguation": "German composer",
-                "type": "Person",
-                "name": "Ludwig van Beethoven"
-              },
-              "joinphrase": "; ",
-              "name": "Beethoven"
-            },
-            {
-              "joinphrase": ", ",
-              "name": "Cleveland Orchestra",
-              "artist": {
-                "disambiguation": "",
-                "country": "US",
-                "type": "Orchestra",
-                "name": "The Cleveland Orchestra",
-                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                "sort-name": "Cleveland Orchestra, The",
-                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
-              }
-            },
-            {
-              "artist": {
-                "sort-name": "Szell, George",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                "country": "US",
-                "disambiguation": "conductor, pianist, composer",
-                "type": "Person",
-                "name": "George Szell"
-              },
-              "joinphrase": "",
-              "name": "George Szell"
-            }
-          ],
-          "title": "Symphony No. 4 in B-flat major, Op. 60: III - Allegro Vivace",
-          "length": 355000,
-          "number": "A3",
-          "position": 3,
-          "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "Symphony no. 4 in B-flat major, op. 60: III. Allegro vivace \u2014 Un poco meno allegro",
-            "id": "391b6276-c8ed-42f3-9a3b-7911724349e3",
-            "first-release-date": "1977",
-            "artist-credit": [
-              {
-                "artist": {
-                  "disambiguation": "",
-                  "country": "US",
-                  "name": "The Cleveland Orchestra",
-                  "type": "Orchestra",
-                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                  "sort-name": "Cleveland Orchestra, The",
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
-                },
-                "joinphrase": ", ",
-                "name": "Cleveland Orchestra"
-              },
-              {
-                "name": "George Szell",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Szell, George",
-                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                  "country": "US",
-                  "disambiguation": "conductor, pianist, composer",
-                  "name": "George Szell",
-                  "type": "Person"
-                }
-              }
-            ],
-            "length": 355146,
-            "isrcs": [
-              "USSM16300973"
-            ]
-          }
-        },
-        {
-          "recording": {
-            "length": 365026,
-            "isrcs": [
-              "USSM16300974"
-            ],
-            "video": false,
-            "disambiguation": "",
-            "title": "Symphony no. 4 in B-flat major, op. 60: IV. Allegro ma non troppo",
-            "id": "aa0dc869-a6b4-43c8-9f0b-837cd3fadf8d",
-            "artist-credit": [
-              {
-                "name": "Cleveland Orchestra",
-                "joinphrase": ", ",
-                "artist": {
-                  "sort-name": "Cleveland Orchestra, The",
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                  "country": "US",
-                  "disambiguation": "",
-                  "name": "The Cleveland Orchestra",
-                  "type": "Orchestra"
-                }
-              },
-              {
-                "artist": {
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "sort-name": "Szell, George",
-                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                  "country": "US",
-                  "disambiguation": "conductor, pianist, composer",
-                  "type": "Person",
-                  "name": "George Szell"
-                },
-                "name": "George Szell",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1977"
-          },
-          "number": "A4",
-          "length": 355000,
-          "position": 4,
-          "artist-credit": [
-            {
-              "name": "Beethoven",
-              "joinphrase": "; ",
-              "artist": {
-                "type": "Person",
-                "name": "Ludwig van Beethoven",
-                "disambiguation": "German composer",
-                "country": "DE",
-                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-                "sort-name": "Beethoven, Ludwig van",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-              }
-            },
-            {
-              "artist": {
-                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                "sort-name": "Cleveland Orchestra, The",
-                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                "country": "US",
-                "disambiguation": "",
-                "name": "The Cleveland Orchestra",
-                "type": "Orchestra"
-              },
-              "name": "Cleveland Orchestra",
-              "joinphrase": ", "
-            },
-            {
-              "artist": {
-                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                "type": "Person",
-                "name": "George Szell",
-                "disambiguation": "conductor, pianist, composer",
-                "country": "US",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Szell, George"
-              },
-              "joinphrase": "",
-              "name": "George Szell"
-            }
-          ],
-          "id": "71e2ef50-6700-4b7f-aced-0abc2146a012",
-          "title": "Symphony No. 4 in B-flat major, Op. 60: IV - Allegro Ma Non Troppo"
-        },
-        {
-          "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "Symphony No. 5 in C minor, Op. 67: I - Allegro Con Brio",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                  "type": "Orchestra",
-                  "name": "The Cleveland Orchestra",
-                  "disambiguation": "",
-                  "country": "US",
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "sort-name": "Cleveland Orchestra, The"
-                },
-                "name": "The Cleveland Orchestra",
-                "joinphrase": ", "
-              },
-              {
-                "artist": {
-                  "sort-name": "Szell, George",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                  "type": "Person",
-                  "name": "George Szell",
-                  "country": "US",
-                  "disambiguation": "conductor, pianist, composer"
-                },
-                "name": "George Szell",
-                "joinphrase": ""
-              }
-            ],
-            "first-release-date": "1977",
-            "id": "d90cbb74-8409-4972-aa75-b7abb350dfbc",
-            "isrcs": [],
-            "length": 365000
-          },
-          "number": "B1",
-          "length": 365000,
-          "position": 5,
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-                "type": "Person",
-                "name": "Ludwig van Beethoven",
-                "country": "DE",
-                "disambiguation": "German composer",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Beethoven, Ludwig van"
               },
               "joinphrase": "; ",
               "name": "Beethoven"
@@ -544,210 +96,658 @@
               "artist": {
                 "country": "US",
                 "disambiguation": "",
-                "type": "Orchestra",
-                "name": "The Cleveland Orchestra",
                 "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                "name": "The Cleveland Orchestra",
                 "sort-name": "Cleveland Orchestra, The",
+                "type": "Orchestra",
                 "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
               },
               "joinphrase": ", ",
               "name": "Cleveland Orchestra"
             },
             {
-              "joinphrase": "",
-              "name": "George Szell",
               "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Szell, George",
-                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                "disambiguation": "conductor, pianist, composer",
                 "country": "US",
-                "type": "Person",
-                "name": "George Szell"
-              }
-            }
-          ],
-          "id": "f9d1b56e-8c12-4ecf-b2a6-172e38ae1b15",
-          "title": "Symphony No. 5 in C minor, Op. 67: I - Allegro Con Brio"
-        },
-        {
-          "position": 6,
-          "length": 599000,
-          "number": "B2",
-          "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "Symphony No. 5 in C minor, Op. 67: II - Andante Con Moto",
-            "first-release-date": "1977",
-            "artist-credit": [
-              {
-                "name": "The Cleveland Orchestra",
-                "joinphrase": ", ",
-                "artist": {
-                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                  "name": "The Cleveland Orchestra",
-                  "type": "Orchestra",
-                  "country": "US",
-                  "disambiguation": "",
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "sort-name": "Cleveland Orchestra, The"
-                }
-              },
-              {
-                "artist": {
-                  "sort-name": "Szell, George",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                  "name": "George Szell",
-                  "type": "Person",
-                  "country": "US",
-                  "disambiguation": "conductor, pianist, composer"
-                },
-                "joinphrase": "",
-                "name": "George Szell"
-              }
-            ],
-            "id": "229753fd-7c2c-4d6a-ae4f-8c7af629cec4",
-            "isrcs": [],
-            "length": 599000
-          },
-          "title": "Symphony No. 5 in C minor, Op. 67: II - Andante Con Moto",
-          "id": "907b68b9-fe67-420d-b171-c426970bc30d",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Beethoven, Ludwig van",
-                "type": "Person",
-                "name": "Ludwig van Beethoven",
-                "disambiguation": "German composer",
-                "country": "DE",
-                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9"
-              },
-              "name": "Beethoven",
-              "joinphrase": "; "
-            },
-            {
-              "artist": {
-                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                "sort-name": "Cleveland Orchestra, The",
-                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
-                "type": "Orchestra",
-                "name": "The Cleveland Orchestra",
-                "disambiguation": "",
-                "country": "US"
-              },
-              "name": "Cleveland Orchestra",
-              "joinphrase": ", "
-            },
-            {
-              "artist": {
+                "disambiguation": "conductor, pianist, composer",
                 "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                "type": "Person",
                 "name": "George Szell",
-                "disambiguation": "conductor, pianist, composer",
-                "country": "US",
                 "sort-name": "Szell, George",
+                "type": "Person",
                 "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "",
               "name": "George Szell"
             }
-          ]
-        },
-        {
-          "position": 7,
-          "length": 840000,
-          "number": "B3",
+          ],
+          "id": "a9bade69-b70f-4012-9cc4-56107d93aab1",
+          "length": 601000,
+          "number": "A1",
+          "position": 1,
           "recording": {
-            "video": false,
-            "disambiguation": "",
-            "title": "Symphony No. 5 in C minor, Op. 67: III - Scherzo: Allegro IV - Allegro",
-            "id": "b63ce3ff-0b25-40a2-a374-6cc95a120e09",
             "artist-credit": [
               {
-                "joinphrase": ", ",
-                "name": "The Cleveland Orchestra",
                 "artist": {
-                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                  "sort-name": "Cleveland Orchestra, The",
+                  "country": "US",
+                  "disambiguation": "",
                   "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
                   "name": "The Cleveland Orchestra",
+                  "sort-name": "Cleveland Orchestra, The",
                   "type": "Orchestra",
-                  "country": "US",
-                  "disambiguation": ""
-                }
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "Cleveland Orchestra"
               },
               {
-                "name": "George Szell",
-                "joinphrase": "",
                 "artist": {
                   "country": "US",
                   "disambiguation": "conductor, pianist, composer",
-                  "type": "Person",
-                  "name": "George Szell",
                   "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                  "name": "George Szell",
                   "sort-name": "Szell, George",
+                  "type": "Person",
                   "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
-                }
+                },
+                "joinphrase": "",
+                "name": "George Szell"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "1977",
-            "length": 840000,
-            "isrcs": []
+            "id": "048e8ffe-cbc2-4b87-bcfe-6cf696934a36",
+            "isrcs": [
+              "USSM16300971"
+            ],
+            "length": 601413,
+            "title": "Symphony no. 4 in B-flat major, op. 60: I. Adagio \u2014 Allegro vivace",
+            "video": false
           },
-          "title": "Symphony No. 5 in C minor, Op. 67: III - Scherzo: Allegro IV - Allegro",
-          "id": "38471f02-0663-4f64-921e-8a3cdedf8910",
+          "title": "Symphony No. 4 in B-flat major, Op. 60: I - Adagio; Allegro Vivace"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Beethoven, Ludwig van",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
-                "disambiguation": "German composer",
                 "country": "DE",
+                "disambiguation": "German composer",
+                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
                 "name": "Ludwig van Beethoven",
-                "type": "Person"
+                "sort-name": "Beethoven, Ludwig van",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
               "joinphrase": "; ",
               "name": "Beethoven"
             },
             {
-              "name": "Cleveland Orchestra",
-              "joinphrase": ", ",
               "artist": {
-                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5",
-                "sort-name": "Cleveland Orchestra, The",
-                "name": "The Cleveland Orchestra",
-                "type": "Orchestra",
                 "country": "US",
                 "disambiguation": "",
-                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa"
-              }
+                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                "name": "The Cleveland Orchestra",
+                "sort-name": "Cleveland Orchestra, The",
+                "type": "Orchestra",
+                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+              },
+              "joinphrase": ", ",
+              "name": "Cleveland Orchestra"
             },
             {
               "artist": {
-                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
-                "disambiguation": "conductor, pianist, composer",
                 "country": "US",
+                "disambiguation": "conductor, pianist, composer",
+                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
                 "name": "George Szell",
+                "sort-name": "Szell, George",
                 "type": "Person",
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "sort-name": "Szell, George"
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
               },
-              "name": "George Szell",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "George Szell"
             }
-          ]
+          ],
+          "id": "a9fae011-3a6d-4600-8a22-503f6aab5360",
+          "length": 585000,
+          "number": "A2",
+          "position": 2,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                  "name": "The Cleveland Orchestra",
+                  "sort-name": "Cleveland Orchestra, The",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "Cleveland Orchestra"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "conductor, pianist, composer",
+                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                  "name": "George Szell",
+                  "sort-name": "Szell, George",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "George Szell"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977",
+            "id": "1f628c28-bd54-4901-998b-1a4a4a41a319",
+            "isrcs": [
+              "USSM16300972"
+            ],
+            "length": 588226,
+            "title": "Symphony no. 4 in B-flat major, op. 60: II. Adagio",
+            "video": false
+          },
+          "title": "Symphony No. 4 in B-flat major, Op. 60: II - Adagio"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "DE",
+                "disambiguation": "German composer",
+                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+                "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "; ",
+              "name": "Beethoven"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                "name": "The Cleveland Orchestra",
+                "sort-name": "Cleveland Orchestra, The",
+                "type": "Orchestra",
+                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+              },
+              "joinphrase": ", ",
+              "name": "Cleveland Orchestra"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "conductor, pianist, composer",
+                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                "name": "George Szell",
+                "sort-name": "Szell, George",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "George Szell"
+            }
+          ],
+          "id": "1f574119-e0d0-4a88-82fd-3c8591f97087",
+          "length": 355000,
+          "number": "A3",
+          "position": 3,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                  "name": "The Cleveland Orchestra",
+                  "sort-name": "Cleveland Orchestra, The",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "Cleveland Orchestra"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "conductor, pianist, composer",
+                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                  "name": "George Szell",
+                  "sort-name": "Szell, George",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "George Szell"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977",
+            "id": "391b6276-c8ed-42f3-9a3b-7911724349e3",
+            "isrcs": [
+              "USSM16300973"
+            ],
+            "length": 355146,
+            "title": "Symphony no. 4 in B-flat major, op. 60: III. Allegro vivace \u2014 Un poco meno allegro",
+            "video": false
+          },
+          "title": "Symphony No. 4 in B-flat major, Op. 60: III - Allegro Vivace"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "DE",
+                "disambiguation": "German composer",
+                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+                "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "; ",
+              "name": "Beethoven"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                "name": "The Cleveland Orchestra",
+                "sort-name": "Cleveland Orchestra, The",
+                "type": "Orchestra",
+                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+              },
+              "joinphrase": ", ",
+              "name": "Cleveland Orchestra"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "conductor, pianist, composer",
+                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                "name": "George Szell",
+                "sort-name": "Szell, George",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "George Szell"
+            }
+          ],
+          "id": "71e2ef50-6700-4b7f-aced-0abc2146a012",
+          "length": 355000,
+          "number": "A4",
+          "position": 4,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                  "name": "The Cleveland Orchestra",
+                  "sort-name": "Cleveland Orchestra, The",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "Cleveland Orchestra"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "conductor, pianist, composer",
+                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                  "name": "George Szell",
+                  "sort-name": "Szell, George",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "George Szell"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977",
+            "id": "aa0dc869-a6b4-43c8-9f0b-837cd3fadf8d",
+            "isrcs": [
+              "USSM16300974"
+            ],
+            "length": 365026,
+            "title": "Symphony no. 4 in B-flat major, op. 60: IV. Allegro ma non troppo",
+            "video": false
+          },
+          "title": "Symphony No. 4 in B-flat major, Op. 60: IV - Allegro Ma Non Troppo"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "DE",
+                "disambiguation": "German composer",
+                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+                "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "; ",
+              "name": "Beethoven"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                "name": "The Cleveland Orchestra",
+                "sort-name": "Cleveland Orchestra, The",
+                "type": "Orchestra",
+                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+              },
+              "joinphrase": ", ",
+              "name": "Cleveland Orchestra"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "conductor, pianist, composer",
+                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                "name": "George Szell",
+                "sort-name": "Szell, George",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "George Szell"
+            }
+          ],
+          "id": "f9d1b56e-8c12-4ecf-b2a6-172e38ae1b15",
+          "length": 365000,
+          "number": "B1",
+          "position": 5,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                  "name": "The Cleveland Orchestra",
+                  "sort-name": "Cleveland Orchestra, The",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "The Cleveland Orchestra"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "conductor, pianist, composer",
+                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                  "name": "George Szell",
+                  "sort-name": "Szell, George",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "George Szell"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977",
+            "id": "d90cbb74-8409-4972-aa75-b7abb350dfbc",
+            "isrcs": [],
+            "length": 365000,
+            "title": "Symphony No. 5 in C minor, Op. 67: I - Allegro Con Brio",
+            "video": false
+          },
+          "title": "Symphony No. 5 in C minor, Op. 67: I - Allegro Con Brio"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "DE",
+                "disambiguation": "German composer",
+                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+                "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "; ",
+              "name": "Beethoven"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                "name": "The Cleveland Orchestra",
+                "sort-name": "Cleveland Orchestra, The",
+                "type": "Orchestra",
+                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+              },
+              "joinphrase": ", ",
+              "name": "Cleveland Orchestra"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "conductor, pianist, composer",
+                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                "name": "George Szell",
+                "sort-name": "Szell, George",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "George Szell"
+            }
+          ],
+          "id": "907b68b9-fe67-420d-b171-c426970bc30d",
+          "length": 599000,
+          "number": "B2",
+          "position": 6,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                  "name": "The Cleveland Orchestra",
+                  "sort-name": "Cleveland Orchestra, The",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "The Cleveland Orchestra"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "conductor, pianist, composer",
+                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                  "name": "George Szell",
+                  "sort-name": "Szell, George",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "George Szell"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977",
+            "id": "229753fd-7c2c-4d6a-ae4f-8c7af629cec4",
+            "isrcs": [],
+            "length": 599000,
+            "title": "Symphony No. 5 in C minor, Op. 67: II - Andante Con Moto",
+            "video": false
+          },
+          "title": "Symphony No. 5 in C minor, Op. 67: II - Andante Con Moto"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "DE",
+                "disambiguation": "German composer",
+                "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+                "name": "Ludwig van Beethoven",
+                "sort-name": "Beethoven, Ludwig van",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "; ",
+              "name": "Beethoven"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "",
+                "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                "name": "The Cleveland Orchestra",
+                "sort-name": "Cleveland Orchestra, The",
+                "type": "Orchestra",
+                "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+              },
+              "joinphrase": ", ",
+              "name": "Cleveland Orchestra"
+            },
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "conductor, pianist, composer",
+                "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                "name": "George Szell",
+                "sort-name": "Szell, George",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "George Szell"
+            }
+          ],
+          "id": "38471f02-0663-4f64-921e-8a3cdedf8910",
+          "length": 840000,
+          "number": "B3",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "",
+                  "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+                  "name": "The Cleveland Orchestra",
+                  "sort-name": "Cleveland Orchestra, The",
+                  "type": "Orchestra",
+                  "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+                },
+                "joinphrase": ", ",
+                "name": "The Cleveland Orchestra"
+              },
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "conductor, pianist, composer",
+                  "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+                  "name": "George Szell",
+                  "sort-name": "Szell, George",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "George Szell"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1977",
+            "id": "b63ce3ff-0b25-40a2-a374-6cc95a120e09",
+            "isrcs": [],
+            "length": 840000,
+            "title": "Symphony No. 5 in C minor, Op. 67: III - Scherzo: Allegro IV - Allegro",
+            "video": false
+          },
+          "title": "Symphony No. 5 in C minor, Op. 67: III - Scherzo: Allegro IV - Allegro"
         }
-      ],
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
-      "title": "",
-      "position": 1,
-      "format": "12\" Vinyl",
-      "id": "50a8ed69-ce0e-3428-8853-4b243d846c48",
-      "track-offset": 0
+      ]
     }
   ],
-  "disambiguation": ""
+  "packaging": "Cardboard/Paper Sleeve",
+  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+  "quality": "normal",
+  "release-events": [
+    {
+      "area": null,
+      "date": "1977"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "DE",
+          "disambiguation": "German composer",
+          "id": "1f9df192-a621-4f54-8850-2c5373b7eac9",
+          "name": "Ludwig van Beethoven",
+          "sort-name": "Beethoven, Ludwig van",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "; ",
+        "name": "Beethoven"
+      },
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "",
+          "id": "f33b188e-b80f-4058-92ca-0e30c04ad2fa",
+          "name": "The Cleveland Orchestra",
+          "sort-name": "Cleveland Orchestra, The",
+          "type": "Orchestra",
+          "type-id": "a0b36c92-3eb1-3839-a4f9-4799823f54a5"
+        },
+        "joinphrase": ", ",
+        "name": "Cleveland Orchestra"
+      },
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "conductor, pianist, composer",
+          "id": "642116e0-69e6-48a8-a19d-f272cb5b7756",
+          "name": "George Szell",
+          "sort-name": "Szell, George",
+          "type": "Person",
+          "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+        },
+        "joinphrase": "",
+        "name": "George Szell"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1977",
+    "id": "b7f65937-646e-4039-a182-fb54cb4d5039",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Conducts Beethoven-Symphony No. 5; Symphony No. 4"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Conducts Beethoven-Symphony No. 5; Symphony No. 4"
 }

--- a/scripts/eval_matching/corpus/eval_release_f4469159.json
+++ b/scripts/eval_matching/corpus/eval_release_f4469159.json
@@ -2,797 +2,797 @@
   "artist-credit": [
     {
       "artist": {
-        "sort-name": "Nirvana",
-        "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-        "type": "Group",
-        "disambiguation": "1980s\u20131990s US grunge band",
         "country": "US",
+        "disambiguation": "1980s\u20131990s US grunge band",
+        "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
         "name": "Nirvana",
+        "sort-name": "Nirvana",
+        "type": "Group",
         "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
       },
-      "name": "Nirvana",
-      "joinphrase": ""
+      "joinphrase": "",
+      "name": "Nirvana"
     }
   ],
-  "text-representation": {
-    "language": "eng",
-    "script": "Latn"
+  "asin": null,
+  "barcode": "720642472729",
+  "country": "XE",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": true,
+    "count": 10,
+    "darkened": false,
+    "front": true
   },
   "date": "1994-10-31",
+  "disambiguation": "Disctronics S pressing, BIEM/GEMA",
+  "id": "f4469159-1395-40b5-81e6-a507e2ad34ef",
   "label-info": [
     {
       "catalog-number": "GED 24727",
       "label": {
-        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
-        "sort-name": "Geffen Records",
         "disambiguation": "",
-        "name": "Geffen Records",
-        "type": "Production",
+        "id": "0fadc2ce-f7de-4e27-bbe6-612b317e716b",
         "label-code": 7266,
+        "name": "Geffen Records",
+        "sort-name": "Geffen Records",
+        "type": "Production",
         "type-id": "a2426aab-2dd4-339c-b47d-b4923a241678"
       }
     }
   ],
-  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
-  "barcode": "720642472729",
-  "country": "XE",
-  "disambiguation": "Disctronics S pressing, BIEM/GEMA",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "release-events": [
-    {
-      "date": "1994-10-31",
-      "area": {
-        "sort-name": "Europe",
-        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
-        "type-id": null,
-        "iso-3166-1-codes": [
-          "XE"
-        ],
-        "type": null,
-        "name": "Europe",
-        "disambiguation": ""
-      }
-    },
-    {
-      "area": {
-        "type": null,
-        "name": "United Kingdom",
-        "disambiguation": "",
-        "type-id": null,
-        "iso-3166-1-codes": [
-          "GB"
-        ],
-        "sort-name": "United Kingdom",
-        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed"
-      },
-      "date": "1994-10-31"
-    }
-  ],
-  "release-group": {
-    "primary-type": "Album",
-    "disambiguation": "",
-    "secondary-types": [
-      "Live"
-    ],
-    "artist-credit": [
-      {
-        "artist": {
-          "type": "Group",
-          "country": "US",
-          "name": "Nirvana",
-          "disambiguation": "1980s\u20131990s US grunge band",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "sort-name": "Nirvana",
-          "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-        },
-        "name": "Nirvana",
-        "joinphrase": ""
-      }
-    ],
-    "secondary-type-ids": [
-      "6fd474e2-6b58-3102-9d17-d6f7eb7da0a0"
-    ],
-    "id": "fb3770f6-83fb-32b7-85c4-1f522a92287e",
-    "title": "MTV Unplugged in New York",
-    "first-release-date": "1994-10-31",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc"
-  },
-  "id": "f4469159-1395-40b5-81e6-a507e2ad34ef",
-  "packaging": "Jewel Case",
-  "title": "MTV Unplugged in New York",
-  "asin": null,
   "media": [
     {
-      "track-count": 14,
+      "format": "CD",
+      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
       "id": "a7215e2a-88dd-45f9-afdc-7208f7df5a2a",
+      "position": 1,
+      "title": "",
+      "track-count": 14,
+      "track-offset": 0,
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
           "id": "da12fabf-13cf-4167-a706-5b2acabede83",
+          "length": 218000,
+          "number": "1",
           "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
             "first-release-date": "1994-10-24",
+            "id": "d550b70a-31cd-4c23-a7c3-0f1488b84417",
             "isrcs": [
               "USGF19972701"
             ],
             "length": 218000,
             "title": "About a Girl",
-            "video": false,
-            "id": "d550b70a-31cd-4c23-a7c3-0f1488b84417",
+            "video": false
+          },
+          "title": "About a Girl"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "6704365c-de01-4794-84ca-09e7cb3b07a6",
+          "length": 253893,
+          "number": "2",
+          "position": 2,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "1980s\u20131990s US grunge band",
                   "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                   "name": "Nirvana",
-                  "type": "Group"
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Nirvana"
               }
             ],
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA"
-          },
-          "length": 218000,
-          "title": "About a Girl",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Nirvana",
-              "artist": {
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana",
-                "country": "US",
-                "name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "number": "1"
-        },
-        {
-          "position": 2,
-          "id": "6704365c-de01-4794-84ca-09e7cb3b07a6",
-          "recording": {
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
+            "id": "9738401c-5720-4569-8f56-9780b8b0ab2e",
             "isrcs": [
               "USGF19972702"
             ],
-            "title": "Come as You Are",
             "length": 253893,
-            "first-release-date": "1994-10-31",
+            "title": "Come as You Are",
+            "video": false
+          },
+          "title": "Come as You Are"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "3076e961-4cb0-4931-b1fa-7f614b6ba9e2",
+          "length": 277266,
+          "number": "3",
+          "position": 3,
+          "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Nirvana",
                 "artist": {
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
                   "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                   "name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band"
-                }
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
             "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
-            "video": false,
-            "id": "9738401c-5720-4569-8f56-9780b8b0ab2e"
-          },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Nirvana",
-              "artist": {
-                "sort-name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "country": "US",
-                "name": "Nirvana"
-              }
-            }
-          ],
-          "title": "Come as You Are",
-          "length": 253893,
-          "number": "2"
-        },
-        {
-          "number": "3",
-          "length": 277266,
-          "title": "Jesus Doesn\u2019t Want Me for a Sunbeam",
-          "artist-credit": [
-            {
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "country": "US",
-                "name": "Nirvana",
-                "type": "Group",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana"
-              },
-              "name": "Nirvana",
-              "joinphrase": ""
-            }
-          ],
-          "recording": {
+            "first-release-date": "1994-10-31",
+            "id": "b890f7e9-e1c9-441a-a072-6a1975b82875",
             "isrcs": [
               "USGF19972703"
             ],
-            "title": "Jesus Doesn\u2019t Want Me for a Sunbeam",
             "length": 277266,
-            "first-release-date": "1994-10-31",
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Nirvana",
-                "artist": {
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type": "Group",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "country": "US",
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "id": "b890f7e9-e1c9-441a-a072-6a1975b82875",
+            "title": "Jesus Doesn\u2019t Want Me for a Sunbeam",
             "video": false
           },
-          "position": 3,
-          "id": "3076e961-4cb0-4931-b1fa-7f614b6ba9e2"
+          "title": "Jesus Doesn\u2019t Want Me for a Sunbeam"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "27a7af87-e918-407a-8c3e-e4b4e80387d1",
+          "length": 261106,
+          "number": "4",
+          "position": 4,
           "recording": {
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
             "artist-credit": [
               {
                 "artist": {
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "name": "Nirvana",
                   "country": "US",
                   "disambiguation": "1980s\u20131990s US grunge band",
-                  "type": "Group"
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Nirvana"
               }
             ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
             "id": "fed94ef8-3d92-4fac-a721-5d9a50469628",
-            "video": false,
-            "title": "The Man Who Sold the World",
-            "length": 261093,
             "isrcs": [
               "USGF19972704"
             ],
-            "first-release-date": "1994-10-31"
+            "length": 261093,
+            "title": "The Man Who Sold the World",
+            "video": false
           },
-          "position": 4,
-          "id": "27a7af87-e918-407a-8c3e-e4b4e80387d1",
-          "number": "4",
-          "length": 261106,
-          "title": "The Man Who Sold the World",
+          "title": "The Man Who Sold the World"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band",
                 "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "name": "Nirvana",
+                "sort-name": "Nirvana",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Nirvana"
             }
-          ]
-        },
-        {
-          "number": "5",
-          "length": 220493,
-          "title": "Pennyroyal Tea",
-          "artist-credit": [
-            {
-              "artist": {
-                "type": "Group",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "country": "US",
-                "name": "Nirvana",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "sort-name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-              },
-              "joinphrase": "",
-              "name": "Nirvana"
-            }
           ],
+          "id": "39ea040e-ce8a-483a-8df1-317260fecf3b",
+          "length": 220493,
+          "number": "5",
+          "position": 5,
           "recording": {
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
             "artist-credit": [
               {
                 "artist": {
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "1980s\u20131990s US grunge band",
                   "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                   "name": "Nirvana",
-                  "type": "Group"
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
                 "joinphrase": "",
                 "name": "Nirvana"
               }
             ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
             "id": "4741ce2a-636c-4eaa-9507-eb1c37ad9c5d",
-            "video": false,
             "isrcs": [
               "USGF19972705"
             ],
-            "title": "Pennyroyal Tea",
             "length": 220493,
-            "first-release-date": "1994-10-31"
-          },
-          "position": 5,
-          "id": "39ea040e-ce8a-483a-8df1-317260fecf3b"
-        },
-        {
-          "recording": {
-            "title": "Dumb",
-            "length": 172933,
-            "isrcs": [
-              "USGF19972706"
-            ],
-            "first-release-date": "1994-10-31",
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
-            "artist-credit": [
-              {
-                "name": "Nirvana",
-                "joinphrase": "",
-                "artist": {
-                  "type": "Group",
-                  "country": "US",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-                }
-              }
-            ],
-            "id": "656cfcb3-5870-4db8-8510-6cb598b47aad",
+            "title": "Pennyroyal Tea",
             "video": false
           },
-          "position": 6,
-          "id": "efdcb494-8bf7-4718-a624-718ad19f05b0",
-          "number": "6",
+          "title": "Pennyroyal Tea"
+        },
+        {
           "artist-credit": [
             {
               "artist": {
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band",
                 "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "name": "Nirvana",
+                "sort-name": "Nirvana",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Nirvana",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Nirvana"
             }
           ],
+          "id": "efdcb494-8bf7-4718-a624-718ad19f05b0",
           "length": 172933,
-          "title": "Dumb"
-        },
-        {
+          "number": "6",
+          "position": 6,
           "recording": {
-            "id": "31ea5270-bbcf-4e51-aa53-5cb84cc4c99e",
-            "video": false,
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
             "artist-credit": [
               {
                 "artist": {
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band",
                   "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                   "name": "Nirvana",
+                  "sort-name": "Nirvana",
                   "type": "Group",
                   "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Nirvana",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
             "first-release-date": "1994-10-31",
+            "id": "656cfcb3-5870-4db8-8510-6cb598b47aad",
+            "isrcs": [
+              "USGF19972706"
+            ],
+            "length": 172933,
+            "title": "Dumb",
+            "video": false
+          },
+          "title": "Dumb"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "abadfd88-250b-4a48-8de7-4ee65d551c1f",
+          "length": 196466,
+          "number": "7",
+          "position": 7,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
+            "id": "31ea5270-bbcf-4e51-aa53-5cb84cc4c99e",
             "isrcs": [
               "USGF19972707"
             ],
             "length": 196466,
-            "title": "Polly"
+            "title": "Polly",
+            "video": false
           },
-          "position": 7,
-          "id": "abadfd88-250b-4a48-8de7-4ee65d551c1f",
-          "number": "7",
-          "length": 196466,
-          "title": "Polly",
-          "artist-credit": [
-            {
-              "name": "Nirvana",
-              "joinphrase": "",
-              "artist": {
-                "name": "Nirvana",
-                "country": "US",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana"
-              }
-            }
-          ]
+          "title": "Polly"
         },
         {
-          "position": 8,
-          "id": "befec6be-bacc-4beb-8a08-f57ef7a5d2c2",
-          "recording": {
-            "video": false,
-            "id": "6e3a9fd2-3660-49b2-97cc-9cd9c03744df",
-            "artist-credit": [
-              {
-                "name": "Nirvana",
-                "joinphrase": "",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "country": "US",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "name": "Nirvana",
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-                }
-              }
-            ],
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
-            "first-release-date": "1994-10-31",
-            "isrcs": [
-              "USGF19972708"
-            ],
-            "length": 224733,
-            "title": "On a Plain"
-          },
           "artist-credit": [
             {
-              "name": "Nirvana",
-              "joinphrase": "",
               "artist": {
                 "country": "US",
                 "disambiguation": "1980s\u20131990s US grunge band",
-                "name": "Nirvana",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana"
-              }
-            }
-          ],
-          "length": 224733,
-          "title": "On a Plain",
-          "number": "8"
-        },
-        {
-          "recording": {
-            "first-release-date": "1994-10-31",
-            "title": "Something in the Way",
-            "length": 241533,
-            "isrcs": [
-              "USGF19972709"
-            ],
-            "video": false,
-            "id": "c15254c7-79ae-4d39-81b7-61fdddadc5bf",
-            "artist-credit": [
-              {
-                "joinphrase": "",
                 "name": "Nirvana",
-                "artist": {
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "country": "US",
-                  "name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band"
-                }
-              }
-            ],
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA"
-          },
-          "position": 9,
-          "id": "845f69e2-e99f-42f9-b72d-41026a7ca74c",
-          "number": "9",
-          "artist-credit": [
-            {
-              "name": "Nirvana",
-              "joinphrase": "",
-              "artist": {
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "sort-name": "Nirvana",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "US",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "name": "Nirvana",
-                "type": "Group"
-              }
-            }
-          ],
-          "title": "Something in the Way",
-          "length": 241533
-        },
-        {
-          "number": "10",
-          "artist-credit": [
-            {
-              "artist": {
-                "country": "US",
-                "name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band",
                 "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Nirvana"
             }
           ],
-          "length": 218133,
-          "title": "Plateau",
+          "id": "befec6be-bacc-4beb-8a08-f57ef7a5d2c2",
+          "length": 224733,
+          "number": "8",
+          "position": 8,
           "recording": {
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
             "artist-credit": [
               {
-                "name": "Nirvana",
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
                   "country": "US",
                   "disambiguation": "1980s\u20131990s US grunge band",
-                  "name": "Nirvana"
-                }
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
               }
             ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
+            "id": "6e3a9fd2-3660-49b2-97cc-9cd9c03744df",
+            "isrcs": [
+              "USGF19972708"
+            ],
+            "length": 224733,
+            "title": "On a Plain",
+            "video": false
+          },
+          "title": "On a Plain"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "845f69e2-e99f-42f9-b72d-41026a7ca74c",
+          "length": 241533,
+          "number": "9",
+          "position": 9,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
+            "id": "c15254c7-79ae-4d39-81b7-61fdddadc5bf",
+            "isrcs": [
+              "USGF19972709"
+            ],
+            "length": 241533,
+            "title": "Something in the Way",
+            "video": false
+          },
+          "title": "Something in the Way"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "392e53a9-15cb-44d4-8853-cca8b9840331",
+          "length": 218133,
+          "number": "10",
+          "position": 10,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
             "id": "7e630960-3960-4f7f-97e2-378d58fcd6ce",
-            "video": false,
             "isrcs": [
               "USGF19972710"
             ],
             "length": 218133,
             "title": "Plateau",
-            "first-release-date": "1994-10-31"
+            "video": false
           },
-          "id": "392e53a9-15cb-44d4-8853-cca8b9840331",
-          "position": 10
-        },
-        {
-          "length": 206173,
-          "title": "Oh Me",
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "sort-name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band",
-                "country": "US",
-                "name": "Nirvana",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              },
-              "name": "Nirvana",
-              "joinphrase": ""
-            }
-          ],
-          "number": "11",
-          "position": 11,
-          "id": "91454f2e-23b7-49db-bd22-3acf07eec112",
-          "recording": {
-            "first-release-date": "1994-10-31",
-            "title": "Oh Me",
-            "length": 206173,
-            "isrcs": [
-              "USGF19972711"
-            ],
-            "video": false,
-            "id": "c727762f-75de-46ec-b28e-8097c1f3881a",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Nirvana",
-                "artist": {
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "US",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "name": "Nirvana",
-                  "type": "Group"
-                }
-              }
-            ],
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA"
-          }
+          "title": "Plateau"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
                 "country": "US",
                 "disambiguation": "1980s\u20131990s US grunge band",
-                "name": "Nirvana",
-                "sort-name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da"
-              },
-              "name": "Nirvana",
-              "joinphrase": ""
-            }
-          ],
-          "length": 175960,
-          "title": "Lake of Fire",
-          "number": "12",
-          "position": 12,
-          "id": "f0fa0747-b9cb-4521-9203-4486d88fbbe0",
-          "recording": {
-            "id": "6d054703-b851-4671-a4fa-6fa75222b45f",
-            "video": false,
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "country": "US",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "name": "Nirvana",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "joinphrase": "",
-                "name": "Nirvana"
-              }
-            ],
-            "first-release-date": "1994-10-31",
-            "isrcs": [
-              "USGF19972712"
-            ],
-            "title": "Lake of Fire",
-            "length": 175960
-          }
-        },
-        {
-          "recording": {
-            "video": false,
-            "id": "18eb6dcd-2377-4260-a818-a0b958bd21c2",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Nirvana",
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "country": "US",
-                  "name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band"
-                },
-                "joinphrase": "",
-                "name": "Nirvana"
-              }
-            ],
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
-            "first-release-date": "1994-10-31",
-            "isrcs": [
-              "USGF19972713"
-            ],
-            "length": 263240,
-            "title": "All Apologies"
-          },
-          "position": 13,
-          "id": "0d39aeca-74e0-48c4-a4d5-6e673350340a",
-          "number": "13",
-          "artist-credit": [
-            {
-              "name": "Nirvana",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Nirvana",
                 "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
                 "name": "Nirvana",
-                "country": "US",
-                "disambiguation": "1980s\u20131990s US grunge band"
-              }
-            }
-          ],
-          "length": 263240,
-          "title": "All Apologies"
-        },
-        {
-          "recording": {
-            "first-release-date": "1994-10-31",
-            "length": 306066,
-            "title": "Where Did You Sleep Last Night",
-            "isrcs": [
-              "USGF19972714"
-            ],
-            "video": false,
-            "id": "49d5edae-4f85-4b40-bb30-30b4f71dbbae",
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
-                  "sort-name": "Nirvana",
-                  "disambiguation": "1980s\u20131990s US grunge band",
-                  "country": "US",
-                  "name": "Nirvana",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Nirvana",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA"
-          },
-          "position": 14,
-          "id": "8e66dfef-d69c-40dd-80dd-66184ec4d209",
-          "number": "14",
-          "artist-credit": [
-            {
-              "artist": {
                 "sort-name": "Nirvana",
-                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
                 "type": "Group",
-                "country": "US",
-                "name": "Nirvana",
-                "disambiguation": "1980s\u20131990s US grunge band",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Nirvana"
             }
           ],
-          "title": "Where Did You Sleep Last Night",
-          "length": 306066
+          "id": "91454f2e-23b7-49db-bd22-3acf07eec112",
+          "length": 206173,
+          "number": "11",
+          "position": 11,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
+            "id": "c727762f-75de-46ec-b28e-8097c1f3881a",
+            "isrcs": [
+              "USGF19972711"
+            ],
+            "length": 206173,
+            "title": "Oh Me",
+            "video": false
+          },
+          "title": "Oh Me"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "f0fa0747-b9cb-4521-9203-4486d88fbbe0",
+          "length": 175960,
+          "number": "12",
+          "position": 12,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
+            "id": "6d054703-b851-4671-a4fa-6fa75222b45f",
+            "isrcs": [
+              "USGF19972712"
+            ],
+            "length": 175960,
+            "title": "Lake of Fire",
+            "video": false
+          },
+          "title": "Lake of Fire"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "0d39aeca-74e0-48c4-a4d5-6e673350340a",
+          "length": 263240,
+          "number": "13",
+          "position": 13,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
+            "id": "18eb6dcd-2377-4260-a818-a0b958bd21c2",
+            "isrcs": [
+              "USGF19972713"
+            ],
+            "length": 263240,
+            "title": "All Apologies",
+            "video": false
+          },
+          "title": "All Apologies"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "US",
+                "disambiguation": "1980s\u20131990s US grunge band",
+                "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                "name": "Nirvana",
+                "sort-name": "Nirvana",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Nirvana"
+            }
+          ],
+          "id": "8e66dfef-d69c-40dd-80dd-66184ec4d209",
+          "length": 306066,
+          "number": "14",
+          "position": 14,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "US",
+                  "disambiguation": "1980s\u20131990s US grunge band",
+                  "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+                  "name": "Nirvana",
+                  "sort-name": "Nirvana",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Nirvana"
+              }
+            ],
+            "disambiguation": "live, 1993\u201011\u201018: Sony Studios, New York, NY, USA",
+            "first-release-date": "1994-10-31",
+            "id": "49d5edae-4f85-4b40-bb30-30b4f71dbbae",
+            "isrcs": [
+              "USGF19972714"
+            ],
+            "length": 306066,
+            "title": "Where Did You Sleep Last Night",
+            "video": false
+          },
+          "title": "Where Did You Sleep Last Night"
         }
-      ],
-      "format": "CD",
-      "format-id": "9712d52a-4509-3d4b-a1a2-67c88c643e31",
-      "title": "",
-      "track-offset": 0,
-      "position": 1
+      ]
     }
   ],
-  "status": "Official",
+  "packaging": "Jewel Case",
+  "packaging-id": "ec27701a-4a22-37f4-bfac-6616e0f9750a",
   "quality": "normal",
-  "cover-art-archive": {
-    "back": true,
-    "front": true,
-    "darkened": false,
-    "count": 10,
-    "artwork": true
-  }
+  "release-events": [
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "89a675c2-3e37-3518-b83c-418bad59a85a",
+        "iso-3166-1-codes": [
+          "XE"
+        ],
+        "name": "Europe",
+        "sort-name": "Europe",
+        "type": null,
+        "type-id": null
+      },
+      "date": "1994-10-31"
+    },
+    {
+      "area": {
+        "disambiguation": "",
+        "id": "8a754a16-0027-3a29-b6d7-2b40ea0481ed",
+        "iso-3166-1-codes": [
+          "GB"
+        ],
+        "name": "United Kingdom",
+        "sort-name": "United Kingdom",
+        "type": null,
+        "type-id": null
+      },
+      "date": "1994-10-31"
+    }
+  ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "US",
+          "disambiguation": "1980s\u20131990s US grunge band",
+          "id": "5b11f4ce-a62d-471e-81fc-a69a8278c7da",
+          "name": "Nirvana",
+          "sort-name": "Nirvana",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Nirvana"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1994-10-31",
+    "id": "fb3770f6-83fb-32b7-85c4-1f522a92287e",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [
+      "6fd474e2-6b58-3102-9d17-d6f7eb7da0a0"
+    ],
+    "secondary-types": [
+      "Live"
+    ],
+    "title": "MTV Unplugged in New York"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "MTV Unplugged in New York"
 }

--- a/scripts/eval_matching/corpus/eval_release_f77eeaef.json
+++ b/scripts/eval_matching/corpus/eval_release_f77eeaef.json
@@ -1,311 +1,311 @@
 {
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "CA",
+        "disambiguation": "",
+        "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+        "name": "Godspeed You! Black Emperor",
+        "sort-name": "Godspeed You! Black Emperor",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Godspeed You! Black Emperor"
+    }
+  ],
+  "asin": null,
+  "barcode": "887396825833",
+  "country": "XW",
+  "cover-art-archive": {
+    "artwork": true,
+    "back": false,
+    "count": 1,
+    "darkened": false,
+    "front": true
+  },
+  "date": "2017-09-18",
+  "disambiguation": "",
   "id": "f77eeaef-878e-4db3-ae65-5161cf929f14",
   "label-info": [
     {
       "catalog-number": "KRANK 043",
       "label": {
         "disambiguation": "",
+        "id": "4536e738-6350-4cae-af70-79d56d106c45",
+        "label-code": null,
+        "name": "kranky",
         "sort-name": "kranky",
         "type": "Original Production",
-        "name": "kranky",
-        "label-code": null,
-        "id": "4536e738-6350-4cae-af70-79d56d106c45",
         "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
       }
     }
   ],
-  "release-group": {
-    "id": "3822abb6-ca53-3ae1-a4ec-7718cb321e9b",
-    "first-release-date": "2000-10-09",
-    "secondary-types": [],
-    "primary-type": "Album",
-    "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!",
-    "disambiguation": "",
-    "secondary-type-ids": [],
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "artist-credit": [
-      {
-        "joinphrase": "",
-        "name": "Godspeed You Black Emperor!",
-        "artist": {
-          "type": "Group",
-          "name": "Godspeed You! Black Emperor",
-          "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-          "country": "CA",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-          "disambiguation": "",
-          "sort-name": "Godspeed You! Black Emperor"
-        }
-      }
-    ]
-  },
-  "status": "Official",
-  "quality": "normal",
-  "disambiguation": "",
-  "release-events": [
-    {
-      "date": "2017-09-18",
-      "area": {
-        "type-id": null,
-        "id": "525d4e18-3d00-31b9-a58b-a146a916de8f",
-        "type": null,
-        "name": "[Worldwide]",
-        "iso-3166-1-codes": [
-          "XW"
-        ],
-        "disambiguation": "",
-        "sort-name": "[Worldwide]"
-      }
-    }
-  ],
-  "cover-art-archive": {
-    "front": true,
-    "back": false,
-    "darkened": false,
-    "count": 1,
-    "artwork": true
-  },
-  "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b",
-  "date": "2017-09-18",
-  "country": "XW",
-  "title": "Lift Your Skinny Fists Like Antennas to Heaven",
-  "text-representation": {
-    "script": "Latn",
-    "language": "eng"
-  },
-  "asin": null,
   "media": [
     {
-      "track-offset": 0,
-      "position": 1,
-      "title": "",
       "format": "Digital Media",
       "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
+      "id": "9b7181b5-8287-3b0f-93eb-cbffd746946f",
+      "position": 1,
+      "title": "",
+      "track-count": 2,
+      "track-offset": 0,
       "tracks": [
         {
-          "number": "1",
-          "position": 1,
-          "title": "Storm",
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
+                "country": "CA",
                 "disambiguation": "",
-                "sort-name": "Godspeed You! Black Emperor",
                 "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "type": "Group",
                 "name": "Godspeed You! Black Emperor",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "CA"
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Godspeed You Black Emperor!"
             }
           ],
+          "id": "c86854a9-e109-4e51-b862-255c617ae328",
           "length": 1352413,
+          "number": "1",
+          "position": 1,
           "recording": {
-            "disambiguation": "",
-            "title": "Storm",
             "artist-credit": [
               {
                 "artist": {
+                  "country": "CA",
                   "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "name": "Godspeed You! Black Emperor",
-                  "type": "Group",
                   "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "CA"
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Godspeed You Black Emperor!",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
               }
             ],
-            "length": 1352413,
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
+            "id": "519e6d2f-c762-48b1-8798-8f0299e11cc7",
             "isrcs": [
               "USI4R0401862"
             ],
-            "video": false,
-            "id": "519e6d2f-c762-48b1-8798-8f0299e11cc7",
-            "first-release-date": "2000-10-09"
+            "length": 1352413,
+            "title": "Storm",
+            "video": false
           },
-          "id": "c86854a9-e109-4e51-b862-255c617ae328"
+          "title": "Storm"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
           "id": "581e6ddc-4ab6-4c25-9335-50df92c7cd89",
+          "length": 1355946,
+          "number": "2",
+          "position": 2,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
             "id": "30d53b2b-dbd5-4975-bbdf-48986b4bd089",
             "isrcs": [
               "USI4R0401863"
             ],
-            "video": false,
-            "first-release-date": "2000-10-09",
-            "title": "Static",
-            "disambiguation": "",
             "length": 1355946,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Godspeed You Black Emperor!",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "country": "CA",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "name": "Godspeed You! Black Emperor",
-                  "type": "Group"
-                }
-              }
-            ]
+            "title": "Static",
+            "video": false
           },
-          "position": 2,
-          "title": "Static",
-          "number": "2",
-          "length": 1355946,
-          "artist-credit": [
-            {
-              "artist": {
-                "disambiguation": "",
-                "sort-name": "Godspeed You! Black Emperor",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "CA",
-                "type": "Group",
-                "name": "Godspeed You! Black Emperor",
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4"
-              },
-              "name": "Godspeed You Black Emperor!",
-              "joinphrase": ""
-            }
-          ]
+          "title": "Static"
         }
-      ],
-      "id": "9b7181b5-8287-3b0f-93eb-cbffd746946f",
-      "track-count": 2
+      ]
     },
     {
+      "format": "Digital Media",
+      "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
       "id": "a36b332a-5c4a-3701-8030-0f8c1105312e",
+      "position": 2,
+      "title": "",
       "track-count": 2,
       "track-offset": 0,
-      "position": 2,
-      "format": "Digital Media",
-      "title": "",
-      "format-id": "907a28d9-b3b2-3ef6-89a8-7b18d91d4794",
       "tracks": [
         {
-          "number": "1",
-          "title": "Sleep",
-          "position": 1,
           "artist-credit": [
             {
-              "joinphrase": "",
               "artist": {
-                "sort-name": "Godspeed You! Black Emperor",
-                "disambiguation": "",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "country": "CA",
+                "disambiguation": "",
                 "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
                 "type": "Group",
-                "name": "Godspeed You! Black Emperor"
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
+              "joinphrase": "",
               "name": "Godspeed You Black Emperor!"
             }
           ],
+          "id": "95b751c9-e04f-496b-8b22-68b795a2872d",
           "length": 1397000,
+          "number": "1",
+          "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "CA",
+                  "disambiguation": "",
+                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                  "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "2000-10-09",
             "id": "b8f1c93d-4273-4428-96cb-c38c6fb0d867",
             "isrcs": [
               "USI4R0401864"
             ],
-            "video": false,
-            "first-release-date": "2000-10-09",
-            "title": "Sleep",
-            "disambiguation": "",
             "length": 1397746,
+            "title": "Sleep",
+            "video": false
+          },
+          "title": "Sleep"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "CA",
+                "disambiguation": "",
+                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+                "name": "Godspeed You! Black Emperor",
+                "sort-name": "Godspeed You! Black Emperor",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Godspeed You Black Emperor!"
+            }
+          ],
+          "id": "13424d71-e7d2-45d5-8c0e-fa636599696e",
+          "length": 1137000,
+          "number": "2",
+          "position": 2,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "CA",
+                  "disambiguation": "",
                   "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
                   "name": "Godspeed You! Black Emperor",
+                  "sort-name": "Godspeed You! Black Emperor",
                   "type": "Group",
-                  "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor"
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Godspeed You Black Emperor!",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Godspeed You Black Emperor!"
               }
-            ]
-          },
-          "id": "95b751c9-e04f-496b-8b22-68b795a2872d"
-        },
-        {
-          "recording": {
+            ],
+            "disambiguation": "",
             "first-release-date": "2000-10-09",
             "id": "5fb00c2b-5bc9-420a-882a-cc024d137a08",
             "isrcs": [
               "USI4R0401865"
             ],
-            "video": false,
             "length": 1137586,
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "artist": {
-                  "disambiguation": "",
-                  "sort-name": "Godspeed You! Black Emperor",
-                  "name": "Godspeed You! Black Emperor",
-                  "type": "Group",
-                  "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "CA"
-                },
-                "name": "Godspeed You Black Emperor!"
-              }
-            ],
             "title": "Antennas to Heaven",
-            "disambiguation": ""
+            "video": false
           },
-          "id": "13424d71-e7d2-45d5-8c0e-fa636599696e",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Godspeed You Black Emperor!",
-              "artist": {
-                "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
-                "type": "Group",
-                "name": "Godspeed You! Black Emperor",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "CA",
-                "sort-name": "Godspeed You! Black Emperor",
-                "disambiguation": ""
-              }
-            }
-          ],
-          "length": 1137000,
-          "number": "2",
-          "title": "Like Antennas to Heaven\u2026",
-          "position": 2
+          "title": "Like Antennas to Heaven\u2026"
         }
       ]
     }
   ],
-  "barcode": "887396825833",
-  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "artist-credit": [
+  "packaging": "None",
+  "packaging-id": "119eba76-b343-3e02-a292-f0f00644bb9b",
+  "quality": "normal",
+  "release-events": [
     {
-      "name": "Godspeed You! Black Emperor",
-      "artist": {
+      "area": {
         "disambiguation": "",
-        "sort-name": "Godspeed You! Black Emperor",
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "country": "CA",
-        "name": "Godspeed You! Black Emperor",
-        "type": "Group",
-        "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4"
+        "id": "525d4e18-3d00-31b9-a58b-a146a916de8f",
+        "iso-3166-1-codes": [
+          "XW"
+        ],
+        "name": "[Worldwide]",
+        "sort-name": "[Worldwide]",
+        "type": null,
+        "type-id": null
       },
-      "joinphrase": ""
+      "date": "2017-09-18"
     }
   ],
-  "packaging": "None"
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "CA",
+          "disambiguation": "",
+          "id": "3648db01-b29d-4ab9-835c-83f6a5068fe4",
+          "name": "Godspeed You! Black Emperor",
+          "sort-name": "Godspeed You! Black Emperor",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Godspeed You Black Emperor!"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "2000-10-09",
+    "id": "3822abb6-ca53-3ae1-a4ec-7718cb321e9b",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [],
+    "secondary-types": [],
+    "title": "Lift Yr. Skinny Fists Like Antennas to Heaven!"
+  },
+  "status": "Official",
+  "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
+  "text-representation": {
+    "language": "eng",
+    "script": "Latn"
+  },
+  "title": "Lift Your Skinny Fists Like Antennas to Heaven"
 }

--- a/scripts/eval_matching/corpus/eval_release_fcb78d0d.json
+++ b/scripts/eval_matching/corpus/eval_release_fcb78d0d.json
@@ -1,23 +1,107 @@
 {
+  "artist-credit": [
+    {
+      "artist": {
+        "country": "GB",
+        "disambiguation": "UK rock group",
+        "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+        "name": "Queen",
+        "sort-name": "Queen",
+        "type": "Group",
+        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+      },
+      "joinphrase": "",
+      "name": "Queen"
+    }
+  ],
+  "asin": null,
+  "barcode": "",
+  "country": "DE",
   "cover-art-archive": {
     "artwork": true,
+    "back": false,
     "count": 1,
-    "front": true,
     "darkened": false,
-    "back": false
+    "front": true
   },
-  "quality": "normal",
-  "status": "Official",
+  "date": "1981",
+  "disambiguation": "",
+  "id": "fcb78d0d-8067-4b93-ae58-1e4347e20216",
+  "label-info": [
+    {
+      "catalog-number": "1C 064-78 071",
+      "label": {
+        "disambiguation": "EMI Records, or EMI Music only if there is no other imprint",
+        "id": "c029628b-6633-439e-bcee-ed02e8a338f7",
+        "label-code": 542,
+        "name": "EMI",
+        "sort-name": "EMI",
+        "type": "Original Production",
+        "type-id": "7aaa37fe-2def-3476-b359-80245850062d"
+      }
+    },
+    {
+      "catalog-number": "1C 064-78 071",
+      "label": {
+        "disambiguation": "more likely the company trademark of EMI Electrola GmbH than an imprint",
+        "id": "04eb3226-fd4c-4dfb-ae02-c888f0a0e977",
+        "label-code": 193,
+        "name": "EMI Electrola",
+        "sort-name": "EMI Electrola",
+        "type": null,
+        "type-id": null
+      }
+    }
+  ],
   "media": [
     {
-      "track-count": 18,
+      "format": "12\" Vinyl",
+      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
       "id": "9e718827-96ff-3a3c-9c6b-b9c586a9b763",
+      "position": 1,
+      "title": "",
+      "track-count": 18,
+      "track-offset": 0,
       "tracks": [
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "285afac0-7a59-3cd5-8ca1-186c53d0ec30",
+          "length": 332000,
+          "number": "A1",
           "position": 1,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1975-11-21",
+            "id": "b1a9c0e9-d987-4042-ae91-78d6a3267d69",
             "isrcs": [
               "GBCEE0100112",
               "GBCEE0500364",
@@ -27,86 +111,51 @@
               "GBCEE9800022",
               "GBUM71029604"
             ],
-            "title": "Bohemian Rhapsody",
             "length": 355106,
-            "video": false,
-            "id": "b1a9c0e9-d987-4042-ae91-78d6a3267d69",
-            "artist-credit": [
-              {
-                "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "country": "GB",
-                  "name": "Queen",
-                  "disambiguation": "UK rock group"
-                },
-                "joinphrase": "",
-                "name": "Queen"
-              }
-            ],
-            "disambiguation": ""
+            "title": "Bohemian Rhapsody",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "joinphrase": "",
-              "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "name": "Queen",
-                "type": "Group"
-              }
-            }
-          ],
-          "title": "Bohemian Rhapsody",
-          "length": 332000,
-          "number": "A1"
+          "title": "Bohemian Rhapsody"
         },
         {
-          "number": "A2",
-          "length": 213000,
-          "title": "Another One Bites the Dust",
           "artist-credit": [
             {
               "artist": {
-                "type": "Group",
-                "disambiguation": "UK rock group",
                 "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Queen"
             }
           ],
+          "id": "70717714-9a03-3c1e-b926-e701e3528442",
+          "length": 213000,
+          "number": "A2",
+          "position": 2,
           "recording": {
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
                   "country": "GB",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1980-06-24",
             "id": "6b235773-16bd-4fc5-b57e-c966f9d1db6d",
-            "title": "Another One Bites the Dust",
-            "length": 215053,
             "isrcs": [
               "GBCEE0100113",
               "GBCEE0900132",
@@ -116,34 +165,51 @@
               "GBUM71029605",
               "USRHD0532298"
             ],
-            "first-release-date": "1980-06-24"
+            "length": 215053,
+            "title": "Another One Bites the Dust",
+            "video": false
           },
-          "position": 2,
-          "id": "70717714-9a03-3c1e-b926-e701e3528442"
+          "title": "Another One Bites the Dust"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "8918cd8a-eb5e-306e-87fb-2068f8597441",
+          "length": 180000,
+          "number": "A3",
           "position": 3,
           "recording": {
-            "video": false,
-            "id": "7b3d96c9-3e22-4337-be32-f8a26b816685",
             "artist-credit": [
               {
                 "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
                   "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "disambiguation": "UK rock group"
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Queen",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
             "disambiguation": "",
             "first-release-date": "1974-10",
+            "id": "7b3d96c9-3e22-4337-be32-f8a26b816685",
             "isrcs": [
               "GBCEE0100114",
               "GBCEE0900140",
@@ -151,33 +217,51 @@
               "GBCEE9300004",
               "GBUM71029606"
             ],
+            "length": 180906,
             "title": "Killer Queen",
-            "length": 180906
+            "video": false
           },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "name": "Queen",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-              }
-            }
-          ],
-          "title": "Killer Queen",
-          "length": 180000,
-          "number": "A3"
+          "title": "Killer Queen"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "b40baf99-1cb5-3448-9566-9a18d79e2f39",
+          "length": 254000,
+          "number": "A4",
+          "position": 4,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "single version",
             "first-release-date": "1978-10-13",
-            "title": "Fat Bottomed Girls",
-            "length": 203000,
+            "id": "eab2a796-b692-4c95-97ee-092517da0345",
             "isrcs": [
               "GBCEE0100115",
               "GBCEE9300007",
@@ -185,52 +269,51 @@
               "GBUM71029607",
               "GBUM71103524"
             ],
-            "video": false,
-            "id": "eab2a796-b692-4c95-97ee-092517da0345",
-            "artist-credit": [
-              {
-                "name": "Queen",
-                "joinphrase": "",
-                "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Queen",
-                  "country": "GB",
-                  "disambiguation": "UK rock group"
-                }
-              }
-            ],
-            "disambiguation": "single version"
+            "length": 203000,
+            "title": "Fat Bottomed Girls",
+            "video": false
           },
-          "position": 4,
-          "id": "b40baf99-1cb5-3448-9566-9a18d79e2f39",
-          "number": "A4",
-          "title": "Fat Bottomed Girls",
-          "length": 254000,
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "name": "Queen",
-                "country": "GB",
-                "disambiguation": "UK rock group"
-              }
-            }
-          ]
+          "title": "Fat Bottomed Girls"
         },
         {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "c968e7f4-c10a-3dfd-83f0-5916d5e9fd98",
+          "length": 180000,
+          "number": "A5",
           "position": 5,
           "recording": {
-            "title": "Bicycle Race",
-            "length": 182000,
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1978-10-13",
+            "id": "135214af-6058-4705-9f17-18d396f36191",
             "isrcs": [
               "GBCEE0100116",
               "GBCEE9300008",
@@ -238,69 +321,51 @@
               "GBCEG9800004",
               "GBUM71029608"
             ],
-            "first-release-date": "1978-10-13",
-            "disambiguation": "",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type": "Group",
-                  "country": "GB",
-                  "disambiguation": "UK rock group",
-                  "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "id": "135214af-6058-4705-9f17-18d396f36191",
+            "length": 182000,
+            "title": "Bicycle Race",
             "video": false
           },
-          "length": 180000,
-          "title": "Bicycle Race",
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "joinphrase": "",
-              "artist": {
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type": "Group",
-                "name": "Queen",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "number": "A5"
+          "title": "Bicycle Race"
         },
         {
-          "position": 6,
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
           "id": "abc322c1-d49a-3276-bbfb-a290757d4414",
+          "length": 159000,
+          "number": "A6",
+          "position": 6,
           "recording": {
-            "disambiguation": "",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
-                  "type": "Group",
-                  "disambiguation": "UK rock group",
                   "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                }
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
+            "disambiguation": "",
+            "first-release-date": "1975-11-21",
             "id": "471dc436-80be-4f06-bc8f-7e2685876cfc",
-            "video": false,
-            "title": "You\u2019re My Best Friend",
-            "length": 172000,
             "isrcs": [
               "GBCEE0100117",
               "GBCEE0500375",
@@ -310,66 +375,51 @@
               "GBCEE9300010",
               "GBUM71029609"
             ],
-            "first-release-date": "1975-11-21"
+            "length": 172000,
+            "title": "You\u2019re My Best Friend",
+            "video": false
           },
-          "length": 159000,
-          "title": "You\u2019re My Best Friend",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "number": "A6"
+          "title": "You\u2019re My Best Friend"
         },
         {
-          "number": "A7",
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Queen",
               "artist": {
-                "disambiguation": "UK rock group",
                 "country": "GB",
-                "name": "Queen",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
+                "disambiguation": "UK rock group",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
-              }
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
-          "title": "Don\u2019t Stop Me Now",
+          "id": "80077346-e091-32b3-9730-f2f0e8cf5e00",
           "length": 209000,
+          "number": "A7",
+          "position": 7,
           "recording": {
-            "id": "d4009c09-a339-4b89-bc45-d91ab649acb6",
-            "video": false,
-            "disambiguation": "",
             "artist-credit": [
               {
                 "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
                   "country": "GB",
-                  "name": "Queen",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
                   "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Queen",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
+            "disambiguation": "",
             "first-release-date": "1978-11-10",
+            "id": "d4009c09-a339-4b89-bc45-d91ab649acb6",
             "isrcs": [
               "GBCEE0100118",
               "GBCEE0900139",
@@ -379,34 +429,51 @@
               "GBCEG9800012",
               "GBUM71029610"
             ],
+            "length": 210146,
             "title": "Don\u2019t Stop Me Now",
-            "length": 210146
+            "video": false
           },
-          "position": 7,
-          "id": "80077346-e091-32b3-9730-f2f0e8cf5e00"
+          "title": "Don\u2019t Stop Me Now"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "type": "Group",
-                "disambiguation": "UK rock group",
                 "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Queen"
             }
           ],
-          "title": "Save Me",
+          "id": "afa07567-e9fa-30af-b1cf-c60dd5ed1f7e",
           "length": 225000,
           "number": "A8",
           "position": 8,
-          "id": "afa07567-e9fa-30af-b1cf-c60dd5ed1f7e",
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1980-01-25",
+            "id": "95706c6c-3bd7-4f5b-bad8-d03095771a71",
             "isrcs": [
               "GBCEE0100119",
               "GBCEE8000034",
@@ -415,34 +482,77 @@
               "GBUM71029611",
               "GBUM71404711"
             ],
-            "title": "Save Me",
             "length": 228600,
-            "first-release-date": "1980-01-25",
+            "title": "Save Me",
+            "video": false
+          },
+          "title": "Save Me"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": " & ",
+              "name": "Queen"
+            },
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "English singer\u2010songwriter",
+                "id": "5441c29d-3602-4898-b1a1-b77fa23b8e50",
+                "name": "David Bowie",
+                "sort-name": "Bowie, David",
+                "type": "Person",
+                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+              },
+              "joinphrase": "",
+              "name": "David Bowie"
+            }
+          ],
+          "id": "f33d7319-9d9b-3deb-96ab-1a681923ea5e",
+          "length": 243000,
+          "number": "A9",
+          "position": 9,
+          "recording": {
             "artist-credit": [
               {
-                "name": "Queen",
-                "joinphrase": "",
                 "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Queen",
                   "country": "GB",
-                  "disambiguation": "UK rock group"
-                }
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": " & ",
+                "name": "Queen"
+              },
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "English singer\u2010songwriter",
+                  "id": "5441c29d-3602-4898-b1a1-b77fa23b8e50",
+                  "name": "David Bowie",
+                  "sort-name": "Bowie, David",
+                  "type": "Person",
+                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df"
+                },
+                "joinphrase": "",
+                "name": "David Bowie"
               }
             ],
             "disambiguation": "",
-            "video": false,
-            "id": "95706c6c-3bd7-4f5b-bad8-d03095771a71"
-          }
-        },
-        {
-          "recording": {
             "first-release-date": "1981-10",
-            "title": "Under Pressure",
-            "length": 243000,
+            "id": "32c7e292-14f1-4080-bddf-ef852e0a4c59",
             "isrcs": [
               "CBCEG8100001",
               "GBCEE0900136",
@@ -453,97 +563,51 @@
               "GBUM71106916",
               "GBUM71404523"
             ],
-            "video": false,
-            "id": "32c7e292-14f1-4080-bddf-ef852e0a4c59",
-            "artist-credit": [
-              {
-                "joinphrase": " & ",
-                "name": "Queen",
-                "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "country": "GB",
-                  "name": "Queen",
-                  "disambiguation": "UK rock group",
-                  "type": "Group"
-                }
-              },
-              {
-                "artist": {
-                  "country": "GB",
-                  "name": "David Bowie",
-                  "disambiguation": "English singer\u2010songwriter",
-                  "type": "Person",
-                  "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                  "id": "5441c29d-3602-4898-b1a1-b77fa23b8e50",
-                  "sort-name": "Bowie, David"
-                },
-                "name": "David Bowie",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": ""
+            "length": 243000,
+            "title": "Under Pressure",
+            "video": false
           },
-          "position": 9,
-          "id": "f33d7319-9d9b-3deb-96ab-1a681923ea5e",
-          "number": "A9",
-          "length": 243000,
-          "title": "Under Pressure",
-          "artist-credit": [
-            {
-              "joinphrase": " & ",
-              "name": "Queen",
-              "artist": {
-                "disambiguation": "UK rock group",
-                "country": "GB",
-                "name": "Queen",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
-              }
-            },
-            {
-              "joinphrase": "",
-              "name": "David Bowie",
-              "artist": {
-                "type-id": "b6e035f4-3ce9-331c-97df-83397230b0df",
-                "type": "Person",
-                "disambiguation": "English singer\u2010songwriter",
-                "country": "GB",
-                "name": "David Bowie",
-                "sort-name": "Bowie, David",
-                "id": "5441c29d-3602-4898-b1a1-b77fa23b8e50"
-              }
-            }
-          ]
+          "title": "Under Pressure"
         },
         {
-          "title": "Crazy Little Thing Called Love",
-          "length": 161000,
           "artist-credit": [
             {
               "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
                 "country": "GB",
                 "disambiguation": "UK rock group",
-                "type": "Group"
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Queen"
             }
           ],
-          "number": "B1",
           "id": "54edaa0b-c6c4-3feb-8d40-63fc0b313b77",
+          "length": 161000,
+          "number": "B1",
           "position": 10,
           "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
             "first-release-date": "1979-10-05",
-            "length": 163706,
-            "title": "Crazy Little Thing Called Love",
+            "id": "fd125370-5ac9-45eb-86ad-ab99e258404b",
             "isrcs": [
               "GBCEE0100120",
               "GBCEE0900134",
@@ -551,33 +615,51 @@
               "GBCEE9300013",
               "GBUM71029612"
             ],
-            "id": "fd125370-5ac9-45eb-86ad-ab99e258404b",
-            "video": false,
-            "disambiguation": "",
+            "length": 163706,
+            "title": "Crazy Little Thing Called Love",
+            "video": false
+          },
+          "title": "Crazy Little Thing Called Love"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "55ab6500-3ae4-39ee-9e39-c456be3472eb",
+          "length": 290000,
+          "number": "B2",
+          "position": 11,
+          "recording": {
             "artist-credit": [
               {
                 "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "GB",
                   "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "type": "Group"
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
                 },
-                "name": "Queen",
-                "joinphrase": ""
+                "joinphrase": "",
+                "name": "Queen"
               }
-            ]
-          }
-        },
-        {
-          "position": 11,
-          "id": "55ab6500-3ae4-39ee-9e39-c456be3472eb",
-          "recording": {
+            ],
+            "disambiguation": "",
             "first-release-date": "1976-11",
-            "title": "Somebody to Love",
-            "length": 296466,
+            "id": "3b286fbf-0dc9-45b8-bf4a-5036ac72526d",
             "isrcs": [
               "GBCEE0100121",
               "GBCEE0900145",
@@ -586,262 +668,21 @@
               "GBUM71029613",
               "GBUM71404710"
             ],
-            "video": false,
-            "id": "3b286fbf-0dc9-45b8-bf4a-5036ac72526d",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "type": "Group",
-                  "name": "Queen",
-                  "country": "GB",
-                  "disambiguation": "UK rock group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                }
-              }
-            ],
-            "disambiguation": ""
+            "length": 296466,
+            "title": "Somebody to Love",
+            "video": false
           },
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type": "Group",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
-              }
-            }
-          ],
-          "title": "Somebody to Love",
-          "length": 290000,
-          "number": "B2"
+          "title": "Somebody to Love"
         },
         {
-          "position": 12,
-          "id": "846808de-344c-3f8b-91f8-a727482f96f6",
-          "recording": {
-            "first-release-date": "1974-11-01",
-            "isrcs": [
-              "GBCEE0100122",
-              "GBCEE7400027",
-              "GBCEE9300015",
-              "GBUM71029620"
-            ],
-            "title": "Now I\u2019m Here",
-            "length": 254920,
-            "video": false,
-            "id": "44901061-7a57-4b3f-9c22-b17da050b604",
-            "artist-credit": [
-              {
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "name": "Queen",
-                  "country": "GB",
-                  "disambiguation": "UK rock group",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                },
-                "name": "Queen",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": ""
-          },
           "artist-credit": [
             {
-              "joinphrase": "",
-              "name": "Queen",
               "artist": {
-                "name": "Queen",
                 "country": "GB",
                 "disambiguation": "UK rock group",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen"
-              }
-            }
-          ],
-          "title": "Now I\u2019m Here",
-          "length": 255000,
-          "number": "B3"
-        },
-        {
-          "number": "B4",
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "joinphrase": "",
-              "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "name": "Queen",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type": "Group"
-              }
-            }
-          ],
-          "title": "Good Old\u2010Fashioned Lover Boy",
-          "length": 167000,
-          "recording": {
-            "artist-credit": [
-              {
-                "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "name": "Queen",
-                  "country": "GB",
-                  "disambiguation": "UK rock group",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-                },
-                "name": "Queen",
-                "joinphrase": ""
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "312d688d-fdef-43a1-a0b6-71d4afa1f351",
-            "title": "Good Old\u2010Fashioned Lover Boy",
-            "length": 174200,
-            "isrcs": [
-              "GBCEE0100123",
-              "GBCEE7600012",
-              "GBCEE9300016",
-              "GBUM71029614"
-            ],
-            "first-release-date": "1976-12-10"
-          },
-          "position": 13,
-          "id": "43977a4d-a632-3caf-aa9f-9ce9b033e98e"
-        },
-        {
-          "recording": {
-            "title": "Play the Game",
-            "length": 212066,
-            "isrcs": [
-              "GBCEE0100124",
-              "GBCEE8000025",
-              "GBCEE9300017",
-              "GBCEE9400026",
-              "GBUM71029615"
-            ],
-            "first-release-date": "1980-05",
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "name": "Queen",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
-                }
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "fd69655e-91e3-42d5-8cb5-27e3a3784067"
-          },
-          "position": 14,
-          "id": "8f7397a4-71ce-3246-843b-c9574da9c481",
-          "number": "B5",
-          "title": "Play the Game",
-          "length": 208000,
-          "artist-credit": [
-            {
-              "name": "Queen",
-              "joinphrase": "",
-              "artist": {
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                "type": "Group",
-                "country": "GB",
-                "disambiguation": "UK rock group",
                 "name": "Queen",
                 "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-              }
-            }
-          ]
-        },
-        {
-          "length": 174000,
-          "title": "Flash",
-          "artist-credit": [
-            {
-              "joinphrase": "",
-              "name": "Queen",
-              "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "name": "Queen",
-                "country": "GB",
-                "disambiguation": "UK rock group",
-                "type": "Group",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-              }
-            }
-          ],
-          "number": "B6",
-          "position": 15,
-          "id": "203ca0b1-00d7-3e08-b8d7-853f461d81f0",
-          "recording": {
-            "artist-credit": [
-              {
-                "joinphrase": "",
-                "name": "Queen",
-                "artist": {
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "type": "Group",
-                  "disambiguation": "UK rock group",
-                  "country": "GB",
-                  "name": "Queen",
-                  "sort-name": "Queen",
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-                }
-              }
-            ],
-            "disambiguation": "",
-            "video": false,
-            "id": "e61e12a1-118a-4441-9a58-b5eaff2ce9bc",
-            "length": 168426,
-            "title": "Flash",
-            "isrcs": [
-              "GBCEE0100125",
-              "GBCEE8000036",
-              "GBCEE9300009",
-              "GBUM71029616",
-              "GBUM71103537"
-            ],
-            "first-release-date": "1980"
-          }
-        },
-        {
-          "number": "B7",
-          "title": "Seven Seas of Rhye",
-          "length": 166000,
-          "artist-credit": [
-            {
-              "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
-                "country": "GB",
-                "name": "Queen",
-                "disambiguation": "UK rock group",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
@@ -849,24 +690,234 @@
               "name": "Queen"
             }
           ],
+          "id": "846808de-344c-3f8b-91f8-a727482f96f6",
+          "length": 255000,
+          "number": "B3",
+          "position": 12,
           "recording": {
             "artist-credit": [
               {
-                "name": "Queen",
-                "joinphrase": "",
                 "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-                  "disambiguation": "UK rock group",
                   "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                   "name": "Queen",
-                  "type": "Group"
-                }
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1974-11-01",
+            "id": "44901061-7a57-4b3f-9c22-b17da050b604",
+            "isrcs": [
+              "GBCEE0100122",
+              "GBCEE7400027",
+              "GBCEE9300015",
+              "GBUM71029620"
+            ],
+            "length": 254920,
+            "title": "Now I\u2019m Here",
+            "video": false
+          },
+          "title": "Now I\u2019m Here"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "43977a4d-a632-3caf-aa9f-9ce9b033e98e",
+          "length": 167000,
+          "number": "B4",
+          "position": 13,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1976-12-10",
+            "id": "312d688d-fdef-43a1-a0b6-71d4afa1f351",
+            "isrcs": [
+              "GBCEE0100123",
+              "GBCEE7600012",
+              "GBCEE9300016",
+              "GBUM71029614"
+            ],
+            "length": 174200,
+            "title": "Good Old\u2010Fashioned Lover Boy",
+            "video": false
+          },
+          "title": "Good Old\u2010Fashioned Lover Boy"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "8f7397a4-71ce-3246-843b-c9574da9c481",
+          "length": 208000,
+          "number": "B5",
+          "position": 14,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1980-05",
+            "id": "fd69655e-91e3-42d5-8cb5-27e3a3784067",
+            "isrcs": [
+              "GBCEE0100124",
+              "GBCEE8000025",
+              "GBCEE9300017",
+              "GBCEE9400026",
+              "GBUM71029615"
+            ],
+            "length": 212066,
+            "title": "Play the Game",
+            "video": false
+          },
+          "title": "Play the Game"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "203ca0b1-00d7-3e08-b8d7-853f461d81f0",
+          "length": 174000,
+          "number": "B6",
+          "position": 15,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1980",
+            "id": "e61e12a1-118a-4441-9a58-b5eaff2ce9bc",
+            "isrcs": [
+              "GBCEE0100125",
+              "GBCEE8000036",
+              "GBCEE9300009",
+              "GBUM71029616",
+              "GBUM71103537"
+            ],
+            "length": 168426,
+            "title": "Flash",
+            "video": false
+          },
+          "title": "Flash"
+        },
+        {
+          "artist-credit": [
+            {
+              "artist": {
+                "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                "name": "Queen",
+                "sort-name": "Queen",
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+              },
+              "joinphrase": "",
+              "name": "Queen"
+            }
+          ],
+          "id": "91916cb9-3bc0-31e3-87cc-beb9f5e52c0b",
+          "length": 166000,
+          "number": "B7",
+          "position": 16,
+          "recording": {
+            "artist-credit": [
+              {
+                "artist": {
+                  "country": "GB",
+                  "disambiguation": "UK rock group",
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
+              }
+            ],
+            "disambiguation": "",
+            "first-release-date": "1974-02-23",
             "id": "8402fc0f-71b8-4773-ae7b-86bde5ac7b43",
             "isrcs": [
               "GBCEE0100126",
@@ -878,50 +929,48 @@
             ],
             "length": 168973,
             "title": "Seven Seas of Rhye",
-            "first-release-date": "1974-02-23"
+            "video": false
           },
-          "position": 16,
-          "id": "91916cb9-3bc0-31e3-87cc-beb9f5e52c0b"
+          "title": "Seven Seas of Rhye"
         },
         {
-          "title": "We Will Rock You",
-          "length": 120000,
           "artist-credit": [
             {
               "artist": {
-                "type": "Group",
-                "disambiguation": "UK rock group",
                 "country": "GB",
+                "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "name": "Queen",
-                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                 "sort-name": "Queen",
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
+                "type": "Group",
+                "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
               "joinphrase": "",
               "name": "Queen"
             }
           ],
+          "id": "b8307e6b-57b3-3851-886a-278d5a5427aa",
+          "length": 120000,
           "number": "B8",
           "position": 17,
-          "id": "b8307e6b-57b3-3851-886a-278d5a5427aa",
           "recording": {
             "artist-credit": [
               {
-                "name": "Queen",
-                "joinphrase": "",
                 "artist": {
-                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "country": "GB",
-                  "name": "Queen",
                   "disambiguation": "UK rock group",
-                  "type": "Group"
-                }
+                  "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
             "disambiguation": "",
-            "video": false,
+            "first-release-date": "1977-10-28",
             "id": "f8581c2b-61ac-465d-82ae-0fa2916a4799",
             "isrcs": [
               "GBCEE0100127",
@@ -936,54 +985,51 @@
               "USHR10320404",
               "USHR10320405"
             ],
-            "title": "We Will Rock You",
             "length": 122000,
-            "first-release-date": "1977-10-28"
-          }
+            "title": "We Will Rock You",
+            "video": false
+          },
+          "title": "We Will Rock You"
         },
         {
           "artist-credit": [
             {
               "artist": {
-                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                "sort-name": "Queen",
                 "country": "GB",
                 "disambiguation": "UK rock group",
+                "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
                 "name": "Queen",
+                "sort-name": "Queen",
                 "type": "Group",
                 "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
               },
-              "name": "Queen",
-              "joinphrase": ""
+              "joinphrase": "",
+              "name": "Queen"
             }
           ],
+          "id": "81b97ade-2db4-3c41-9246-848ed2b582c5",
           "length": 178000,
-          "title": "We Are the Champions",
           "number": "B9",
           "position": 18,
-          "id": "81b97ade-2db4-3c41-9246-848ed2b582c5",
           "recording": {
-            "video": false,
-            "id": "3604eb06-4bc2-4416-9b31-ceadae51bc70",
             "artist-credit": [
               {
-                "joinphrase": "",
-                "name": "Queen",
                 "artist": {
-                  "name": "Queen",
                   "country": "GB",
                   "disambiguation": "UK rock group",
-                  "type": "Group",
-                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
                   "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-                  "sort-name": "Queen"
-                }
+                  "name": "Queen",
+                  "sort-name": "Queen",
+                  "type": "Group",
+                  "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+                },
+                "joinphrase": "",
+                "name": "Queen"
               }
             ],
             "disambiguation": "",
             "first-release-date": "1977-10-28",
-            "length": 181026,
-            "title": "We Are the Champions",
+            "id": "3604eb06-4bc2-4416-9b31-ceadae51bc70",
             "isrcs": [
               "GBCEE0100128",
               "GBCEE0900130",
@@ -993,115 +1039,69 @@
               "GBCEE9800058",
               "GBUM71029619",
               "USRH10652606"
-            ]
-          }
+            ],
+            "length": 181026,
+            "title": "We Are the Champions",
+            "video": false
+          },
+          "title": "We Are the Champions"
         }
-      ],
-      "format": "12\" Vinyl",
-      "format-id": "3e9080b0-5e6c-34ab-bd15-f526b6306a64",
-      "title": "",
-      "track-offset": 0,
-      "position": 1
+      ]
     }
   ],
-  "asin": null,
-  "title": "Greatest Hits",
   "packaging": "Cardboard/Paper Sleeve",
-  "id": "fcb78d0d-8067-4b93-ae58-1e4347e20216",
-  "release-group": {
-    "id": "69ce61c8-127f-3809-95d8-62fdf3ae1347",
-    "primary-type": "Album",
-    "secondary-type-ids": [
-      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
-    ],
-    "artist-credit": [
-      {
-        "artist": {
-          "sort-name": "Queen",
-          "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
-          "type": "Group",
-          "country": "GB",
-          "disambiguation": "UK rock group",
-          "name": "Queen",
-          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
-        },
-        "name": "Queen",
-        "joinphrase": ""
-      }
-    ],
-    "secondary-types": [
-      "Compilation"
-    ],
-    "disambiguation": "",
-    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
-    "first-release-date": "1981-11-03",
-    "title": "Greatest Hits"
-  },
+  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
+  "quality": "normal",
   "release-events": [
     {
       "area": {
-        "sort-name": "Germany",
-        "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
-        "type": null,
-        "name": "Germany",
         "disambiguation": "",
-        "type-id": null,
+        "id": "85752fda-13c4-31a3-bee5-0e5cb1f51dad",
         "iso-3166-1-codes": [
           "DE"
-        ]
+        ],
+        "name": "Germany",
+        "sort-name": "Germany",
+        "type": null,
+        "type-id": null
       },
       "date": "1981"
     }
   ],
+  "release-group": {
+    "artist-credit": [
+      {
+        "artist": {
+          "country": "GB",
+          "disambiguation": "UK rock group",
+          "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3",
+          "name": "Queen",
+          "sort-name": "Queen",
+          "type": "Group",
+          "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b"
+        },
+        "joinphrase": "",
+        "name": "Queen"
+      }
+    ],
+    "disambiguation": "",
+    "first-release-date": "1981-11-03",
+    "id": "69ce61c8-127f-3809-95d8-62fdf3ae1347",
+    "primary-type": "Album",
+    "primary-type-id": "f529b476-6e62-324f-b0aa-1f3e33d313fc",
+    "secondary-type-ids": [
+      "dd2a21e1-0c00-3729-a7a0-de60b84eb5d1"
+    ],
+    "secondary-types": [
+      "Compilation"
+    ],
+    "title": "Greatest Hits"
+  },
+  "status": "Official",
   "status-id": "4e304316-386d-3409-af2e-78857eec5cfe",
-  "country": "DE",
-  "disambiguation": "",
-  "barcode": "",
-  "packaging-id": "f7101ce3-0384-39ce-9fde-fbbd0044d35f",
-  "label-info": [
-    {
-      "catalog-number": "1C 064-78 071",
-      "label": {
-        "label-code": 542,
-        "type-id": "7aaa37fe-2def-3476-b359-80245850062d",
-        "disambiguation": "EMI Records, or EMI Music only if there is no other imprint",
-        "name": "EMI",
-        "type": "Original Production",
-        "id": "c029628b-6633-439e-bcee-ed02e8a338f7",
-        "sort-name": "EMI"
-      }
-    },
-    {
-      "catalog-number": "1C 064-78 071",
-      "label": {
-        "id": "04eb3226-fd4c-4dfb-ae02-c888f0a0e977",
-        "sort-name": "EMI Electrola",
-        "name": "EMI Electrola",
-        "disambiguation": "more likely the company trademark of EMI Electrola GmbH than an imprint",
-        "type": null,
-        "label-code": 193,
-        "type-id": null
-      }
-    }
-  ],
-  "date": "1981",
   "text-representation": {
     "language": "eng",
     "script": "Latn"
   },
-  "artist-credit": [
-    {
-      "artist": {
-        "type-id": "e431f5f6-b5d2-343d-8b36-72607fffb74b",
-        "type": "Group",
-        "country": "GB",
-        "disambiguation": "UK rock group",
-        "name": "Queen",
-        "sort-name": "Queen",
-        "id": "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
-      },
-      "name": "Queen",
-      "joinphrase": ""
-    }
-  ]
+  "title": "Greatest Hits"
 }

--- a/scripts/eval_matching/eval_matching.py
+++ b/scripts/eval_matching/eval_matching.py
@@ -1190,7 +1190,7 @@ def _save_snapshot(results, path):
             }
         )
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(snapshot, f, indent=2)
+        json.dump(snapshot, f, indent=2, sort_keys=True)
         f.write("\n")
     print(f"\n  Snapshot saved to {path} ({len(snapshot)} entries)")
 

--- a/scripts/eval_matching/eval_recording_lookup.py
+++ b/scripts/eval_matching/eval_recording_lookup.py
@@ -338,7 +338,7 @@ def save_results(results, path):
             }
         )
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(snapshot, f, indent=2)
+        json.dump(snapshot, f, indent=2, sort_keys=True)
     print(f"Saved {len(snapshot)} results to {path}")
 
 

--- a/scripts/eval_matching/refresh_corpus.py
+++ b/scripts/eval_matching/refresh_corpus.py
@@ -72,7 +72,7 @@ def save_release(data):
     """Save release JSON to corpus/, named by MBID prefix."""
     path = CORPUS_DIR / f"eval_release_{data['id'][:8]}.json"
     with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, indent=2)
+        json.dump(data, f, indent=2, sort_keys=True)
         f.write("\n")
     return path
 


### PR DESCRIPTION
Implements the review suggestions from https://github.com/metabrainz/picard/pull/3211:

1. **Use direct dict access** — `medium.get('track', None)` → `medium['track']` since `'track' in medium` was already checked on the line above.

2. **Use `continue` instead of early `return 0.0`** — When no match is found on a particular medium, continue checking remaining media across all releases instead of returning immediately. Only return 0.0 after exhausting all media. This fixes a case where the matching track is on a non-first medium (improves eval score by 1: 1484 → 1485/1527).

3. **Add `sort_keys=True` to `json.dump()` calls** — Stabilizes JSON output ordering so corpus diffs only show actual data changes.

4. **Refresh corpus** — Re-generated all corpus JSON with sorted keys.

Eval results:
```
Previous (PR as-is): 1484/1527 correct
Current (with fix):  1485/1527 correct
Improved: 1  Regressed: 0

IMPROVED (1):
  MTV Ultimate Mash‐Ups Presents: Collision Course | Dirt Off Your Shoulder / Lying From You
    (continue fix found match on non-first medium)
```