### PR TITLE
Review fixes for theme refactor

### DIFF
--- a/picard/ui/theme.py
+++ b/picard/ui/theme.py
@@ -182,7 +182,7 @@ def apply_dark_theme_to_palette(palette: QtGui.QPalette) -> None:
         apply_dark_palette_colors(palette)
 
 
-def get_accent_color_from_palette(palette: QtGui.QPalette) -> QtGui.QColor | None:
+def get_accent_color_from_palette(palette: QtGui.QPalette) -> QtGui.QColor:
     """Returns the accent color from the palette."""
     if hasattr(QtGui.QPalette.ColorRole, 'Accent'):
         accent_color = palette.color(QtGui.QPalette.ColorGroup.Active, QtGui.QPalette.ColorRole.Accent)

--- a/picard/ui/theme_detect.py
+++ b/picard/ui/theme_detect.py
@@ -54,7 +54,6 @@ def gsettings_get(key: str) -> str | None:
 
 def detect_gnome_color_scheme_dark() -> bool:
     """Detect if GNOME color-scheme is set to dark."""
-    # Fallback to subprocess method (legacy support)
     value = gsettings_get("color-scheme")
     if value and "dark" in value.lower():
         log.debug("Detected GNOME color-scheme: dark")

--- a/test/test_theme.py
+++ b/test/test_theme.py
@@ -171,7 +171,6 @@ def test_detect_linux_dark_mode_integration(
         # Mock D-Bus detector to return None (force fallback to subprocess)
         mock_detector = Mock()
         mock_detector.freedesktop_portal_color_scheme_is_dark.return_value = None
-        mock_detector.gnome_color_scheme_is_dark.return_value = None
         mock_get_detector.return_value = mock_detector
 
         def gsettings_get_side_effect(key):

--- a/test/test_theme_detect_qtdbus.py
+++ b/test/test_theme_detect_qtdbus.py
@@ -53,18 +53,9 @@ def mock_portal_interface() -> Mock:
 
 
 @pytest.fixture
-def mock_gnome_interface() -> Mock:
-    """Create a mock GNOME dconf interface."""
-    mock_interface = Mock()
-    mock_interface.isValid.return_value = True
-    return mock_interface
-
-
-@pytest.fixture
 def mock_dbus_detector(
     mock_dbus_connection: Mock,
     mock_portal_interface: Mock,
-    mock_gnome_interface: Mock,
 ) -> DBusThemeDetector:
     """Create a DBusThemeDetector with mocked D-Bus components."""
     with (
@@ -77,14 +68,12 @@ def mock_dbus_detector(
         def qdbus_interface_side_effect(*args, **kwargs):
             if "org.freedesktop.portal.Settings" in args:
                 return mock_portal_interface
-            elif "ca.desrt.dconf.Writer" in args:
-                return mock_gnome_interface
             elif "org.freedesktop.DBus" in args:
                 # Mock for service availability checking
                 mock_db_interface = Mock()
                 mock_db_message = Mock()
                 mock_db_message.type.return_value = QDBusMessage.MessageType.ReplyMessage
-                mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop", "ca.desrt.dconf"]]
+                mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop"]]
                 mock_db_interface.call.return_value = mock_db_message
                 return mock_db_interface
             return Mock()
@@ -214,20 +203,16 @@ class TestDBusThemeDetector:
         assert result is None
 
     @pytest.mark.parametrize(
-        ("portal_service_available", "gnome_service_available", "expected_portal", "expected_gnome"),
+        ("portal_service_available", "expected_portal"),
         [
-            (True, True, True, True),  # Both services available
-            (True, False, True, False),  # Only portal available
-            (False, True, False, True),  # Only GNOME available
-            (False, False, False, False),  # Neither service available
+            (True, True),  # Portal service available
+            (False, False),  # Portal service not available
         ],
     )
     def test_detection_with_service_availability(
         self,
         portal_service_available: bool,
-        gnome_service_available: bool,
         expected_portal: bool,
-        expected_gnome: bool,
     ) -> None:
         """Test detection methods when services are not available."""
         with (
@@ -242,15 +227,13 @@ class TestDBusThemeDetector:
             def service_availability_side_effect(service_name: str) -> bool:
                 if "portal" in service_name:
                     return portal_service_available
-                elif "dconf" in service_name:
-                    return gnome_service_available
                 return False
 
             # Mock the D-Bus interface for service listing
             mock_db_interface = Mock()
             mock_db_message = Mock()
             mock_db_message.type.return_value = QDBusMessage.MessageType.ReplyMessage
-            mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop", "ca.desrt.dconf"]]
+            mock_db_message.arguments.return_value = [["org.freedesktop.portal.Desktop"]]
             mock_db_interface.call.return_value = mock_db_message
 
             # Configure QDBusInterface to return different mocks for different calls
@@ -265,14 +248,6 @@ class TestDBusThemeDetector:
                     mock_portal_message.arguments.return_value = [1]  # Dark theme
                     mock_portal.call.return_value = mock_portal_message
                     return mock_portal
-                elif "ca.desrt.dconf.Writer" in args:
-                    mock_gnome = Mock()
-                    mock_gnome.isValid.return_value = True
-                    mock_gnome_message = Mock()
-                    mock_gnome_message.type.return_value = QDBusMessage.MessageType.ReplyMessage
-                    mock_gnome_message.arguments.return_value = ["dark"]
-                    mock_gnome.call.return_value = mock_gnome_message
-                    return mock_gnome
                 return Mock()
 
             mock_qdbus_interface.side_effect = qdbus_interface_side_effect
@@ -292,10 +267,10 @@ class TestServiceAvailability:
     @pytest.mark.parametrize(
         ("service_name", "available_services", "expected"),
         [
-            ("org.freedesktop.portal.Desktop", ["org.freedesktop.portal.Desktop", "ca.desrt.dconf"], True),
-            ("ca.desrt.dconf", ["org.freedesktop.portal.Desktop", "ca.desrt.dconf"], True),
-            ("org.freedesktop.portal.Desktop", ["ca.desrt.dconf"], False),
-            ("ca.desrt.dconf", ["org.freedesktop.portal.Desktop"], False),
+            ("org.freedesktop.portal.Desktop", ["org.freedesktop.portal.Desktop", "org.example.Service"], True),
+            ("org.example.Service", ["org.freedesktop.portal.Desktop", "org.example.Service"], True),
+            ("org.freedesktop.portal.Desktop", ["org.example.Service"], False),
+            ("org.example.Service", ["org.freedesktop.portal.Desktop"], False),
             ("org.freedesktop.portal.Desktop", [], False),
         ],
     )

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -395,7 +395,8 @@ class TestWindowsTheme:
             mock_winreg.QueryValueEx.assert_called_once_with(
                 mock_winreg.OpenKey.return_value.__enter__.return_value, 'ColorizationColor'
             )
-            assert result == QtGui.QColor(0xAABBCC11)
+            # The code masks out the alpha byte (& 0xFFFFFF), so only RGB is used
+            assert result == QtGui.QColor('#bbcc11')
 
     def test_get_system_accent_color_error_fallback(self):
         theme = theme_mod.WindowsTheme()

--- a/test/test_theme_stylehints.py
+++ b/test/test_theme_stylehints.py
@@ -203,7 +203,6 @@ class TestApplyAccentColorToPalette:
     def test_apply_accent_color_to_palette(self):
         palette = QtGui.QPalette()
         accent_color = QtGui.QColor(220, 220, 120)
-        print(accent_color.lightness())
         theme_mod.apply_accent_color_to_palette(palette, accent_color)
         assert palette.color(QtGui.QPalette.ColorRole.Highlight) == accent_color
         if hasattr(QtGui.QPalette.ColorRole, 'Accent'):


### PR DESCRIPTION
Cleanup commits addressing review feedback on the theme refactor branch.

Each commit is independent and can be cherry-picked individually:

1. **Remove leftover mock_gnome_interface fixture and ca.desrt.dconf references** — dead test code from removed GNOME D-Bus detection
2. **Remove dead gnome_color_scheme_is_dark mock setup in test_theme.py** — mock for a method that no longer exists
3. **Remove misleading 'Fallback to subprocess' comment** — no longer a fallback since D-Bus primary was removed
4. **Fix misleading accent color test assertion value** — use `'#bbcc11'` to make the `& 0xFFFFFF` masking obvious
5. **Fix get_accent_color_from_palette return type** — `QPalette.color()` always returns a `QColor`, never `None`
6. **Remove debug print() in test** — leftover from development