### PR TITLE
Wizard UI fixes: stylesheet, messages, validation

### DIFF
--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -298,23 +298,23 @@ class UpdatesPage(SetupWizardPage):
         layout = QtWidgets.QVBoxLayout(self)
 
         self.update_check_app = WizardCheckbox(
-            _("Check for program updates during startup"),
-            _("Check for a new program version on the Picard website and show an update dialog if available."),
+            _("Check for program updates"),
+            _("Check for a new program version online and show an update dialog if available."),
         )
         layout.addWidget(self.update_check_app)
         if not tagger.autoupdate_enabled:
             self.update_check_app.hide()
 
         self.update_check_plugins = WizardCheckbox(
-            _("Check for plugin updates during startup"),
-            _("Check for plugin updates on the Picard website and show a notification in the status bar."),
+            _("Check for plugin updates"),
+            _("Check for plugin updates online and show a notification in the status bar."),
         )
         layout.addWidget(self.update_check_plugins)
         if not tagger._pluginmanager3:
             self.update_check_plugins.hide()
 
         self.update_check_docs = WizardCheckbox(
-            _("Check for documentation updates during startup"),
+            _("Check for documentation updates"),
             _("Check for available documentation translations, so the online help can be shown in your language."),
         )
         layout.addWidget(self.update_check_docs)

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -92,6 +92,9 @@ class WizardCheckbox(QtWidgets.QWidget):
     def mousePressEvent(self, event: QtGui.QMouseEvent | None) -> None:
         if event is None:
             return
+        child = self.childAt(event.position().toPoint())
+        if isinstance(child, (QtWidgets.QLineEdit, QtWidgets.QToolButton, QtWidgets.QCheckBox)):
+            return
         self._checkbox.toggle()
         event.accept()
 

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -49,19 +49,9 @@ class WizardCheckbox(QtWidgets.QWidget):
         style = QtWidgets.QApplication.style()
         assert style
 
-        palette = self.palette()
-        highlight_bg = palette.color(QtGui.QPalette.ColorRole.Highlight)
-        highlight_text = palette.color(QtGui.QPalette.ColorRole.HighlightedText)
-
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_StyledBackground, True)
-        self.setStyleSheet(f"""
-            WizardCheckbox:hover {{
-                background-color: {highlight_bg.name()};
-            }}
-            * {{
-                color: {highlight_text.name()};
-            }}
-        """)
+        self._updating_stylesheet = False
+        self._update_stylesheet()
 
         layout = QtWidgets.QVBoxLayout(self)
 
@@ -94,11 +84,34 @@ class WizardCheckbox(QtWidgets.QWidget):
     def add_extra_layout(self, layout: QtWidgets.QLayout) -> None:
         self._inner_layout.addLayout(layout)
 
+    def changeEvent(self, event: QtCore.QEvent | None) -> None:
+        if event and event.type() == QtCore.QEvent.Type.PaletteChange:
+            self._update_stylesheet()
+        super().changeEvent(event)
+
     def mousePressEvent(self, event: QtGui.QMouseEvent | None) -> None:
         if event is None:
             return
         self._checkbox.toggle()
         event.accept()
+
+    def _update_stylesheet(self) -> None:
+        if self._updating_stylesheet:
+            return
+        self._updating_stylesheet = True
+        palette = self.palette()
+        text_color = palette.color(QtGui.QPalette.ColorRole.WindowText)
+        highlight_bg = palette.color(QtGui.QPalette.ColorRole.Highlight)
+        highlight_bg.setAlpha(40)
+        self.setStyleSheet(f"""
+            WizardCheckbox {{
+                color: {text_color.name()};
+            }}
+            WizardCheckbox:hover {{
+                background-color: rgba({highlight_bg.red()}, {highlight_bg.green()}, {highlight_bg.blue()}, {highlight_bg.alpha()});
+            }}
+        """)
+        self._updating_stylesheet = False
 
     def set_checked(self, checked: bool) -> None:
         self._checkbox.setChecked(checked)

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -228,6 +228,16 @@ class FileOrganizationPage(SetupWizardPage):
         config.setting['move_files'] = self.move_checkbox.is_checked()
         config.setting['move_files_to'] = self.move_to_edit.text()
 
