### PR TITLE
Fix test issues and sync CLI documentation

### DIFF
--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -906,13 +906,10 @@ picard-cli plugins check-blacklist --uuid a1b2c3d4-e5f6-4a5b-8c9d-0e1f2a3b4c5d
 # Refresh registry cache
 picard-cli plugins refresh-registry
 
-# Combine with other commands (recommended when switching registries)
-picard-cli plugins refresh-registry --browse
-picard-cli plugins refresh-registry --install view-script-variables
-
 # After changing PICARD_PLUGIN_REGISTRY_URL
 export PICARD_PLUGIN_REGISTRY_URL="https://example.com/custom-registry.toml"
-picard-cli plugins refresh-registry --browse
+picard-cli plugins refresh-registry
+picard-cli plugins browse
 ```
 
 **Use cases:**
@@ -921,7 +918,7 @@ picard-cli plugins refresh-registry --browse
 - Forcing immediate update of registry data
 - Clearing stale cache
 
-**Note:** The registry is cached locally. Use `--refresh-registry` to bypass the cache and fetch the latest version immediately. It can be combined with any other command that uses the registry (--browse, --search, --install, etc.).
+**Note:** The registry is cached locally. Use `refresh-registry` to bypass the cache and fetch the latest version immediately. Run it before other registry commands (`browse`, `search`, `install`) if you need fresh data.
 
 ---
 

--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -322,7 +322,7 @@ picard-cli plugins install view-script-variables
 picard-cli plugins install listenbrainz discogs acoustid
 ```
 
-**Note:** The registry ID is shown in `--browse` and `--search` output. It's different from the internal plugin_id that gets created after installation.
+**Note:** The registry ID is shown in `browse` and `search` output. It's different from the internal plugin_id that gets created after installation.
 
 **Versioning behavior:**
 - If plugin has `versioning_scheme` in registry and no `--ref` specified:
@@ -410,19 +410,19 @@ picard-cli plugins update view-script-variables
 # Update one plugin (using plugin ID)
 picard-cli plugins update listenbrainz_a1b2c3d4-e5f6-...
 
-# Update to specific ref
-picard-cli plugins update view-script-variables --ref v2.0.0
-
 # Update all plugins
 picard-cli plugins update --all
 
 # Check for updates without installing
 picard-cli plugins check-updates
+
+# To switch to a specific ref, use switch-ref
+picard-cli plugins switch-ref view-script-variables v2.0.0
 ```
 
 **Note on registry ID:** If you installed a plugin from the registry (e.g., `picard-cli plugins install view-script-variables`), you can use the short registry ID for updates instead of the long plugin_id with UUID suffix.
 
-**Note on `--check-updates`:** This command checks for updates within the currently installed git ref (branch/tag). If a plugin is installed from a specific branch (e.g., `dev`), it will only check for updates on that branch, not on other branches like `main`. To switch to a different branch, use `--switch-ref` instead.
+**Note on `check-updates`:** This command checks for updates within the currently installed git ref (branch/tag). If a plugin is installed from a specific branch (e.g., `dev`), it will only check for updates on that branch, not on other branches like `main`. To switch to a different branch, use `switch-ref` instead.
 
 **Versioning behavior:**
 - If plugin has `versioning_scheme` in registry:
@@ -443,7 +443,7 @@ picard-cli plugins update my-plugin
 # Updates to latest commit on current branch
 ```
 
-**Note on tags:** If a plugin is installed with a version tag (e.g., `v1.0.0`, `1.2.3`), `--update` will automatically find and switch to the latest version tag. Non-version tags (e.g., `stable`, `latest`) are treated as immutable.
+**Note on tags:** If a plugin is installed with a version tag (e.g., `v1.0.0`, `1.2.3`), `update` will automatically find and switch to the latest version tag. Non-version tags (e.g., `stable`, `latest`) are treated as immutable.
 
 ```bash
 # Plugin installed with version tag v1.0.0
@@ -461,7 +461,7 @@ picard-cli plugins switch-ref myplugin v2.0.0
 picard-cli plugins switch-ref myplugin main
 ```
 
-**Note on commits:** If a plugin was installed with a specific commit hash, `--update` will report "Already up to date" because commit hashes are immutable. Use `--switch-ref` to change to a different commit, tag, or branch.
+**Note on commits:** If a plugin was installed with a specific commit hash, `update` will report "Already up to date" because commit hashes are immutable. Use `switch-ref` to change to a different commit, tag, or branch.
 
 **Example:**
 ```bash
@@ -550,16 +550,15 @@ Last Updated: 2025-11-20 14:15:00
 - `picard-cli plugins refs <name|url>` - List available refs for plugin
 - `picard-cli plugins install <url> --ref <ref>` - Install specific ref
 - `picard-cli plugins switch-ref <name> <ref>` - Switch to different ref
-- `picard-cli plugins update <name> --ref <ref>` - Update to specific ref
 - `picard-cli plugins info <name>` - Show available refs for registered plugins
 
 **Description:** Manage git branches, tags, and commits
 
 **Understanding refs:**
-- **Branches** (e.g., `main`, `dev`): Mutable - `--update` pulls latest commits
-- **Version tags** (e.g., `v1.0.0`, `2.1.3`): `--update` automatically finds and switches to latest version tag
-- **Non-version tags** (e.g., `stable`, `latest`): Immutable - use `--switch-ref` to change
-- **Commits** (e.g., `abc1234`): Immutable - cannot be updated, use `--switch-ref` to change
+- **Branches** (e.g., `main`, `dev`): Mutable - `update` pulls latest commits
+- **Version tags** (e.g., `v1.0.0`, `2.1.3`): `update` automatically finds and switches to latest version tag
+- **Non-version tags** (e.g., `stable`, `latest`): Immutable - use `switch-ref` to change
+- **Commits** (e.g., `abc1234`): Immutable - cannot be updated, use `switch-ref` to change
 
 **Registry refs:**
 Plugins in the official registry can specify multiple refs (branches/tags) that are available for installation:
@@ -572,9 +571,9 @@ When installing a registered plugin without specifying `--ref`, Picard automatic
 - Picard 3.x users get the `picard-v3` branch
 - Picard 4.x users get the `main` branch
 
-**When to use `--update` vs `--switch-ref`:**
-- Use `--update` to get the latest version (works for both branches and tags)
-- Use `--switch-ref` to change to a different branch/tag, or to switch from commit to branch/tag
+**When to use `update` vs `switch-ref`:**
+- Use `update` to get the latest version (works for both branches and tags)
+- Use `switch-ref` to change to a different branch/tag, or to switch from commit to branch/tag
 
 **Examples:**
 ```bash
