### PR TITLE
PICARD-3308: Improve macOS locale detection robustness

### DIFF
--- a/picard/i18n/gettext.py
+++ b/picard/i18n/gettext.py
@@ -92,6 +92,33 @@ def set_locale_from_env():
     return current_locale
 
 
+def _bcp47_to_locale(tag: str) -> str:
+    """Convert a BCP 47 language tag to a POSIX locale identifier.
+
+    Extracts the language and region components, skipping script subtags.
+    If no region is found, uses locale.normalize() to infer a default region
+    for the language.
+
+    Examples:
+        'en-US' -> 'en_US'
+        'zh-Hans-CN' -> 'zh_CN'
+        'en' -> 'en_US' (via locale.normalize)
+        'fr' -> 'fr_FR' (via locale.normalize)
+    """
+    parts = tag.split('-')
+    language = parts[0]
+    for part in parts[1:]:
+        # Region designator: 2 uppercase ASCII letters or 3 digits
+        if (len(part) == 2 and part.isascii() and part.isupper()) or (len(part) == 3 and part.isdigit()):
+            return f'{language}_{part}'
+    # No region found — use locale.normalize to infer a default region
+    normalized = locale.normalize(language)
+    if normalized != language:
+        # Strip encoding suffix (e.g. 'en_US.ISO8859-1' -> 'en_US')
+        return normalized.split('.')[0]
+    return language
+
+
 if IS_WIN:
     from ctypes import windll  # type: ignore[attr-defined]
 
@@ -106,14 +133,31 @@ if IS_WIN:
 elif IS_MACOS:
     import Foundation
 
-    def _get_default_locale_mac():
-        defaults = Foundation.NSUserDefaults.standardUserDefaults()
-        if 'AppleLocale' in defaults:
-            return defaults['AppleLocale']
-        elif 'AppleLanguages' in defaults:
-            # Note: In newer macOS versions AppleLanguages no longer contains the full
-            # locale name with region, so this might be unusable.
-            return defaults['AppleLanguages'][0].replace('-', '_')
+    def _get_default_locale_mac() -> str | None:
+        """Read the user's locale from macOS user defaults.
+
+        Prefers AppleLocale (full locale with region, e.g. 'en_US') and falls
+        back to AppleLanguages (BCP 47 language tags, e.g. 'en-US').
+
+        Handles known quirks:
+        - AppleLocale may contain ICU keyword suffixes (e.g. '@currency=GBP')
+          when the user has customized regional settings; these are stripped.
+        - AppleLocale may be absent on some macOS 10.13/10.14 configurations.
+        - AppleLanguages on newer macOS may contain script subtags
+          (e.g. 'zh-Hans-CN') or lack region entirely (e.g. 'en').
+        """
+        try:
+            defaults = Foundation.NSUserDefaults.standardUserDefaults()
+            if 'AppleLocale' in defaults:
+                locale_str = defaults['AppleLocale']
+                # Strip ICU keyword suffixes like @currency=USD or @calendar=gregorian
+                return locale_str.split('@')[0] if locale_str else None
+            elif 'AppleLanguages' in defaults:
+                # Note: In newer macOS versions AppleLanguages no longer contains the full
+                # locale name with region, so this might return only a language code.
+                return _bcp47_to_locale(defaults['AppleLanguages'][0])
+        except Exception as e:
+            _logger("Failed to read macOS locale defaults: %s", e)
         return None
 
     _get_default_locale = _get_default_locale_mac

--- a/test/test_i18n.py
+++ b/test/test_i18n.py
@@ -42,6 +42,7 @@ from picard.i18n import (
     sort_key,
 )
 from picard.i18n.gettext import (
+    _bcp47_to_locale,
     _try_encodings,
     _try_locales,
 )
@@ -163,3 +164,31 @@ class TestTryEncodingsLocales(PicardTestCase):
         locale_getpreferredencoding_mock.assert_called_once()
         calls = [call('EN.ISO-8859-1'), call('EN.UTF-8')]
         locale_nomalize_mock.assert_has_calls(calls)
+
+
+class TestBcp47ToLocale(PicardTestCase):
+    def test_language_with_region(self):
+        self.assertEqual('en_US', _bcp47_to_locale('en-US'))
+        self.assertEqual('en_GB', _bcp47_to_locale('en-GB'))
+        self.assertEqual('pt_BR', _bcp47_to_locale('pt-BR'))
+
+    def test_language_with_script_and_region(self):
+        self.assertEqual('zh_CN', _bcp47_to_locale('zh-Hans-CN'))
+        self.assertEqual('zh_TW', _bcp47_to_locale('zh-Hant-TW'))
+
+    @patch('locale.normalize', autospec=True)
+    def test_bare_language_normalizes(self, locale_normalize_mock):
+        locale_normalize_mock.return_value = 'en_US.ISO8859-1'
+        self.assertEqual('en_US', _bcp47_to_locale('en'))
+        locale_normalize_mock.assert_called_once_with('en')
+
+    @patch('locale.normalize', autospec=True)
+    def test_bare_language_no_mapping(self, locale_normalize_mock):
+        # locale.normalize returns input unchanged if no mapping exists
+        locale_normalize_mock.return_value = 'xx'
+        self.assertEqual('xx', _bcp47_to_locale('xx'))
+        locale_normalize_mock.assert_called_once_with('xx')
+
+    def test_numeric_region(self):
+        # UN M.49 numeric region codes (3 digits)
+        self.assertEqual('es_419', _bcp47_to_locale('es-419'))


### PR DESCRIPTION
## Summary

Improves `_get_default_locale_mac()` to handle several known macOS quirks that could cause locale detection to silently fail or produce invalid locale identifiers.

## Problem

The current implementation has a few issues:

1. **AppleLocale ICU keyword suffixes**: On macOS 10.12+, when users customize regional settings, `AppleLocale` can return values like `en_GB@currency=GBP`. These are rejected by `locale.setlocale()`.

2. **AppleLanguages BCP 47 script subtags**: Tags like `zh-Hans-CN` become `zh_Hans_CN` after naive `.replace('-', '_')`, which is not a valid POSIX locale identifier.

3. **AppleLanguages bare language codes**: On newer macOS, `AppleLanguages` may contain only a language code without region (e.g. `en`, `fr`), which fails in `setlocale()`.

4. **No exception handling**: Unlike `_get_default_locale_win()`, the macOS variant had no try/except, so unexpected PyObjC errors could crash the caller.

## Solution

- Strip ICU keyword suffixes (`@...`) from `AppleLocale` values
- Add `_bcp47_to_locale()` helper that properly parses BCP 47 tags (extracts language + region, skips script subtags)
- Use `locale.normalize()` to infer a default region when only a bare language code is available
- Wrap in try/except with logging via `_logger`
- Move `_bcp47_to_locale()` to module level so it's testable cross-platform
- Add unit tests for the new helper

## Testing

- All existing tests pass (5326 passed)
- 5 new unit tests added for `_bcp47_to_locale()`
- Manually verified conversion for: `en-US`, `en-GB`, `zh-Hans-CN`, `zh-Hant-TW`, `pt-BR`, `en`, `fr`, `cs`, `de`, `es-419`