+    def validatePage(self) -> bool:
+        if self.move_checkbox.is_checked() and not self.move_to_edit.text().strip():
+            QtWidgets.QMessageBox.warning(
+                self,
+                _("Destination folder required"),
+                _("Please choose a destination folder for your music files, or uncheck the move files option."),
+            )
+            return False
+        return True
+
     def _update_move_to_state(self, checked: bool) -> None:
         self.move_to_edit.setEnabled(checked)
         self.browse_button.setEnabled(checked)

--- a/picard/ui/setupwizard.py
+++ b/picard/ui/setupwizard.py
@@ -179,16 +179,13 @@ class FileOrganizationPage(SetupWizardPage):
 
         self.rename_checkbox = WizardCheckbox(
             _("Rename files based on tags (e.g. \"Artist - Title.mp3\")"),
-            _("When saving filenames will be updated based on the tags."),
+            _("When you save tagged files, their filenames will be updated based on the new tags."),
         )
         layout.addWidget(self.rename_checkbox)
 
         self.move_checkbox = WizardCheckbox(
             _("Move files to a folder structure based on tags"),
-            _(
-                "Choose the base folder where you want your tagged audio files. "
-                "Saved files will be moved to this folder and a subfolder structure based on the tags."
-            ),
+            _("Saved files will be organized into subfolders (e.g. Artist/Album/) inside the folder you choose below."),
         )
         self.move_checkbox.toggled.connect(self._update_move_to_state)
         layout.addWidget(self.move_checkbox)
@@ -254,13 +251,13 @@ class CoverArtPage(SetupWizardPage):
 
         self.embed_checkbox = WizardCheckbox(
             _("Embed cover art into audio files"),
-            _("When enabled, cover art will be embedded into audio files as metadata."),
+            _("The cover image will be stored inside the audio file itself, so it shows up in any music player."),
         )
         layout.addWidget(self.embed_checkbox)
 
         self.save_to_files_checkbox = WizardCheckbox(
             _("Save cover art as separate image files"),
-            _("When enabled, cover art will be saved as separate image files."),
+            _("A cover image file (e.g. cover.jpg) will be saved alongside your audio files in the same folder."),
         )
         layout.addWidget(self.save_to_files_checkbox)
 
@@ -315,11 +312,7 @@ class UpdatesPage(SetupWizardPage):
 
         self.update_check_docs = WizardCheckbox(
             _("Check for documentation updates during startup"),
-            _(
-                "On startup the available documentation languages will be updated from ReadTheDocs.org. "
-                "This allows showing the online documentation in the best available language based on "
-                "the currently selected user interface language."
-            ),
+            _("Check for available documentation translations, so the online help can be shown in your language."),
         )
         layout.addWidget(self.update_check_docs)
 


### PR DESCRIPTION
Suggested improvements on top of #3260:

1. **Fix WizardCheckbox stylesheet for light/dark theme compatibility** — Use a subtle semi-transparent hover background instead of full highlight. Set explicit text color from palette so text is readable on both light and dark themes.

2. **Improve wizard descriptions for clarity** — Rewrite checkbox descriptions to be more helpful for new users (concrete explanations instead of restating the title, plain language, examples).

3. **Fix WizardCheckbox toggling when clicking interactive child widgets** — Don't toggle the checkbox when clicking on QLineEdit, QToolButton, or QCheckBox children (e.g. the folder path input).

4. **Simplify update page checkbox titles** — Remove redundant 'during startup' (already implied by page subtitle). Replace 'on the Picard website' with 'online'.

5. **Add validation for move folder in setup wizard** — Prevent proceeding if move files is checked but no destination folder is selected.