@@ -610,7 +609,7 @@ picard-cli plugins switch-ref myplugin v1.1.0
 
 **Ref validation:**
 
-When using `--switch-ref`, Picard validates the ref exists:
+When using `switch-ref`, Picard validates the ref exists:
 
 - **With `versioning_scheme`**: Validates tag matches pattern and exists
   ```bash

--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -111,9 +111,9 @@ picard-cli plugins manifest ~/dev/my-plugin    # From local directory
 picard-cli plugins browse
 picard-cli plugins search "cover art"
 
-# Disable colored output
-picard-cli plugins list --no-color
-picard-cli plugins validate ~/dev/my-plugin --no-color
+# Disable colored output (--no-color and --yes are top-level picard-cli options)
+picard-cli --no-color plugins list
+picard-cli --no-color plugins validate ~/dev/my-plugin
 ```
 
 ---
@@ -151,13 +151,12 @@ picard -e "PLUGIN_ENABLE listenbrainz"
 ### Help Output
 
 ```text
-usage: picard-cli plugins [-h] [--yes] [--locale LOCALE] <command> ...
+usage: picard-cli plugins [-h] [--locale LOCALE] <command> ...
 
 Install, update, enable, and manage Picard plugins.
 
 options:
   -h, --help        show this help message and exit
-  --yes, -y         skip confirmation prompts
   --locale LOCALE   locale for displaying plugin info (e.g., 'fr', 'de', 'en')
 
 plugin commands:

--- a/docs/PLUGINSV3/CLI.md
+++ b/docs/PLUGINSV3/CLI.md
@@ -1253,12 +1253,7 @@ Clean with: picard-cli plugins clean-config <uuid>
 | 0 | Success |
 | 1 | General error |
 | 2 | Plugin not found |
-| 3 | Network error |
-| 4 | Git error |
-| 5 | Blacklisted plugin |
-| 6 | Incompatible API version |
-| 7 | Invalid manifest |
-| 8 | User cancelled |
+| 130 | Operation cancelled (SIGINT) |
 
 ---
 

--- a/test/plugins3/helpers.py
+++ b/test/plugins3/helpers.py
@@ -160,7 +160,7 @@ class MockCliArgs(Mock):
     def __init__(self, **kwargs):
         # Name has special meaning in Mock
         name = kwargs.get('name', None)
-        if name:
+        if name is not None:
             del kwargs['name']
         defaults = {
             'verb': None,

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -228,8 +228,8 @@ class TestPluginCLI(PicardTestCase):
         self.assertEqual(exit_code, 0)
         manager.check_updates.assert_called_once()
 
-        # Test check-updates --all
-        exit_code, _, _ = run_cli(manager, verb='update', all=True)
+        # Test update --all
+        exit_code, _, _ = run_cli(manager, verb='update', update_all=True)
         self.assertEqual(exit_code, 0)
         manager.update_all_plugins.assert_called_once()
 

--- a/test/plugins3/test_cli.py
+++ b/test/plugins3/test_cli.py
@@ -1512,7 +1512,6 @@ class TestPluginCLIInitInteractive(PicardTestCase):
             exit_code, stdout, stderr = run_cli(MockPluginManager(), verb='init', target_dir=str(target))
         self.assertEqual(ExitCode.SUCCESS, exit_code)
         manifest = (target / 'MANIFEST.toml').read_text(encoding='utf-8')
-        print(manifest)
         self.assertNotIn('categories', manifest)
 
     def test_interactive_multiple_categories(self):


### PR DESCRIPTION
Small fixes on top of the remove-plugin-cli branch:

**Test fixes:**
- Remove stray `print(manifest)` debug statement
- Fix test using `all=True` instead of `update_all=True` (matching argparse dest)
- Fix `MockCliArgs` to handle `name=''` correctly (`if name:` → `if name is not None:`)

**Documentation sync (docs/PLUGINSV3/CLI.md):**
- Remove refresh-registry combination examples (subcommands can't be combined)
- Remove `update --ref` references, point to `switch-ref` instead
- Fix exit codes table to match actual `ExitCode` enum (was aspirational, never implemented)
- Fix help output block (`--yes`/`--no-color` are top-level `picard-cli` options)